### PR TITLE
🐛 fix(branding): remove duplicate APPLE_APP_STORE_ID export

### DIFF
--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -57,7 +57,5 @@ export const BRANDING_PROVIDER = readBrandingEnv('BRANDING_PROVIDER', 'official'
 
 export const APPLE_APP_STORE_ID = '';
 
-export const APPLE_APP_STORE_ID = '';
-
 export const COPYRIGHT = `© ${new Date().getFullYear()} ${ORG_NAME}`;
 export const COPYRIGHT_FULL = `${COPYRIGHT}. All rights reserved.`;


### PR DESCRIPTION
## Summary

- Removes a duplicated `APPLE_APP_STORE_ID` export left by the upstream history merge that broke `pnpm build` (Vite PARSE_ERROR).

## Test plan

- [x] `packages/business/const/src/branding.ts` has a single export
- [ ] `pnpm build` / `bun run build:spa` succeeds locally


Made with [Cursor](https://cursor.com)