### PR TITLE
🔒 chore: ignore project Cursor MCP config with secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ vertex-ai-key.json
 .local/
 .claude/
 .mcp.json
+.cursor/mcp.json
 CLAUDE.local.md
 .agent/
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

Ignore local `.cursor/mcp.json` so project MCP credentials (e.g. Plane PAT) are not committed. The auth/fa-IR fix on this branch was already merged via #36; this PR carries the remaining gitignore change.

| Before | After |
| ------ | ----- |
| N/A (no UI) | N/A (no UI) |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified with `git check-ignore -v .cursor/mcp.json` that the path is ignored.

#### 🔗 Related Issue

Related to #36 (auth work already landed; this is the follow-up gitignore-only commit on the same branch).

Made with [Cursor](https://cursor.com)