### PR TITLE
🐛 fix(auth): wire Aico session.user contract into UserUpdater

### DIFF
--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx
@@ -111,4 +111,23 @@ describe('UserUpdater', () => {
 
     expect(useUserStore.getState().user).toBeUndefined();
   });
+
+  it('maps Aico session.user contract fields (phone + empty name) into the store', () => {
+    useSessionMock.mockReturnValue(
+      sampleSession({
+        name: '',
+        phoneNumber: '+989121234567',
+        phoneNumberVerified: true,
+        emailVerified: true,
+      }),
+    );
+    render(<UserUpdater />);
+
+    const user = useUserStore.getState().user;
+    expect(user?.id).toBe('u1');
+    expect(user?.fullName).toBeNull();
+    expect(user?.phoneNumber).toBe('+989121234567');
+    expect(user?.phoneNumberVerified).toBe(true);
+    expect(user?.emailVerified).toBe(true);
+  });
 });

--- a/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
+++ b/src/layout/AuthProvider/BetterAuth/UserUpdater.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect } from 'react';
 import { createStoreUpdater } from 'zustand-utils';
 
 import { useSession } from '@/libs/better-auth/auth-client';
+import { toAicoSessionUser } from '@/libs/better-auth/session-user';
 import { useUserStore } from '@/store/user';
 import { type LobeUser } from '@/types/user';
 
@@ -37,21 +38,26 @@ const UserUpdater = memo(() => {
   // drop the previous user's profile fields so they don't leak across
   // accounts. `useInitUserState` is `useOnlyFetchOnceSWR` with a constant
   // key, so it won't re-fetch profile data for the new user on its own.
+  //
+  // Phone / name / verification fields go through `toAicoSessionUser` so the
+  // Phase 1 session.user contract stays the single mapping source (AICO-8).
   useEffect(() => {
-    if (betterAuthUser) {
+    const aicoUser = toAicoSessionUser(betterAuthUser);
+    if (aicoUser && betterAuthUser) {
       useUserStore.setState((state) => {
-        const baseUser = state.user?.id === betterAuthUser.id ? state.user : undefined;
+        const baseUser = state.user?.id === aicoUser.id ? state.user : undefined;
         return {
           user: {
             ...baseUser,
             // Preserve avatar from settings, don't override with auth provider value
             avatar: baseUser?.avatar || '',
-            email: betterAuthUser.email,
-            emailVerified: Boolean(betterAuthUser.emailVerified),
-            fullName: betterAuthUser.name,
-            id: betterAuthUser.id,
-            phoneNumber: betterAuthUser.phoneNumber ?? null,
-            phoneNumberVerified: Boolean(betterAuthUser.phoneNumberVerified),
+            email: aicoUser.email,
+            emailVerified: aicoUser.emailVerified,
+            fullName: aicoUser.name,
+            id: aicoUser.id,
+            phoneNumber: aicoUser.phoneNumber,
+            phoneNumberVerified: aicoUser.phoneNumberVerified,
+            // username is an additional Better Auth field, outside the Aico contract
             username: betterAuthUser.username,
           } as LobeUser,
         };

--- a/src/libs/better-auth/session-user.test.ts
+++ b/src/libs/better-auth/session-user.test.ts
@@ -41,4 +41,9 @@ describe('toAicoSessionUser', () => {
       phoneNumberVerified: false,
     });
   });
+
+  it('normalizes empty / whitespace name from phone OTP temp signup to null', () => {
+    expect(toAicoSessionUser({ id: 'user_1', name: '' })?.name).toBeNull();
+    expect(toAicoSessionUser({ id: 'user_1', name: '   ' })?.name).toBeNull();
+  });
 });

--- a/src/libs/better-auth/session-user.ts
+++ b/src/libs/better-auth/session-user.ts
@@ -31,12 +31,16 @@ export const toAicoSessionUser = (
 ): AicoSessionUser | null => {
   if (!user) return null;
 
+  // Phone OTP signup uses getTempName: () => '' so the onboarding name
+  // prompt stays blank — treat empty / whitespace as null for consumers.
+  const name = user.name?.trim() ? user.name : null;
+
   return {
     email: user.email ?? null,
     emailVerified: Boolean(user.emailVerified),
     id: user.id,
     image: user.image ?? null,
-    name: user.name ?? null,
+    name,
     phoneNumber: user.phoneNumber ?? null,
     phoneNumberVerified: Boolean(user.phoneNumberVerified),
   };


### PR DESCRIPTION
## Summary

- Route Better Auth → Zustand user sync through `toAicoSessionUser` so Phase 1 `session.user` fields stay consistent
- Normalize empty / whitespace OTP temp `name` to `null` for onboarding consumers
- Add regression coverage for phone + empty-name mapping

## Related

Fixes #51
Plane: [AICO-8](https://plane.panafor.com/panaforai/browse/AICO-8/)

## Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test src/libs/better-auth/session-user.ts src/libs/better-auth/session-user.test.ts src/layout/AuthProvider/BetterAuth/UserUpdater.tsx src/layout/AuthProvider/BetterAuth/UserUpdater.test.tsx`

Made with [Cursor](https://cursor.com)