### PR TITLE
🐛 fix(auth): stretch verify-phone OTP boxes to match button width

### DIFF
--- a/src/features/Auth/VerifyPhone/VerifyPhoneContent.tsx
+++ b/src/features/Auth/VerifyPhone/VerifyPhoneContent.tsx
@@ -1,11 +1,30 @@
 import { Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { Form, Input } from 'antd';
+import { createStaticStyles } from 'antd-style';
 import { useTranslation } from 'react-i18next';
 
 import { isValidIranianPhoneNumber } from '@/libs/better-auth/phone';
 
 import { useVerifyPhone } from './useVerifyPhone';
+
+const styles = createStaticStyles(({ css }) => ({
+  // Stretch OTP cells across the same width as the block action buttons below.
+  otp: css`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+    .ant-otp-input-wrapper {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .ant-otp-input {
+      width: 100%;
+    }
+  `,
+}));
 
 interface VerifyPhoneContentProps {
   callbackUrl: string;
@@ -39,7 +58,7 @@ export const VerifyPhoneContent = ({ callbackUrl }: VerifyPhoneContentProps) => 
               { len: 6, message: t('betterAuth.verifyPhone.otp.length') },
             ]}
           >
-            <Input.OTP autoFocus length={6} size="large" />
+            <Input.OTP autoFocus className={styles.otp} length={6} size="large" />
           </Form.Item>
           <Button block htmlType="submit" loading={loading} size="large" type="primary">
             {t('betterAuth.verifyPhone.otp.submit')}


### PR DESCRIPTION
#### Summary

Makes the 6-digit OTP input on `/verify-phone` span the same width as the Verify / Resend buttons so the digit boxes no longer look narrower than the actions.

**Branch:** `fix/verify-phone-otp-width`

#### Test

- [x] Tested locally — lint clean via `bun run check --lint`
- [ ] Added/updated tests
- [x] No tests needed (layout/CSS only; component tests are discouraged for this surface)

#### 🔗 Related Issue

Fixes #29


Made with [Cursor](https://cursor.com)