### PR TITLE
🐛 fix(db): skip ParadeDB BM25 migrations when pg_search is unavailable

### DIFF
--- a/scripts/migrateServerDB/bm25Compatibility.test.ts
+++ b/scripts/migrateServerDB/bm25Compatibility.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPgSearchUnavailableError, migrationUsesPgSearchOrBm25 } from './bm25Compatibility';
+
+describe('migrationUsesPgSearchOrBm25', () => {
+  it('detects pg_search extension migrations', () => {
+    expect(migrationUsesPgSearchOrBm25(['CREATE EXTENSION IF NOT EXISTS pg_search;'])).toBe(true);
+  });
+
+  it('detects bm25 index migrations', () => {
+    expect(
+      migrationUsesPgSearchOrBm25(['CREATE INDEX agents_bm25_idx ON agents USING bm25 (id)']),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated SQL', () => {
+    expect(migrationUsesPgSearchOrBm25(['CREATE TABLE agents (id text)'])).toBe(false);
+  });
+});
+
+describe('isPgSearchUnavailableError', () => {
+  it('matches Neon deprecated extension errors', () => {
+    expect(
+      isPgSearchUnavailableError(
+        Object.assign(new Error('Failed query'), {
+          cause: new Error('extension "pg_search" is deprecated and no longer allowed'),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects unrelated errors', () => {
+    expect(isPgSearchUnavailableError(new Error('relation users does not exist'))).toBe(false);
+  });
+});

--- a/scripts/migrateServerDB/bm25Compatibility.ts
+++ b/scripts/migrateServerDB/bm25Compatibility.ts
@@ -1,0 +1,31 @@
+/**
+ * Neon (and some managed Postgres) no longer allow ParadeDB `pg_search`.
+ * BM25 index migrations must be recorded as applied without executing when
+ * the extension is unavailable — same idea as packages/database getTestDB.
+ */
+
+export const migrationUsesPgSearchOrBm25 = (sqlStatements: string[]): boolean =>
+  sqlStatements.some((statement) => {
+    const lower = statement.toLowerCase();
+    return lower.includes('pg_search') || lower.includes('bm25');
+  });
+
+export const isPgSearchUnavailableError = (error: unknown): boolean => {
+  const parts: string[] = [];
+  if (error instanceof Error) parts.push(error.message);
+  const cause = (error as { cause?: unknown })?.cause;
+  if (cause instanceof Error) parts.push(cause.message);
+  else if (typeof cause === 'string') parts.push(cause);
+
+  const combined = parts.join(' ').toLowerCase();
+  if (!combined.includes('pg_search')) return false;
+
+  return (
+    combined.includes('deprecated') ||
+    combined.includes('not available') ||
+    combined.includes('not allowed') ||
+    combined.includes('could not open') ||
+    combined.includes('does not exist') ||
+    combined.includes('is not available')
+  );
+};

--- a/scripts/migrateServerDB/index.ts
+++ b/scripts/migrateServerDB/index.ts
@@ -2,9 +2,12 @@ import { join } from 'node:path';
 
 import * as dotenv from 'dotenv';
 import dotenvExpand from 'dotenv-expand';
+import { sql } from 'drizzle-orm';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { migrate as neonMigrate } from 'drizzle-orm/neon-serverless/migrator';
 import { migrate as nodeMigrate } from 'drizzle-orm/node-postgres/migrator';
 
+import { isPgSearchUnavailableError, migrationUsesPgSearchOrBm25 } from './bm25Compatibility';
 // @ts-ignore tsgo handle esm import cjs and compatibility issues
 import { DB_FAIL_INIT_HINT, DUPLICATE_EMAIL_HINT, PGVECTOR_HINT } from './errorHint';
 
@@ -20,14 +23,76 @@ dotenvExpand.expand(dotenv.config({ override: true, path: `.env.${env}.local` })
 
 const migrationsFolder = join(__dirname, '../../packages/database/migrations');
 
+const migrateSkippingUnavailableBm25 = async (serverDB: {
+  execute: (query: unknown) => Promise<unknown>;
+}) => {
+  const migrations = readMigrationFiles({ migrationsFolder });
+
+  await serverDB.execute(sql`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+  await serverDB.execute(sql`
+    CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at bigint
+    )
+  `);
+
+  const applied = (await serverDB.execute(sql`
+    SELECT hash FROM "drizzle"."__drizzle_migrations"
+  `)) as { rows?: Array<{ hash: string }> } | Array<{ hash: string }>;
+
+  const appliedRows = Array.isArray(applied) ? applied : (applied.rows ?? []);
+  const appliedHashes = new Set(appliedRows.map((row) => row.hash));
+
+  let skipped = 0;
+
+  for (const migration of migrations) {
+    if (appliedHashes.has(migration.hash)) continue;
+
+    const skipSql = migrationUsesPgSearchOrBm25(migration.sql);
+
+    if (skipSql) {
+      skipped += 1;
+      console.warn(
+        `⚠️ Skipping BM25/pg_search migration "${migration.hash}" (extension unavailable)`,
+      );
+    } else {
+      for (const stmt of migration.sql) {
+        await serverDB.execute(sql.raw(stmt));
+      }
+    }
+
+    await serverDB.execute(
+      sql`INSERT INTO "drizzle"."__drizzle_migrations" (hash, created_at) VALUES (${migration.hash}, ${migration.folderMillis})`,
+    );
+  }
+
+  if (skipped > 0) {
+    console.warn(
+      `⚠️ Skipped ${skipped} ParadeDB BM25 migration(s). Full-text BM25 search will be unavailable until pg_search is supported.`,
+    );
+  }
+};
+
 const runMigrations = async () => {
   const { serverDB } = await import('../../packages/database/src/server');
 
   const time = Date.now();
-  if (process.env.DATABASE_DRIVER === 'node') {
-    await nodeMigrate(serverDB, { migrationsFolder });
-  } else {
-    await neonMigrate(serverDB, { migrationsFolder });
+  const useNodeDriver = process.env.DATABASE_DRIVER === 'node';
+
+  try {
+    if (useNodeDriver) {
+      await nodeMigrate(serverDB, { migrationsFolder });
+    } else {
+      await neonMigrate(serverDB, { migrationsFolder });
+    }
+  } catch (error) {
+    if (!isPgSearchUnavailableError(error)) throw error;
+
+    console.warn(
+      '⚠️ pg_search is not available on this database (common on Neon). Replaying migrations while skipping BM25/pg_search statements…',
+    );
+    await migrateSkippingUnavailableBm25(serverDB);
   }
 
   console.log('✅ database migration pass. use: %s ms', Date.now() - time);


### PR DESCRIPTION
Neon rejects deprecated pg_search, which broke Vercel build:vercel db:migrate. Replay remaining migrations and record BM25 ones as applied so Hobby Neon deploys can succeed.

<!-- Brief and heads-up -->

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
