### PR TITLE
📝 docs(cursor): dual-track issues — GitHub EN + Plane FA

### DIFF
--- a/.cursor/rules/plane-github-language.mdc
+++ b/.cursor/rules/plane-github-language.mdc
@@ -1,0 +1,23 @@
+---
+description: Dual tracking — Plane (FA) + GitHub (EN); language rules for each
+alwaysApply: true
+---
+
+# Plane vs GitHub language
+
+- **Plane** (work items, titles, descriptions, comments, completion notes): write in **Persian (فارسی)**. Keep file paths, identifiers (`AICO-17`), code, commands, and error strings in English.
+- **GitHub** (issues, PR titles/bodies, commit messages, code review comments): write in **English**.
+- When linking Plane ↔ GitHub, put the Plane identifier/URL in the PR/issue body; put the PR/issue URL in a Plane comment (Persian summary is fine).
+
+# Creating an “issue”
+
+When the user asks to **create an issue** (or “issue + PR”), create **both** trackers — do not stop at Plane alone:
+
+1. **GitHub issue** — English title and body (`gh issue create`).
+2. **Plane work item** — Persian title and description (default Aico project unless named otherwise).
+
+Then cross-link:
+
+- Plane comment (or link) → GitHub issue URL
+- GitHub issue body → Plane browse URL / `AICO-xx`
+- If a PR follows, reference **both** in the PR body (`Related to #n`, Plane `AICO-xx`)


### PR DESCRIPTION
## Summary

- Codify that “create an issue” means **both** a GitHub issue (English) and a Plane work item (Persian), with cross-links.
- Keeps existing Plane↔GitHub language split in an always-applied Cursor rule.

## Related

- Related to #48 / [AICO-35](https://plane.panafor.com/panaforai/browse/AICO-35) (process follow-up)

## Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Made with [Cursor](https://cursor.com)