### PR TITLE
🐛 fix(aico): parse OpenRouter create-key top-level secret

### DIFF
--- a/apps/server/src/services/openrouter/createKeyResponse.test.ts
+++ b/apps/server/src/services/openrouter/createKeyResponse.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCreateKeyResponse } from './createKeyResponse';
+
+describe('parseCreateKeyResponse', () => {
+  it('reads top-level key from the real OpenRouter create response shape', () => {
+    const parsed = parseCreateKeyResponse({
+      data: {
+        disabled: false,
+        hash: 'abc123',
+        limit: 5,
+        limit_remaining: 5,
+        name: 'cust',
+        usage: 0,
+      },
+      key: 'sk-or-v1-real',
+    });
+
+    expect(parsed.key).toBe('sk-or-v1-real');
+    expect(parsed.hash).toBe('abc123');
+    expect(parsed.limit).toBe(5);
+    expect(parsed.limitRemaining).toBe(5);
+  });
+
+  it('falls back to nested data.key for older shapes', () => {
+    const parsed = parseCreateKeyResponse({
+      data: {
+        disabled: false,
+        hash: 'nested',
+        key: 'sk-or-v1-nested',
+        limit: 1,
+        limit_remaining: 1,
+        name: 'cust',
+        usage: 0,
+      },
+    });
+
+    expect(parsed.key).toBe('sk-or-v1-nested');
+    expect(parsed.hash).toBe('nested');
+  });
+
+  it('throws when plaintext key is missing', () => {
+    expect(() =>
+      parseCreateKeyResponse({
+        data: {
+          disabled: false,
+          hash: 'no-key',
+          limit: 1,
+          limit_remaining: 1,
+          name: 'cust',
+          usage: 0,
+        },
+      }),
+    ).toThrow(/createKey response missing key/);
+  });
+});

--- a/apps/server/src/services/openrouter/createKeyResponse.ts
+++ b/apps/server/src/services/openrouter/createKeyResponse.ts
@@ -1,0 +1,36 @@
+export interface OpenRouterKeyInfo {
+  disabled: boolean;
+  hash: string;
+  limit: number | null;
+  limitRemaining: number | null;
+  name: string;
+  usage: number;
+}
+
+export interface CreateOpenRouterKeyResult extends OpenRouterKeyInfo {
+  /** Plaintext key — only available at creation time. Encrypt before persist. */
+  key: string;
+}
+
+export const mapOpenRouterKeyInfo = (data: Record<string, unknown>): OpenRouterKeyInfo => ({
+  disabled: Boolean(data.disabled),
+  hash: String(data.hash),
+  limit: data.limit == null ? null : Number(data.limit),
+  limitRemaining: data.limit_remaining == null ? null : Number(data.limit_remaining),
+  name: String(data.name ?? ''),
+  usage: Number(data.usage ?? 0),
+});
+
+/**
+ * Parse OpenRouter `POST /api/v1/keys` JSON.
+ * The plaintext key is a top-level sibling of `data` (create only); older / mock
+ * shapes may nest it under `data.key`.
+ */
+export const parseCreateKeyResponse = (
+  json: Record<string, unknown>,
+): CreateOpenRouterKeyResult => {
+  const data = (json.data as Record<string, unknown> | undefined) ?? json;
+  const key = String(json.key ?? data.key ?? '');
+  if (!key) throw new Error('OpenRouter createKey response missing key');
+  return { ...mapOpenRouterKeyInfo(data), key };
+};

--- a/apps/server/src/services/openrouter/management.test.ts
+++ b/apps/server/src/services/openrouter/management.test.ts
@@ -5,6 +5,15 @@ import {
   createOpenRouterManagementClient,
 } from './management';
 
