### PR TITLE
🐛 fix(i18n): map region locales for dayjs; add aico-ship overlay

### DIFF
--- a/.agents/skills/aico-ship/SKILL.md
+++ b/.agents/skills/aico-ship/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: aico-ship
+description: >-
+  Aico dual-track shipping: GitHub issues (English) + Plane work items (Persian),
+  cross-links, finish-job closeout, and PRs to canary with Fixes #n. Use when
+  creating an issue, opening a PR, finishing a shippable job, or the user asks
+  for Plane/GitHub workflow, ship, submit, or closeout. Triggers on 'issue',
+  'create issue', 'pr', 'create pr', 'ship', 'submit', 'workflow', 'plane',
+  'AICO-', 'finish', 'closeout', 'ذخیره', 'ببند'.
+---
+
+# Aico ship (Plane + GitHub + PR)
+
+Aico-owned overlay. **Do not edit** upstream LobeHub skills under `.agents/skills/`
+(e.g. `pr`, `linear`) for Aico process — put overrides here instead.
+
+## Ownership split
+
+| Concern                                                         | Use                             |
+| --------------------------------------------------------------- | ------------------------------- |
+| Git branch / commit / push / `gh pr create` mechanics           | `pr` skill (untouched upstream) |
+| Plane MCP tools, states, Persian comment format                 | `plane` skill                   |
+| Dual trackers, no-search policy, finish-job, Aico PR body rules | **this skill** (`aico-ship`)    |
+
+When `pr` says to search GitHub issues or link Linear (`LOBE-xxx`), **ignore that for Aico**. This fork tracks work with Plane + GitHub issues created from Cursor.
+
+## Language
+
+- **Plane** titles, descriptions, comments → **Persian (فارسی)**. Paths, `AICO-xx`, code, commands, errors stay English inside Persian text.
+- **GitHub** issues, PR titles/bodies, commits, review comments → **English**.
+
+## No duplicate search
+
+Do **not** run Plane `search_work_items` or `gh issue list --search` before creating trackers. Agent work issues are expected to be created from Cursor in this session.
+
+Only reuse a tracker if this chat (or the user) already supplied a specific `#n` or `AICO-xx`.
+
+## Creating an “issue”
+
+Create **both**:
+
+1. GitHub issue (EN) — `gh issue create`
+2. Plane work item (FA) — default Aico project unless named otherwise (`plane` skill defaults)
+
+Cross-link:
+
+- Plane comment or `create_work_item_link` → GitHub issue URL
+- GitHub issue body → Plane browse URL / `AICO-xx`
+
+## Finish-job closeout
+
+When implementation is done (or the user asks to ship / open a PR / “do the workflow”), run closeout — do not leave shippable code only as local uncommitted changes without this path.
+
+### Auto-run vs suggest
+
+**Run automatically** when any of:
+
+- User asked for issue / PR / Plane / workflow / ship / submit
+- Change is a real product bug fix or feature meant for `canary`
+- This chat already has Plane/`AICO-xx` and/or a GitHub `#n` for the work
+
+**Suggest once** when:
+
+- Scope is ambiguous and they never mentioned shipping
+- Only docs / agent rules / local tooling changed
+- Unrelated diffs are mixed — ask which slice to track
+
+**Skip** when: pure Q\&A; user forbade commit/push/PR/trackers; trackers + PR already exist and are current.
+
+### Checklist
+
+1. If this chat has no `#n` / `AICO-xx`, create GitHub (EN) + Plane (FA) and cross-link — **no** prior search
+2. Follow the `pr` skill for branch (off `canary` if needed), gitmoji commit, push, and `gh pr create --base canary`
+3. PR body **must** include `Fixes #n` (not only `Related to`) and Plane `AICO-xx` / browse URL
+4. Plane: state → **Testing** (review stand-in; not Done until merge) + Persian completion comment with PR URL (`plane` skill format)
+
+## PR body (Aico)
+
+```markdown
+#### 🔗 Related Issue
+
+Fixes #123
+
+Plane: [AICO-xx](https://plane.panafor.com/panaforai/browse/AICO-xx)
+```
+
+Multiple finished GitHub issues → one `Fixes #n` line each.
+
+## After merge
+
+Mark Plane **Done** only after merge (or when the user says no review is needed).

--- a/.cursor/rules/plane-github-language.mdc
+++ b/.cursor/rules/plane-github-language.mdc
@@ -1,5 +1,5 @@
 ---
-description: Dual tracking — Plane (FA) + GitHub (EN); language rules for each
+description: Aico dual track — Plane (FA) + GitHub (EN); point agents at aico-ship
 alwaysApply: true
 ---
 
