### PR TITLE
📝 docs(cursor): dedupe issues before create; require Fixes #n

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -50,7 +50,8 @@ If current branch is `canary`/`main` but there are NO uncommitted changes and no
 
 - Title: `<gitmoji> <type>(<scope>): <description>`
 - Body: based on PR template (`.github/PULL_REQUEST_TEMPLATE.md`), fill checkboxes
-- Link related GitHub issues using magic keywords (`Fixes #123`, `Closes #123`)
+- **Required for linked GitHub issues**: include closing keyword(s) in the PR body so merge closes them — one line per issue, e.g. `Fixes #123` and `Fixes #456` (also `Closes` / `Resolves`). Do not use only `Related to #123` when the PR completes those issues.
+- Link Plane work items by URL / identifier in the body (Plane does not auto-close from GitHub keywords)
 - Link Linear issues if applicable (`Fixes LOBE-xxx`)
 - Use HEREDOC for body to preserve formatting
 

--- a/.cursor/rules/plane-github-language.mdc
+++ b/.cursor/rules/plane-github-language.mdc
@@ -1,5 +1,5 @@
 ---
-description: Dual tracking — Plane (FA) + GitHub (EN); language rules for each
+description: Dual tracking — Plane (FA) + GitHub (EN); dedupe before create; Fixes #n on PRs
 alwaysApply: true
 ---
 
@@ -11,13 +11,47 @@ alwaysApply: true
 
 # Creating an “issue”
 
-When the user asks to **create an issue** (or “issue + PR”), create **both** trackers — do not stop at Plane alone:
+When the user asks to **create an issue** (or “issue + PR”), create **both** trackers — do not stop at Plane alone — **but never create a duplicate**.
 
-1. **GitHub issue** — English title and body (`gh issue create`).
-2. **Plane work item** — Persian title and description (default Aico project unless named otherwise).
+## Deduplicate first (required)
 
-Then cross-link:
+Before creating anything:
+
+1. **Plane** — `search_work_items` (and/or `list_work_items` with PQL) for the same topic / keywords / identifier in the default Aico project. Prefer open / In Progress / Testing items over Done.
+2. **GitHub** — `gh issue list --search "…" --state open` (and check the current PR/conversation for an already-linked `#n` or `AICO-xx`).
+
+Then:
+
+| Finding | Action |
+| -------- | ------ |
+| Matching **Plane** item exists | **Reuse it** — do not `create_work_item` again. Update / comment / link as needed. |
+| Matching **GitHub** issue exists | **Reuse it** — do not `gh issue create` again. |
+| Only one side exists | Create **only the missing** tracker and cross-link. |
+| Neither exists | Create GitHub (EN) **and** Plane (FA), then cross-link. |
+
+If an existing Plane item already links a GitHub issue (or the reverse), use that pair — do not open a second Plane work item when the user later says “create issue” for the same work.
+
+Cross-link when creating or reusing:
 
 - Plane comment (or link) → GitHub issue URL
-- GitHub issue body → Plane browse URL / `AICO-xx`
-- If a PR follows, reference **both** in the PR body (`Related to #n`, Plane `AICO-xx`)
+- GitHub issue body / comment → Plane browse URL / `AICO-xx`
+
+# Pull requests and auto-close
+
+When a PR finishes GitHub issue(s), the PR body **must** include closing keyword(s) so merge closes them:
+
+```markdown
+Fixes #123
+```
+
+For **multiple** issues, one closing line each:
+
+```markdown
+Fixes #123
+Fixes #456
+Closes #789
+```
+
+Also acceptable: `Closes #n`, `Resolves #n`. Do **not** use only `Related to #n` / `See #n` when the PR is meant to finish those issues.
+
+Also list Plane URL(s) in the PR body (Plane does not auto-close from GitHub keywords).


### PR DESCRIPTION
## Summary

- Before creating an issue, search Plane and GitHub and **reuse** matches instead of opening duplicates (especially when dual-tracking GitHub EN + Plane FA).
- Restore / require `Fixes #n` (one line per issue) so merge auto-closes GitHub issues; link Plane separately.

## Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Made with [Cursor](https://cursor.com)