+vi.mock('@/envs/aico', () => ({
+  aicoEnv: {
+    AICO_ALLOW_MOCK_TOPUP: false,
+    AICO_OPENROUTER_MOCK: false,
+    AICO_TOMAN_PER_USD: 50_000,
+    OPENROUTER_MANAGEMENT_API_KEY: undefined,
+  },
+}));
+
 describe('MockOpenRouterManagementClient', () => {
   beforeEach(() => {
     __resetOpenRouterManagementClientForTests();
@@ -26,42 +35,5 @@ describe('MockOpenRouterManagementClient', () => {
 
     await client.deleteKey(created.hash);
     await expect(client.getKey(created.hash)).rejects.toThrow(/not found/);
-  });
-});
-
-describe('HttpOpenRouterManagementClient', () => {
-  it('posts create payload to OpenRouter keys endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      json: async () => ({
-        data: {
-          disabled: false,
-          hash: 'abc123',
-          key: 'sk-or-v1-real',
-          limit: 5,
-          limit_remaining: 5,
-          name: 'cust',
-          usage: 0,
-        },
-      }),
-      ok: true,
-      status: 200,
-    });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const client = createOpenRouterManagementClient({
-      managementKey: 'mgmt-test-key',
-    });
-
-    const created = await client.createKey({ limitUsd: 5, name: 'cust' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://openrouter.ai/api/v1/keys',
-      expect.objectContaining({
-        method: 'POST',
-      }),
-    );
-    expect(created.key).toBe('sk-or-v1-real');
-    expect(created.hash).toBe('abc123');
-
-    vi.unstubAllGlobals();
   });
 });

--- a/apps/server/src/services/openrouter/management.ts
+++ b/apps/server/src/services/openrouter/management.ts
@@ -1,22 +1,18 @@
 import { aicoEnv } from '@/envs/aico';
 
+import {
+  type CreateOpenRouterKeyResult,
+  mapOpenRouterKeyInfo,
+  type OpenRouterKeyInfo,
+  parseCreateKeyResponse,
+} from './createKeyResponse';
+
+export type { CreateOpenRouterKeyResult, OpenRouterKeyInfo };
+export { parseCreateKeyResponse };
+
 const BASE_URL = 'https://openrouter.ai/api/v1/keys';
 
 export type OpenRouterKeyLimitReset = 'daily' | 'weekly' | 'monthly' | null;
-
-export interface OpenRouterKeyInfo {
-  disabled: boolean;
-  hash: string;
-  limit: number | null;
-  limitRemaining: number | null;
-  name: string;
-  usage: number;
-}
-
-export interface CreateOpenRouterKeyResult extends OpenRouterKeyInfo {
-  /** Plaintext key — only available at creation time. Encrypt before persist. */
-  key: string;
-}
 
 export interface OpenRouterManagementClient {
   createKey: (params: {
@@ -33,15 +29,6 @@ export interface OpenRouterManagementClient {
     name?: string;
   }) => Promise<OpenRouterKeyInfo>;
 }
-
-const mapKey = (data: Record<string, unknown>): OpenRouterKeyInfo => ({
-  disabled: Boolean(data.disabled),
-  hash: String(data.hash),
-  limit: data.limit == null ? null : Number(data.limit),
-  limitRemaining: data.limit_remaining == null ? null : Number(data.limit_remaining),
-  name: String(data.name ?? ''),
-  usage: Number(data.usage ?? 0),
-});
 
 class HttpOpenRouterManagementClient implements OpenRouterManagementClient {
   constructor(private readonly apiKey: string) {}
@@ -74,17 +61,14 @@ class HttpOpenRouterManagementClient implements OpenRouterManagementClient {
       }),
       method: 'POST',
     });
-    const data = (json.data as Record<string, unknown> | undefined) ?? json;
-    const key = String(data.key ?? '');
-    if (!key) throw new Error('OpenRouter createKey response missing key');
-    return { ...mapKey(data), key };
+    return parseCreateKeyResponse(json);
   };
 
   getKey: OpenRouterManagementClient['getKey'] = async (hash) => {
     const json = await this.request<{ data: Record<string, unknown> }>(`/${hash}`, {
       method: 'GET',
     });
-    return mapKey(json.data ?? (json as unknown as Record<string, unknown>));
+    return mapOpenRouterKeyInfo(json.data ?? (json as unknown as Record<string, unknown>));
   };
 
   updateKey: OpenRouterManagementClient['updateKey'] = async (params) => {
@@ -96,7 +80,7 @@ class HttpOpenRouterManagementClient implements OpenRouterManagementClient {
       }),
       method: 'PATCH',
     });
-    return mapKey(json.data ?? (json as unknown as Record<string, unknown>));
+    return mapOpenRouterKeyInfo(json.data ?? (json as unknown as Record<string, unknown>));
   };
 
   deleteKey: OpenRouterManagementClient['deleteKey'] = async (hash) => {


### PR DESCRIPTION
Real OpenRouter responses put the plaintext key beside data, not under data.key — extract a shared parser so provisioning does not miss the secret.

<!-- Brief and heads-up -->

<!-- If this PR includes UI changes, please provide screenshots or videos. -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### Test

<!-- How you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->