@@ -9,15 +9,13 @@ alwaysApply: true
 - **GitHub** (issues, PR titles/bodies, commit messages, code review comments): write in **English**.
 - When linking Plane ↔ GitHub, put the Plane identifier/URL in the PR/issue body; put the PR/issue URL in a Plane comment (Persian summary is fine).
 
-# Creating an “issue”
+# Shipping / issues / PRs
 
-When the user asks to **create an issue** (or “issue + PR”), create **both** trackers — do not stop at Plane alone:
+For creating issues, finish-job closeout, dual trackers, and Aico PR linking, follow the **`aico-ship`** skill (do not patch upstream `pr` / `linear` skills).
 
-1. **GitHub issue** — English title and body (`gh issue create`).
-2. **Plane work item** — Persian title and description (default Aico project unless named otherwise).
+Short rules (details in `aico-ship`):
 
-Then cross-link:
-
-- Plane comment (or link) → GitHub issue URL
-- GitHub issue body → Plane browse URL / `AICO-xx`
-- If a PR follows, reference **both** in the PR body (`Related to #n`, Plane `AICO-xx`)
+- “Create an issue” → **both** GitHub (EN) and Plane (FA), then cross-link
+- **No duplicate search** — create from this Cursor session; reuse only an `#n` / `AICO-xx` already in this chat
+- PR that finishes the work → `Fixes #n` + Plane `AICO-xx`; Plane state **Testing** + Persian completion comment (not Done until merge)
+- Auto-run closeout when the user asks to ship/PR/workflow, or the change is a clear product fix/feature; otherwise suggest once

--- a/src/utils/dayjsLocale.test.ts
+++ b/src/utils/dayjsLocale.test.ts
@@ -18,6 +18,19 @@ describe('normalizeDayjsLocale', () => {
     expect(normalizeDayjsLocale('pt-BR')).toBe('pt-br');
   });
 
+  it('should strip region codes for language-only dayjs locales', () => {
+    expect(normalizeDayjsLocale('fa-IR')).toBe('fa');
+    expect(normalizeDayjsLocale('de-DE')).toBe('de');
+    expect(normalizeDayjsLocale('ja-JP')).toBe('ja');
+    expect(normalizeDayjsLocale('ko-KR')).toBe('ko');
+    expect(normalizeDayjsLocale('vi-VN')).toBe('vi');
+  });
+
+  it('should keep already-short dayjs locale ids', () => {
+    expect(normalizeDayjsLocale('fa')).toBe('fa');
+    expect(normalizeDayjsLocale('ar')).toBe('ar');
+  });
+
   it('should normalize simplified Chinese script locales to zh-cn', () => {
     expect(normalizeDayjsLocale('zh-Hans')).toBe('zh-cn');
     expect(normalizeDayjsLocale('zh-Hans-CN')).toBe('zh-cn');

--- a/src/utils/dayjsLocale.ts
+++ b/src/utils/dayjsLocale.ts
@@ -6,6 +6,8 @@ const DAYJS_LOCALE_ALIASES: Record<string, string> = {
   'zh': 'zh-cn',
   'zh-cn': 'zh-cn',
   'zh-tw': 'zh-tw',
+  // dayjs ships `pt-br` (not `pt`) — must not be stripped to the language tag
+  'pt-br': 'pt-br',
 };
 
 interface DayjsLocaleModule {
@@ -25,5 +27,15 @@ export const normalizeDayjsLocale = (lang: string): string => {
   if (lower.startsWith('zh-hans')) return 'zh-cn';
   if (lower.startsWith('zh-hant')) return 'zh-tw';
 
-  return DAYJS_LOCALE_ALIASES[lower] ?? lower;
+  const aliased = DAYJS_LOCALE_ALIASES[lower];
+  if (aliased) return aliased;
+
+  // App locales are usually BCP-47 with a region (`fa-IR`, `de-DE`, `ja-JP`),
+  // while dayjs mostly registers language-only ids (`fa`, `de`, `ja`). Without
+  // this strip, loaders miss and relativeTime falls back to English
+  // ("a few seconds ago ذخیره شد").
+  if (lower.startsWith('pt-br')) return 'pt-br';
+
+  const [language] = lower.split('-');
+  return language || lower;
 };


### PR DESCRIPTION
## Summary

- Map BCP-47 region locales (`fa-IR`, `de-DE`, …) to dayjs language ids so relative time (e.g. auto-save hint) is not stuck in English next to Persian `ذخیره شد`.
- Add Aico-owned `aico-ship` skill for Plane (FA) + GitHub (EN) closeout without patching upstream `pr` / `linear`.
- Slim the always-applied Cursor rule to language + pointer at `aico-ship`.

## Test

- [x] Tested locally — `bun run check --test src/utils/dayjsLocale.ts src/utils/dayjsLocale.test.ts`
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #53

Plane: [AICO-36](https://plane.panafor.com/panaforai/browse/AICO-36)


Made with [Cursor](https://cursor.com)