### PR TITLE
🐛 fix(server): separate SMS value/type imports for Turbopack

### DIFF
--- a/apps/server/src/services/sms/index.test.ts
+++ b/apps/server/src/services/sms/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { SmsImplType, SmsService } from './index';
+
+describe('SmsService module imports', () => {
+  it('exports runtime values without import-type parse errors', () => {
+    expect(SmsImplType.Debug).toBe('debug');
+    expect(SmsImplType.Kavenegar).toBe('kavenegar');
+    expect(typeof SmsService).toBe('function');
+    expect(new SmsService(SmsImplType.Debug)).toBeInstanceOf(SmsService);
+  });
+});

--- a/apps/server/src/services/sms/index.ts
+++ b/apps/server/src/services/sms/index.ts
@@ -1,10 +1,5 @@
-import type {
-  createSmsServiceImpl,
-  SmsImplType,
-  type SmsPayload,
-  type SmsResponse,
-  type SmsServiceImpl,
-} from './impls';
+import type { SmsImplType, SmsPayload, SmsResponse, SmsServiceImpl } from './impls';
+import { createSmsServiceImpl } from './impls';
 import { DebugSmsService } from './impls/debug';
 
 /**


### PR DESCRIPTION
Vercel next build failed parsing import type with mixed value imports and inline type modifiers in SmsService.

<!-- Brief and heads-up -->

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
