### PR TITLE
🐛 fix(auth): exit verify-phone to callback instead of sign-in

### DIFF
--- a/locales/en-US/auth.json
+++ b/locales/en-US/auth.json
@@ -155,7 +155,7 @@
   "betterAuth.verifyEmail.resend.noEmail": "Email address is missing",
   "betterAuth.verifyEmail.resend.success": "Verification email resent. Please check your inbox.",
   "betterAuth.verifyEmail.title": "Verify Your Email",
-  "betterAuth.verifyPhone.backToSignIn": "Back to Sign In",
+  "betterAuth.verifyPhone.back": "Back",
   "betterAuth.verifyPhone.description": "Verify your mobile number to activate trial credits and prevent abuse.",
   "betterAuth.verifyPhone.errors.generic": "Phone verification failed. Please try again.",
   "betterAuth.verifyPhone.errors.invalidOtp": "Incorrect code. Please try again.",

--- a/locales/zh-CN/auth.json
+++ b/locales/zh-CN/auth.json
@@ -155,7 +155,7 @@
   "betterAuth.verifyEmail.resend.noEmail": "未获取到邮箱地址",
   "betterAuth.verifyEmail.resend.success": "已重新发送，请查收邮箱",
   "betterAuth.verifyEmail.title": "验证邮箱",
-  "betterAuth.verifyPhone.backToSignIn": "返回登录",
+  "betterAuth.verifyPhone.back": "返回",
   "betterAuth.verifyPhone.description": "验证手机号以激活试用额度并防止滥用。",
   "betterAuth.verifyPhone.errors.generic": "手机验证失败，请重试。",
   "betterAuth.verifyPhone.errors.invalidOtp": "验证码错误，请重试。",

--- a/packages/locales/src/default/auth.ts
+++ b/packages/locales/src/default/auth.ts
@@ -171,7 +171,7 @@ export default {
   'betterAuth.verifyEmail.resend.noEmail': 'Email address is missing',
   'betterAuth.verifyEmail.resend.success': 'Verification email resent. Please check your inbox.',
   'betterAuth.verifyEmail.title': 'Verify Your Email',
-  'betterAuth.verifyPhone.backToSignIn': 'Back to Sign In',
+  'betterAuth.verifyPhone.back': 'Back',
   'betterAuth.verifyPhone.description':
     'Verify your mobile number to activate trial credits and prevent abuse.',
   'betterAuth.verifyPhone.errors.generic': 'Phone verification failed. Please try again.',

--- a/src/features/Auth/VerifyPhone/index.tsx
+++ b/src/features/Auth/VerifyPhone/index.tsx
@@ -3,11 +3,12 @@
 import { Button } from '@lobehub/ui/base-ui';
 import { ChevronLeftIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router';
 
 import AuthCard from '@/features/AuthCard';
 import { sanitizeRedirectPath } from '@/utils/onboardingRedirect';
 
+import { exitVerifyPhoneFlow } from './useVerifyPhone';
 import { VerifyPhoneContent } from './VerifyPhoneContent';
 
 const VerifyPhonePage = () => {
@@ -20,11 +21,14 @@ const VerifyPhonePage = () => {
       subtitle={t('betterAuth.verifyPhone.description')}
       title={t('betterAuth.verifyPhone.title')}
       footer={
-        <Link to={`/signin?callbackUrl=${encodeURIComponent(callbackUrl)}`}>
-          <Button block icon={ChevronLeftIcon} size={'large'}>
-            {t('betterAuth.verifyPhone.backToSignIn')}
-          </Button>
-        </Link>
+        <Button
+          block
+          icon={ChevronLeftIcon}
+          size="large"
+          onClick={() => exitVerifyPhoneFlow(callbackUrl)}
+        >
+          {t('betterAuth.verifyPhone.back')}
+        </Button>
       }
     >
       <VerifyPhoneContent callbackUrl={callbackUrl} />

--- a/src/features/Auth/VerifyPhone/useVerifyPhone.test.ts
+++ b/src/features/Auth/VerifyPhone/useVerifyPhone.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { exitVerifyPhoneFlow } from './useVerifyPhone';
+
+describe('exitVerifyPhoneFlow', () => {
+  const assign = vi.fn();
+
+  beforeEach(() => {
+    assign.mockReset();
+    vi.stubGlobal('location', { assign });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns to callbackUrl instead of sign-in (logged-in trial verify)', () => {
+    exitVerifyPhoneFlow('/settings/profile');
+
+    expect(assign).toHaveBeenCalledTimes(1);
+    expect(assign).toHaveBeenCalledWith('/settings/profile');
+    expect(assign.mock.calls[0][0]).not.toContain('signin');
+  });
+
+  it('falls back to home for unsafe callback URLs', () => {
+    exitVerifyPhoneFlow('https://evil.example');
+
+    expect(assign).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/features/Auth/VerifyPhone/useVerifyPhone.ts
+++ b/src/features/Auth/VerifyPhone/useVerifyPhone.ts
@@ -124,3 +124,12 @@ export const useVerifyPhone = ({ callbackUrl }: UseVerifyPhoneParams) => {
     step,
   };
 };
+
+/**
+ * Leave the trial verify flow without going through Sign In.
+ * Hard navigation is required: `/verify-phone` lives on the auth SPA
+ * while `callbackUrl` is usually a main-app path (e.g. `/settings/profile`).
+ */
+export const exitVerifyPhoneFlow = (callbackUrl: string) => {
+  window.location.assign(sanitizeRedirectPath(callbackUrl, '/'));
+};


### PR DESCRIPTION
#### Summary

Trial phone verify is a logged-in flow. The footer previously linked to **Back to Sign In** (`/signin`), which dropped users out of the app. It now hard-navigates to `callbackUrl` (e.g. `/settings/profile`) and is labeled **Back**.

**Branch:** `fix/verify-phone-back-navigation`

Related UI polish (OTP width) is in a separate PR on `fix/verify-phone-otp-width` (#31).

#### Test

- [x] Tested locally — `bunx vitest run src/features/Auth/VerifyPhone/useVerifyPhone.test.ts`
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #30


Made with [Cursor](https://cursor.com)