### PR TITLE
🚀 feat(deploy): add moz CLI, local Docker ship workflow, and DB persistence check

### DIFF
--- a/.agents/skills/self-host-deploy/SKILL.md
+++ b/.agents/skills/self-host-deploy/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: self-host-deploy
+description: >-
+  Deploy Aico self-hosted with Docker Compose — zero to production.
+  Covers setup.sh, custom domain, reverse proxy/CDN, build-from-source,
+  platform admin bootstrap, production hardening, and SPA chunk troubleshooting.
+  Use when the user asks to deploy, self-host, docker compose, production setup,
+  domain config, platform admin, best practices, or errors like "Failed to fetch
+  dynamically imported module" on /_spa/assets.
+user-invocable: true
+---
+
+# Aico Deploy (Zero → Production)
+
+## Choose a path
+
+| Goal                              | Path                                                      |
+| --------------------------------- | --------------------------------------------------------- |
+| Fastest start, upstream image     | [Official image](#path-a-official-image)                  |
+| Custom Aico code / fork           | [Build from source](#path-b-build-from-source)            |
+| Already deployed, something broke | [Verify](#verification) → [Troubleshooting](reference.md) |
+
+---
+
+## Path A: Official image
+
+### 1. Server prerequisites
+
+- Linux or macOS (Windows → WSL2)
+- Docker + Docker Compose v2
+- Free ports: `3210` (app), `9000` (S3), `5432` (optional external DB access)
+- Min 2 CPU / 4 GB RAM
+
+### 2. Run setup script
+
+```bash
+mkdir lobehub && cd lobehub
+bash <(curl -fsSL https://lobe.li/setup.sh) -l en
+```
+
+Modes: **local** (localhost only) · **port** (LAN/IP) · **domain** (HTTPS + reverse proxy).
+
+### 3. Start stack
+
+```bash
+docker compose up -d
+docker logs -f lobehub # wait for "database migration pass" + "Ready"
+```
+
+### 4. Configure `.env` (domain / production)
+
+Minimum overrides for a public domain like `https://chat.example.com`:
+
+```env
+APP_URL=https://chat.example.com
+INTERNAL_APP_URL=http://localhost:3210
+S3_ENDPOINT=https://s3.example.com # browser-reachable, NOT rustfs:9000
+AUTH_TRUSTED_ORIGINS=https://chat.example.com
+```
+
+`INTERNAL_APP_URL` must be reachable **inside** the container (`http://localhost:3210` or `http://lobe:3210`). `APP_URL` is what browsers and OAuth use.
+
+Restart after edits: `docker compose up -d lobe`
+
+### 5. Production hardening (before going public)
+
+# Deploy from repo: docker-compose/deploy/
+
+# cp .env.example.aico .env
+
+# cp docker-compose/deploy/.env.example.aico docker-compose/deploy/.env
+
+# ./scripts/deploy-local.sh
+
+Full checklist: [best-practices.md](best-practices.md)
+
+---
+
+## Path B: Build from source
+
+Use when deploying this repo (Aico fork) with custom changes.
+
+```bash
+# From repo root
+docker build -t aico/lobehub:latest .
+
+# In deploy directory — point compose at your image
+# docker-compose/deploy/docker-compose.aico.override.yml → image: aico/lobehub:local
+./scripts/deploy-local.sh
+```
+
+Build pipeline inside Dockerfile runs: `build:spa` → `build:spa:mobile` → `build:spa:auth` → `build:spa:workbench` → `build:spa:copy` → `next build`. Never skip `build:spa:copy` — it publishes JS chunks to `public/_spa*`.
+
+---
+
+## Reverse proxy / CDN
+
+Proxy **all** paths to port `3210`. SPA static assets live at:
+
+- `/_spa/assets/*` — main app JS/CSS
+- `/_spa-auth/assets/*` — sign-in/sign-up
+- `/_spa/icons/*`, `/_spa-auth/favicon.ico`
+
+**Do not** add CDN rules that rewrite or block `/_spa*/assets/*`. A common failure: icons return 200 but JS chunks return 500/404 → browser shows `Failed to fetch dynamically imported module`.
+
+Nginx minimum:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:3210;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+Full proxy/CDN notes: [reference.md](reference.md)
+
+---
+
+## Post-deploy bootstrap
+
+### 1. Create first user
+
+Open `APP_URL`, sign up with email/password (or configure SSO in `~/Aico/.env`).
+
+### 2. Grant platform admin
+
+Find user id (Clerk-style id in `users` table):
+
+```bash
+docker exec lobe-postgres psql -U postgres -d lobechat -c \
+  "SELECT id, email FROM users ORDER BY created_at LIMIT 5;"
+```
+
+Insert platform admin — **`id` is required** (Drizzle default, not a DB default):
+
+```bash
+docker exec lobe-postgres psql -U postgres -d lobechat -c \
+  "INSERT INTO platform_admins (id, user_id)
+   VALUES ('padm_' || substr(md5(random()::text || clock_timestamp()::text), 1, 12), 'USER_ID_HERE')
+   ON CONFLICT (user_id) DO NOTHING;"
+```
+
+Replace `USER_ID_HERE` with the `id` from `users`. Platform admin pages: `/platform`.
+
+---
+
+## Verification
+
+Run the bundled checker (pass your public URL):
+
+```bash
+bash .claude/skills/self-host-deploy/scripts/verify-deployment.sh https://chat.example.com
+```
+
+Manual spot-checks:
+
+```bash
+# App up
+curl -sI https://chat.example.com/ | head -3
+
+# SPA chunks must be 200, not 500/404
+curl -sI https://chat.example.com/_spa/icons/icon-192x192.png | head -3
+# Pick a current hash from page source:
+curl -sI https://chat.example.com/_spa-auth/assets/index.auth-*.js | head -3
+
+# Inside container — assets dir must be populated
+docker exec lobehub ls /app/public/_spa/assets/ | head -5
+docker exec lobehub ls /app/public/_spa-auth/assets/ | head -5
+```
+
+Expected: migration log in `docker logs lobehub`, sign-in page loads, JS assets return `200` with `content-type: application/javascript` or `text/javascript`.
+
+---
+
+## Operations cheat sheet
+
+```bash
+docker compose logs -f lobe                 # live logs
+docker compose pull && docker compose up -d # update official image
+docker compose exec postgresql pg_dump -U postgres lobechat > backup.sql
+docker compose down && sudo rm -rf ./data && docker compose up -d # reset DB (destructive)
+```
+
+After deploy updates, users may need one hard refresh (`Ctrl+Shift+R`). The app auto-reloads once on chunk errors via `lobe-chunk-reload` session flag.
+
+---
+
+## Troubleshooting quick hits
+
+| Symptom                                                           | Likely cause                                             | Fix                                                                                  |
+| ----------------------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Failed to fetch dynamically imported module` on `/_spa/assets/*` | Missing SPA build in image, or CDN/proxy blocking assets | Rebuild image; verify `/_spa/assets/*` returns 200; see [reference.md](reference.md) |
+| `null value in column "id"` on `platform_admins`                  | Raw SQL without `id`                                     | Use insert with `padm_` prefix id (above)                                            |
+| OAuth redirect mismatch                                           | Wrong `APP_URL`                                          | Set `APP_URL` to exact public URL; add to `AUTH_TRUSTED_ORIGINS`                     |
+| Image upload in chat fails                                        | `S3_ENDPOINT` not browser-reachable                      | Use public domain, not `http://rustfs:9000`                                          |
+| Async features silent fail                                        | Missing `INTERNAL_APP_URL`                               | Set `INTERNAL_APP_URL=http://localhost:3210`                                         |
+
+Full troubleshooting: [reference.md](reference.md)
+
+---
+
+## Production best practices (summary)
+
+| Area        | Rule                                                                                                      |
+| ----------- | --------------------------------------------------------------------------------------------------------- |
+| **Secrets** | Rotate `AUTH_SECRET`, `KEY_VAULTS_SECRET`, DB password — never use setup.sh defaults in prod              |
+| **Network** | Only 80/443 public; bind `lobe` to `127.0.0.1`; remove Postgres/Redis port mappings                       |
+| **URLs**    | `APP_URL` = HTTPS domain; `INTERNAL_APP_URL` = `http://localhost:3210`; `S3_ENDPOINT` = browser-reachable |
+| **Access**  | Set `AUTH_ALLOWED_EMAILS` or SSO-only for private deployments                                             |
+| **CDN**     | Pass `/_spa*` through unchanged; cache hashed assets, not HTML                                            |
+| **Deploy**  | Backup → pull/rebuild → `verify-deployment.sh` → rollback plan ready                                      |
+| **Updates** | Pin image tags; never `pull` without a DB backup                                                          |
+
+Templates:
+
+- [production.env.example](templates/production.env.example)
+- [docker-compose.production.override.yml](templates/docker-compose.production.override.yml)
+
+Complete guide: [best-practices.md](best-practices.md)

--- a/.agents/skills/self-host-deploy/best-practices.md
+++ b/.agents/skills/self-host-deploy/best-practices.md
@@ -1,0 +1,284 @@
+# Production Best Practices
+
+Use this checklist after initial deploy. Items marked **required** block a safe production launch.
+
+---
+
+## Pre-launch checklist
+
+```
+Security
+- [ ] HTTPS on APP_URL (required)
+- [ ] AUTH_SECRET rotated — not setup.sh default (required)
+- [ ] KEY_VAULTS_SECRET rotated (required)
+- [ ] .env mode 600, not in git (required)
+- [ ] Postgres/Redis not exposed to internet (required)
+- [ ] AUTH_ALLOWED_EMAILS set (recommended for private teams)
+- [ ] Firewall: only 80/443 public (required)
+
+Networking
+- [ ] APP_URL = exact public URL (scheme + host, no trailing slash)
+- [ ] INTERNAL_APP_URL = http://localhost:3210 (required in Docker)
+- [ ] S3_ENDPOINT = browser-reachable HTTPS domain (required for chat images)
+- [ ] AUTH_TRUSTED_ORIGINS includes APP_URL
+
+SPA / CDN
+- [ ] /_spa/assets/* returns 200 (required)
+- [ ] /_spa-auth/assets/* returns 200 (required)
+- [ ] CDN passes all /_spa* paths to origin unchanged
+- [ ] verify-deployment.sh passes
+
+Operations
+- [ ] Automated DB backup cron
+- [ ] Image tag pinned (not bare :latest in prod)
+- [ ] Disk alert configured
+- [ ] Update runbook documented
+```
+
+---
+
+## 1. Secrets & access control
+
+### Rotate all auto-generated secrets
+
+`setup.sh` secrets are fine for dev. **Before going public**, regenerate:
+
+```bash
+openssl rand -base64 32 # AUTH_SECRET
+openssl rand -base64 32 # KEY_VAULTS_SECRET
+openssl rand -base64 24 # POSTGRES_PASSWORD
+openssl rand -base64 24 # RUSTFS_SECRET_KEY
+```
+
+Update `.env`, then: `docker compose up -d --force-recreate`
+
+### Restrict who can sign up
+
+```env
+# Only these emails can log in (comma-separated)
+AUTH_ALLOWED_EMAILS=you@company.com,team@company.com
+
+# Or SSO-only (disable email/password registration)
+AUTH_DISABLE_EMAIL_PASSWORD=1
+AUTH_SSO_PROVIDERS=google,github
+```
+
+### Protect `.env`
+
+```bash
+chmod 600 .env
+echo ".env" >> .gitignore # must never be committed
+```
+
+---
+
+## 2. Network hardening
+
+### Do not expose internal services
+
+Default compose publishes Postgres (`5432`), Redis (`6379`), and RustFS admin (`9001`) to the host. **Remove these in production** — containers talk over the internal `lobe-network` bridge.
+
+Use the production override:
+
+```bash
+docker compose -f docker-compose.yml \
+  -f .claude/skills/self-host-deploy/templates/docker-compose.production.override.yml \
+  up -d
+```
+
+Or manually delete `ports:` blocks from `postgresql`, `redis`, and `rustfs` (keep only what the reverse proxy needs).
+
+### Bind app to localhost
+
+Only the reverse proxy should reach the app:
+
+```yaml
+# production override — lobe service
+ports:
+  - '127.0.0.1:${LOBE_PORT:-3210}:3210'
+```
+
+### Firewall
+
+```bash
+# UFW example
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw enable
+```
+
+### URL variables (critical)
+
+| Variable               | Production value           | Why                                       |
+| ---------------------- | -------------------------- | ----------------------------------------- |
+| `APP_URL`              | `https://chat.example.com` | OAuth callbacks, emails, browser links    |
+| `INTERNAL_APP_URL`     | `http://localhost:3210`    | In-container async jobs bypass CDN        |
+| `S3_ENDPOINT`          | `https://s3.example.com`   | Browser uploads images via presigned URLs |
+| `AUTH_TRUSTED_ORIGINS` | `https://chat.example.com` | Better Auth origin validation             |
+
+Never set `S3_ENDPOINT=http://rustfs:9000` — browsers cannot resolve Docker service names.
+
+---
+
+## 3. Reverse proxy & CDN
+
+### Required headers
+
+```nginx
+proxy_set_header Host              $host;
+proxy_set_header X-Real-IP         $remote_addr;
+proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;   # required for HTTPS detection
+proxy_http_version 1.1;
+proxy_set_header Upgrade           $http_upgrade;
+proxy_set_header Connection        "upgrade";
+```
+
+### SPA asset rules
+
+| Path                       | Cache                         | Notes                                         |
+| -------------------------- | ----------------------------- | --------------------------------------------- |
+| `/_spa/assets/*`           | `immutable, max-age=31536000` | Hashed filenames — safe to cache forever      |
+| `/_spa-auth/assets/*`      | same                          | Auth SPA chunks                               |
+| `/`, `/signin`, `/agent/*` | `no-cache`                    | HTML shell — must not be stale across deploys |
+| `/api/*`, `/trpc/*`        | `no-cache`                    | Dynamic API                                   |
+
+**Never** let CDN "optimize" or rewrite `/_spa*/assets/*.js`. If icons return 200 but JS returns 500, the CDN is misconfigured.
+
+### Cloudflare / ArvanCloud
+
+- SSL mode: **Full (strict)** when origin has valid cert
+- Disable "Rocket Loader" / JS optimization for `/_spa*`
+- Page Rules: bypass cache for `/api/*`, `/trpc/*`, `/signin*`
+- After deploy: purge cache for `/_spa*` **or** rely on hashed filenames (preferred)
+
+---
+
+## 4. Docker & releases
+
+### Pin image versions
+
+```yaml
+# Bad — unpredictable updates
+image: lobehub/lobehub
+
+# Good — pin to digest or semver tag
+image: lobehub/lobehub:1.x.x
+```
+
+Custom builds: tag with git SHA.
+
+```bash
+docker build -t aico/lobehub:$(git rev-parse --short HEAD) .
+```
+
+### Safe update procedure
+
+```bash
+# 1. Backup
+docker compose exec postgresql pg_dump -U postgres lobechat > backup-pre-update.sql
+
+# 2. Pull / rebuild
+docker compose pull # official image
+# OR docker build --no-cache -t aico/lobehub:NEW .
+
+# 3. Deploy
+docker compose up -d --force-recreate lobe
+
+# 4. Verify
+bash .claude/skills/self-host-deploy/scripts/verify-deployment.sh https://chat.example.com
+
+# 5. Rollback if needed
+docker compose down
+# restore image tag / backup
+docker compose up -d
+```
+
+### Resource limits (recommended)
+
+```yaml
+lobe:
+  deploy:
+    resources:
+      limits:
+        cpus: '4'
+        memory: 8G
+      reservations:
+        cpus: '1'
+        memory: 2G
+```
+
+---
+
+## 5. Backups & monitoring
+
+### Automated DB backup (cron)
+
+```bash
+# /etc/cron.daily/lobehub-backup
+#!/bin/bash
+BACKUP_DIR=/var/backups/lobehub
+mkdir -p "$BACKUP_DIR"
+docker compose -f /path/to/lobehub/docker-compose.yml \
+  exec -T postgresql pg_dump -U postgres lobechat \
+  | gzip > "$BACKUP_DIR/lobechat-$(date +%F).sql.gz"
+find "$BACKUP_DIR" -name '*.sql.gz' -mtime +14 -delete
+```
+
+### What to monitor
+
+| Signal                        | Alert threshold           |
+| ----------------------------- | ------------------------- |
+| HTTP 5xx on `APP_URL`         | Any sustained             |
+| Disk usage on `./data` volume | > 80%                     |
+| `docker compose ps` unhealthy | Any service               |
+| `/_spa/assets/*.js`           | Not HTTP 200 after deploy |
+| Container restarts            | > 3/hour                  |
+
+Optional: Grafana stack in `docker-compose/production/grafana/`.
+
+---
+
+## 6. Post-deploy bootstrap
+
+### Platform admin (do once)
+
+```bash
+# 1. Sign up first user via UI
+# 2. Get user id
+docker exec lobe-postgres psql -U postgres -d lobechat -c \
+  "SELECT id, email FROM users ORDER BY created_at LIMIT 5;"
+
+# 3. Grant admin (id column required)
+docker exec lobe-postgres psql -U postgres -d lobechat -c \
+  "INSERT INTO platform_admins (id, user_id)
+   VALUES ('padm_' || substr(md5(random()::text || clock_timestamp()::text), 1, 12), 'USER_ID')
+   ON CONFLICT (user_id) DO NOTHING;"
+```
+
+Prefer tRPC `platformAdmin.addPlatformAdmin` when you already have an admin session.
+
+---
+
+## 7. Staging before production
+
+Mirror production topology in staging:
+
+1. Same reverse proxy + CDN setup
+2. Run `verify-deployment.sh` against staging URL
+3. Test: sign-up, chat, image upload, OAuth callback
+4. Deploy to production only after verify passes
+
+---
+
+## 8. Common anti-patterns
+
+| Anti-pattern                               | Why it's bad                       | Fix                          |
+| ------------------------------------------ | ---------------------------------- | ---------------------------- |
+| `APP_URL=http://IP:3210` with public users | OAuth breaks, mixed content        | Use domain + HTTPS           |
+| Exposed Postgres on 5432                   | Brute-force / data leak            | Remove port mapping          |
+| `docker compose pull` without backup       | No rollback path                   | Backup first                 |
+| CDN caching HTML                           | Stale SPA chunk refs after deploy  | `no-cache` on HTML routes    |
+| Skipping `build:spa:copy` in custom builds | 500 on `/_spa/assets/*`            | Full `build:docker` pipeline |
+| Same secrets dev → prod                    | Compromised dev = compromised prod | Rotate per environment       |

--- a/.agents/skills/self-host-deploy/reference.md
+++ b/.agents/skills/self-host-deploy/reference.md
@@ -1,0 +1,163 @@
+# Self-Host Deploy — Reference
+
+## Architecture
+
+```
+Browser ──► Reverse proxy / CDN ──► lobehub:3210 (Next.js + SPA)
+                                      ├── PostgreSQL (lobe-postgres)
+                                      ├── Redis (lobe-redis)
+                                      └── RustFS S3 (lobe-rustfs:9000)
+```
+
+- **HTML shell**: Next.js rewrites page requests to `/spa/[variants]/…` route handlers.
+- **JS/CSS chunks**: Static files in `public/_spa`, `public/_spa-auth`, `public/_spa-workbench`.
+- **API**: `/api`, `/trpc`, `/webapi` bypass SPA rewrite (middleware matcher excludes them).
+
+## Environment variables
+
+### Required (server DB mode)
+
+| Variable                                    | Purpose                                                   |
+| ------------------------------------------- | --------------------------------------------------------- |
+| `AUTH_SECRET`                               | Session signing — generate with `openssl rand -base64 32` |
+| `KEY_VAULTS_SECRET`                         | Encrypts stored API keys — `openssl rand -base64 32`      |
+| `DATABASE_URL`                              | Postgres connection string                                |
+| `APP_URL`                                   | Public URL browsers use                                   |
+| `INTERNAL_APP_URL`                          | In-container self-calls (`http://localhost:3210`)         |
+| `S3_ENDPOINT`                               | **Browser-reachable** S3 URL for chat image uploads       |
+| `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` | RustFS credentials                                        |
+| `S3_BUCKET`                                 | Bucket name (default `lobe`)                              |
+| `REDIS_URL`                                 | `redis://redis:6379` in compose                           |
+
+### Common optional
+
+| Variable                        | Purpose                                         |
+| ------------------------------- | ----------------------------------------------- |
+| `AUTH_ALLOWED_EMAILS`           | Comma-separated allowlist                       |
+| `AUTH_DISABLE_EMAIL_PASSWORD=1` | SSO-only                                        |
+| `AUTH_TRUSTED_ORIGINS`          | Extra origins for Better Auth (comma-separated) |
+| `AUTH_SSO_PROVIDERS`            | `google`, `github`, `microsoft`, …              |
+| `LOBE_PORT`                     | Host port mapping (default 3210)                |
+
+## Domain mode checklist
+
+1. DNS A/AAAA → server IP
+2. TLS certificate (Let's Encrypt / ArvanCloud / Cloudflare Full Strict)
+3. Proxy `chat.example.com:443` → `localhost:3210` (all paths)
+4. Proxy `s3.example.com:443` → `localhost:9000` (S3 for uploads)
+5. `.env`: `APP_URL=https://chat.example.com`, `S3_ENDPOINT=https://s3.example.com`
+6. `AUTH_TRUSTED_ORIGINS=https://chat.example.com`
+7. Run verify script
+
+## ArvanCloud / CDN notes
+
+Observed failure pattern on `chat.panafor.com`:
+
+- `/_spa/icons/*` → 200
+- `/_spa/assets/*.js` → 500
+- `/_spa-auth/assets/*.js` → 500
+
+This indicates either:
+
+1. **Incomplete image** — `public/_spa/assets/` empty in container (rebuild with full `build:docker`).
+2. **CDN rule** — path-based rule intercepting `/assets` or `*.js` under `/_spa*`.
+3. **Stale deployment** — HTML references old chunk hashes after partial update.
+
+CDN fix: ensure `/_spa/*` and `/_spa-auth/*` pass through to origin with no path rewrite. Disable "static asset optimization" that strips unknown extensions.
+
+## SPA chunk error (deep dive)
+
+Browser error:
+
+```
+TypeError: Failed to fetch dynamically imported module:
+  https://example.com/_spa/assets/_layout-XXXX.js
+```
+
+Server-side causes:
+
+| HTTP status      | Meaning                                                                 |
+| ---------------- | ----------------------------------------------------------------------- |
+| 404              | Chunk hash stale or never deployed — hard refresh; if persists, rebuild |
+| 500              | Origin error or CDN misroute — check container files + proxy            |
+| 200 + wrong MIME | Proxy returning HTML error page — fix CDN                               |
+
+In-container diagnosis:
+
+```bash
+docker exec lobehub ls -la /app/public/_spa/assets/ | wc -l # expect dozens+
+docker exec lobehub ls -la /app/public/_spa-auth/assets/ | wc -l
+docker exec lobehub ls -la /app/public/_spa/vendor/ | head
+```
+
+If counts are 0 or 2 (only `.` and `..`): image built without SPA copy step.
+
+Rebuild:
+
+```bash
+docker build --no-cache -t aico/lobehub:latest .
+docker compose up -d --force-recreate lobe
+```
+
+Client-side: app listens for `vite:preloadError` and reloads once (`src/utils/chunkError.ts`). If reload doesn't help, it's a server problem.
+
+## Platform admin
+
+Table: `platform_admins` — columns `id` (text PK), `user_id` (FK → users), `created_at`.
+
+- IDs use prefix `padm_` + 12-char nanoid (set by Drizzle `$defaultFn`, not Postgres DEFAULT).
+- Raw `INSERT` without `id` fails: `null value in column "id"`.
+- App helper: `OrganizationModel.addPlatformAdmin(userId)` via tRPC `platformAdmin.addPlatformAdmin`.
+
+List admins:
+
+```sql
+SELECT pa.id, pa.user_id, u.email
+FROM platform_admins pa
+JOIN users u ON u.id = pa.user_id;
+```
+
+## Database reset (destructive)
+
+```bash
+docker compose down
+sudo rm -rf ./data # Postgres volume
+docker compose up -d
+```
+
+Migrations run automatically on container start (`docker.cjs`).
+
+## Custom compose without setup.sh
+
+```bash
+curl -O https://raw.githubusercontent.com/lobehub/lobehub/HEAD/docker-compose/deploy/docker-compose.yml
+curl -O https://raw.githubusercontent.com/lobehub/lobehub/HEAD/docker-compose/deploy/.env.example
+mv .env.example .env
+# edit .env
+docker compose up -d
+```
+
+## Resource sizing
+
+| Tier        | CPU | RAM   | Disk       |
+| ----------- | --- | ----- | ---------- |
+| Dev / light | 2   | 4 GB  | 20 GB      |
+| Production  | 4+  | 8 GB+ | 50 GB+ SSD |
+
+## Backup
+
+```bash
+# DB
+docker compose exec postgresql pg_dump -U postgres lobechat > backup-$(date +%F).sql
+
+# S3 data
+docker compose exec rustfs tar czf /tmp/s3-backup.tar.gz /data
+docker cp lobe-rustfs:/tmp/s3-backup.tar.gz ./s3-backup.tar.gz
+```
+
+## Production best practices
+
+See [best-practices.md](best-practices.md) for the full checklist. Templates:
+
+- `templates/production.env.example` — production `.env` starter
+- `templates/docker-compose.production.override.yml` — bind localhost, hide internal ports

--- a/.agents/skills/self-host-deploy/scripts/verify-deployment.sh
+++ b/.agents/skills/self-host-deploy/scripts/verify-deployment.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Verify a LobeHub/Aico self-hosted deployment (functional + best-practice checks).
+# Usage: verify-deployment.sh <BASE_URL> [CONTAINER_NAME]
+# Example: verify-deployment.sh https://chat.example.com lobehub
+
+set -uo pipefail
+
+BASE_URL="${1:?Usage: $0 <BASE_URL> [CONTAINER_NAME]}"
+CONTAINER="${2:-lobehub}"
+PASS=0
+FAIL=0
+WARN=0
+
+green()  { printf '\033[32m✓\033[0m %s\n' "$*"; }
+red()    { printf '\033[31m✗\033[0m %s\n' "$*"; }
+yellow() { printf '\033[33m!\033[0m %s\n' "$*"; }
+
+check_http() {
+  local label="$1" url="$2" expect="${3:-200}"
+  local code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$url" 2>/dev/null || echo "000")
+  if [[ "$code" == "$expect" ]]; then
+    green "$label → HTTP $code"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  red "$label → HTTP $code (expected $expect) — $url"
+  FAIL=$((FAIL + 1))
+  return 1
+}
+
+check_header() {
+  local label="$1" url="$2" header="$3" pattern="$4"
+  local value
+  value=$(curl -sS -I --max-time 15 "$url" 2>/dev/null | grep -i "^${header}:" | head -1 || true)
+  if echo "$value" | grep -qiE "$pattern"; then
+    green "$label → $value"
+    PASS=$((PASS + 1))
+  else
+    yellow "$label → missing or unexpected ($value)"
+    WARN=$((WARN + 1))
+  fi
+}
+
+echo "=== LobeHub deployment check: $BASE_URL ==="
+echo
+
+# --- Best-practice: HTTPS ---
+if [[ "$BASE_URL" == https://* ]]; then
+  green "APP_URL uses HTTPS"
+  PASS=$((PASS + 1))
+else
+  yellow "BASE_URL is not HTTPS — required for production"
+  WARN=$((WARN + 1))
+fi
+
+# --- HTTP functional checks ---
+check_http "Root (may redirect)" "$BASE_URL/" "302" || check_http "Root" "$BASE_URL/" "200"
+check_http "Sign-in page" "$BASE_URL/signin" "200"
+check_http "SPA icons" "$BASE_URL/_spa/icons/icon-192x192.png" "200"
+check_http "SPA-auth favicon" "$BASE_URL/_spa-auth/favicon.ico" "200"
+
+# Extract chunks from sign-in HTML
+SIGNIN_HTML=$(curl -sS --max-time 15 "$BASE_URL/signin" 2>/dev/null || true)
+JS_PATH=$(echo "$SIGNIN_HTML" | grep -oE '/_spa-auth/assets/[^"'\'' ]+\.js' | head -1)
+if [[ -n "$JS_PATH" ]]; then
+  JS_URL="${BASE_URL}${JS_PATH}"
+  check_http "SPA-auth JS chunk ($JS_PATH)" "$JS_URL" "200" || true
+
+  # Best-practice: JS must not be served as text/html (CDN misroute)
+  JS_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$JS_URL" 2>/dev/null || echo "000")
+  if [[ "$JS_CODE" == "200" ]]; then
+    MIME=$(curl -sS -I --max-time 15 "$JS_URL" 2>/dev/null | grep -i '^content-type:' | head -1 || true)
+    if echo "$MIME" | grep -qiE 'javascript|ecmascript'; then
+      green "JS content-type OK → $MIME"
+      PASS=$((PASS + 1))
+    else
+      red "JS content-type wrong → $MIME (CDN may be returning HTML error page)"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+else
+  yellow "Could not find SPA-auth JS path in sign-in HTML"
+  WARN=$((WARN + 1))
+fi
+
+CSS_PATH=$(echo "$SIGNIN_HTML" | grep -oE '/_spa-auth/assets/[^"'\'' ]+\.css' | head -1)
+if [[ -n "$CSS_PATH" ]]; then
+  check_http "SPA-auth CSS ($CSS_PATH)" "${BASE_URL}${CSS_PATH}" "200"
+fi
+
+# Best-practice: forwarded proto header (proxy config sanity)
+check_header "X-Forwarded-Proto (via sign-in)" "$BASE_URL/signin" "x-forwarded-proto" "https"
+
+echo
+
+# --- Container checks (optional, run on deploy host) ---
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
+  echo "=== Container: $CONTAINER ==="
+
+  for dir in /app/public/_spa/assets /app/public/_spa-auth/assets /app/public/_spa/vendor; do
+    count=$(docker exec "$CONTAINER" sh -c "ls -1 $dir 2>/dev/null | wc -l" 2>/dev/null || echo "0")
+    if [[ "$count" -gt 2 ]]; then
+      green "$dir → $count files"
+      PASS=$((PASS + 1))
+    else
+      red "$dir → $count files (expected many — SPA build may be missing)"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+
+  if docker logs "$CONTAINER" 2>&1 | tail -200 | grep -q "database migration pass"; then
+    green "DB migration passed (recent logs)"
+    PASS=$((PASS + 1))
+  else
+    yellow "Could not confirm DB migration in recent logs"
+    WARN=$((WARN + 1))
+  fi
+
+  # Best-practice: internal services should not be bound to 0.0.0.0
+  echo
+  echo "=== Port exposure (best practice) ==="
+  for port_label in "5432:PostgreSQL" "6379:Redis" "9001:RustFS-admin"; do
+    port="${port_label%%:*}"
+    name="${port_label#*:}"
+    if ss -tln 2>/dev/null | grep -q ":${port} " || netstat -tln 2>/dev/null | grep -q ":${port} "; then
+      yellow "$name port $port exposed on host — remove in production (see best-practices.md)"
+      WARN=$((WARN + 1))
+    else
+      green "$name port $port not publicly bound"
+      PASS=$((PASS + 1))
+    fi
+  done
+
+  # Best-practice: lobe should bind localhost only in production
+  if ss -tln 2>/dev/null | grep -q '127.0.0.1:3210 ' || netstat -tln 2>/dev/null | grep -q '127.0.0.1:3210 '; then
+    green "Lobe bound to 127.0.0.1:3210 (good)"
+    PASS=$((PASS + 1))
+  elif ss -tln 2>/dev/null | grep -q ':3210 ' || netstat -tln 2>/dev/null | grep -q ':3210 '; then
+    yellow "Lobe bound to 0.0.0.0:3210 — use production override to bind localhost"
+    WARN=$((WARN + 1))
+  fi
+else
+  yellow "Container '$CONTAINER' not running locally — skipping in-container checks"
+  WARN=$((WARN + 1))
+fi
+
+echo
+echo "=== Summary: $PASS passed, $FAIL failed, $WARN warnings ==="
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "Fix failures before production. See best-practices.md and reference.md."
+  exit 1
+fi
+if [[ "$WARN" -gt 0 ]]; then
+  echo "Warnings present — review best-practices.md before going public."
+fi

--- a/.agents/skills/self-host-deploy/templates/docker-compose.production.override.yml
+++ b/.agents/skills/self-host-deploy/templates/docker-compose.production.override.yml
@@ -1,0 +1,26 @@
+# Production hardening overlay for docker-compose/deploy/docker-compose.yml
+#
+# Usage:
+#   docker compose -f docker-compose.yml \
+#     -f path/to/docker-compose.production.override.yml up -d
+#
+# Changes:
+#   - Bind lobe to localhost only (reverse proxy handles public traffic)
+#   - Remove Postgres, Redis, RustFS admin from public host ports
+#   - Keep RustFS S3 port for browser uploads (proxy s3.example.com → this port)
+
+services:
+  lobe:
+    ports:
+      - '127.0.0.1:${LOBE_PORT:-3210}:3210'
+
+  postgresql:
+    ports: []
+
+  redis:
+    ports: []
+
+  rustfs:
+    ports:
+      - '127.0.0.1:${RUSTFS_PORT:-9000}:9000'
+      # Admin console (9001) not exposed — use docker exec if needed

--- a/.agents/skills/self-host-deploy/templates/production.env.example
+++ b/.agents/skills/self-host-deploy/templates/production.env.example
@@ -1,0 +1,37 @@
+# Production .env template — copy to .env and fill in values.
+# Generate secrets: openssl rand -base64 32
+
+# ── Public URLs (required) ──────────────────────────────────────────
+APP_URL=https://chat.example.com
+INTERNAL_APP_URL=http://localhost:3210
+AUTH_TRUSTED_ORIGINS=https://chat.example.com
+
+# ── Secrets (required — rotate from setup.sh defaults) ──────────────
+AUTH_SECRET=CHANGE_ME_openssl_rand_base64_32
+KEY_VAULTS_SECRET=CHANGE_ME_openssl_rand_base64_32
+POSTGRES_PASSWORD=CHANGE_ME_strong_password
+RUSTFS_SECRET_KEY=CHANGE_ME_strong_password
+
+# ── Access control (recommended) ───────────────────────────────────
+AUTH_ALLOWED_EMAILS=admin@example.com
+# AUTH_DISABLE_EMAIL_PASSWORD=1
+# AUTH_SSO_PROVIDERS=google,github
+
+# ── S3 (browser-reachable domain, NOT rustfs:9000) ────────────────
+S3_ENDPOINT=https://s3.example.com
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_LOBE_BUCKET=lobe
+
+# ── Ports (host binding — use production override) ────────────────
+LOBE_PORT=3210
+RUSTFS_PORT=9000
+
+# ── Database ──────────────────────────────────────────────────────
+LOBE_DB_NAME=lobechat
+
+# ── Optional: email ───────────────────────────────────────────────
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=noreply@example.com

--- a/.env.example.aico
+++ b/.env.example.aico
@@ -1,0 +1,54 @@
+# Aico application environment
+# Source of truth for app-level behavior, provider keys, auth, branding, and public URLs.
+# Docker deploy loads this file first, then docker-compose/deploy/.env for infra-only values.
+
+# Public URLs
+APP_URL=https://chat.example.com
+INTERNAL_APP_URL=http://localhost:3210
+AUTH_TRUSTED_ORIGINS=https://chat.example.com,http://localhost:3210
+
+# Branding
+BRANDING_NAME=Aico
+NEXT_PUBLIC_BRANDING_NAME=Aico
+ORG_NAME=Aico
+NEXT_PUBLIC_ORG_NAME=Aico
+BRANDING_CLOUD_NAME=Aico Cloud
+NEXT_PUBLIC_BRANDING_CLOUD_NAME=Aico Cloud
+
+# Auth behavior
+AUTH_EMAIL_VERIFICATION=0
+# AUTH_ALLOWED_EMAILS=admin@example.com
+# AUTH_DISABLE_EMAIL_PASSWORD=1
+
+# Security
+SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
+
+# Provider / integration examples
+# OPENAI_API_KEY=sk-xxxx
+# OPENROUTER_API_KEY=sk-or-v1-xxxx
+# OPENROUTER_MANAGEMENT_API_KEY=or-mgmt-xxxx
+# COMPOSIO_API_KEY=ak_xxxx
+# QSTASH_TOKEN=xxxx
+
+# Redis overrides (optional; compose already injects container-local defaults)
+# REDIS_URL=redis://redis:6379
+# REDIS_PREFIX=aico
+# REDIS_TLS=0
+
+# SMS / OTP (optional)
+# KAVENEGAR_API_KEY=xxxx
+# KAVENEGAR_OTP_TEMPLATE=login
+# KAVENEGAR_SENDER=1000xxxx
+
+# Aico business flags (optional)
+# AICO_ALLOW_MOCK_TOPUP=0
+# AICO_OPENROUTER_MOCK=0
+# AICO_TOMAN_PER_USD=50000
+
+# Public S3 URL for browser uploads in production
+# S3_ENDPOINT=https://s3.example.com
+# S3_BUCKET=lobe
+# S3_ACCESS_KEY_ID=admin
+# S3_SECRET_ACCESS_KEY=change-me
+# S3_ENABLE_PATH_STYLE=1
+# S3_SET_ACL=0

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ CLAUDE.local.md
 
 # Docker development data
 docker-compose/dev/data/
+docker-compose/deploy/data
 docker-compose/deploy/data/
 docker-compose/deploy/.env
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,8 @@ CLAUDE.local.md
 
 # Docker development data
 docker-compose/dev/data/
+docker-compose/deploy/data/
+docker-compose/deploy/.env
 
 # Migration scripts data
 scripts/clerk-to-betterauth/test/*.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ COPY --from=builder /app/.next/standalone /app/
 COPY --from=builder /app/.next/static /app/.next/static
 # Copy SPA assets (Vite build output)
 COPY --from=builder /app/public/_spa /app/public/_spa
+COPY --from=builder /app/public/_spa-auth /app/public/_spa-auth
 COPY --from=builder /app/public/_spa-workbench /app/public/_spa-workbench
 # Copy database migrations
 COPY --from=builder /app/packages/database/migrations /app/migrations

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,0 +1,28 @@
+# Package a host-built Aico tree into a runnable production image.
+# Prerequisite: DOCKER=true bun run build:docker
+#
+#   docker build -f Dockerfile.prebuilt --ignorefile .dockerignore.prebuilt -t aico/lobehub:local .
+
+FROM node:24-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NODE_OPTIONS="--dns-result-order=ipv4first" \
+    MIDDLEWARE_REWRITE_THROUGH_LOCAL=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3210
+
+COPY .next/standalone ./
+COPY .next/static ./.next/static
+COPY public/_spa ./public/_spa
+COPY public/_spa-auth ./public/_spa-auth
+COPY public/_spa-workbench ./public/_spa-workbench
+COPY packages/database/migrations ./migrations
+COPY scripts/migrateServerDB/docker.cjs ./docker.cjs
+COPY scripts/migrateServerDB/errorHint.js ./errorHint.js
+COPY scripts/serverLauncher/startServer.js ./startServer.js
+COPY scripts/_shared ./scripts/_shared
+
+EXPOSE 3210
+CMD ["node", "startServer.js"]

--- a/bin/moz
+++ b/bin/moz
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Short deploy command for local Aico Docker.
+#
+# Install once:
+#   ln -sf "$HOME/Aico/bin/moz" ~/.local/bin/moz
+#
+# Usage:
+#   moz        # start/redeploy
+#   moz -u     # build + deploy
+#   moz -s     # stop
+
+set -euo pipefail
+
+resolve_script_path() {
+  local source="${BASH_SOURCE[0]}"
+  while [[ -L "$source" ]]; do
+    local dir
+    dir="$(cd -P "$(dirname "$source")" && pwd)"
+    source="$(readlink "$source")"
+    [[ "$source" != /* ]] && source="$dir/$source"
+  done
+  cd -P "$(dirname "$source")" && pwd
+}
+
+ROOT="$(resolve_script_path)/.."
+ROOT="$(cd "$ROOT" && pwd)"
+exec "$ROOT/scripts/deploy-local.sh" "$@"

--- a/docker-compose/deploy/.env.example.aico
+++ b/docker-compose/deploy/.env.example.aico
@@ -1,0 +1,19 @@
+# Aico deploy infrastructure environment
+# Keep this file infra-only. Do NOT duplicate app config from ../../.env.
+
+# Host port mappings
+LOBE_PORT=3210
+RUSTFS_PORT=9000
+RUSTFS_ADMIN_PORT=9001
+
+# Database
+LOBE_DB_NAME=lobechat
+POSTGRES_PASSWORD=change-me-strong-password
+
+# RustFS / object storage bootstrap
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_SECRET_KEY=change-me-strong-password
+RUSTFS_LOBE_BUCKET=lobe
+
+# Required by auth bootstrap / JWT signing keys used by the stack
+JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me","use":"sig","alg":"RS256","n":"replace-me","e":"AQAB","d":"replace-me","p":"replace-me","q":"replace-me","dp":"replace-me","dq":"replace-me","qi":"replace-me"}]}

--- a/docker-compose/deploy/docker-compose.aico.override.yml
+++ b/docker-compose/deploy/docker-compose.aico.override.yml
@@ -1,0 +1,13 @@
+# Use a locally built Aico image instead of the upstream Docker Hub image.
+#
+#   scripts/deploy-local.sh          # build + deploy
+#   docker compose -f docker-compose.yml -f docker-compose.aico.override.yml up -d
+
+services:
+  lobe:
+    image: aico/lobehub:local
+    pull_policy: never
+    # App config lives in repo root .env; deploy/.env keeps infra-only values.
+    env_file:
+      - ../../.env
+      - .env

--- a/scripts/completions/deploy-local.fish
+++ b/scripts/completions/deploy-local.fish
@@ -1,0 +1,11 @@
+complete -c deploy-local.sh -s h -l help -d 'Show help'
+complete -c deploy-local.sh -s u -l up -l ship -d 'Build from source, then deploy'
+complete -c deploy-local.sh -s d -l deploy-only -d 'Redeploy existing image (default)'
+complete -c deploy-local.sh -s b -l build-only -d 'Build image only (skip deploy)'
+complete -c deploy-local.sh -s s -l stop -l down -d 'Stop deployment containers'
+
+complete -c deploy-local -s h -l help -d 'Show help'
+complete -c deploy-local -s u -l up -l ship -d 'Build from source, then deploy'
+complete -c deploy-local -s d -l deploy-only -d 'Redeploy existing image (default)'
+complete -c deploy-local -s b -l build-only -d 'Build image only (skip deploy)'
+complete -c deploy-local -s s -l stop -l down -d 'Stop deployment containers'

--- a/scripts/completions/moz.fish
+++ b/scripts/completions/moz.fish
@@ -1,0 +1,5 @@
+complete -c moz -s h -l help -d 'Show help'
+complete -c moz -s u -l up -l ship -d 'Build from source, then deploy'
+complete -c moz -s d -l deploy-only -d 'Redeploy existing image (default)'
+complete -c moz -s b -l build-only -d 'Build image only (skip deploy)'
+complete -c moz -s s -l stop -l down -d 'Stop deployment containers'

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Build Aico from this repo and deploy via docker-compose/deploy.
+#
+# Usage:
+#   ./scripts/deploy-local.sh                 # deploy existing image (default)
+#   ./scripts/deploy-local.sh -u             # build + deploy after code changes
+#   ./scripts/deploy-local.sh -b             # build image only
+#   ./scripts/deploy-local.sh -s             # stop the deployment
+#
+# Optional env:
+#   AICO_LEGACY_DEPLOY_DIR  One-time .env migration source (default: ~/docker-lobehub/lobehub-db)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEPLOY_DIR="$ROOT/docker-compose/deploy"
+IMAGE="aico/lobehub:local"
+TAG="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo local)"
+LEGACY_DEPLOY_DIR="${AICO_LEGACY_DEPLOY_DIR:-$HOME/docker-lobehub/lobehub-db}"
+CONTAINER_NAME="lobehub"
+STAGE=""
+
+BUILD=0
+DEPLOY=1
+STOP=0
+for arg in "$@"; do
+  case "$arg" in
+    --up|--ship|-u) BUILD=1 ;;
+    --deploy-only|-d) BUILD=0 ;;
+    --build-only|-b) BUILD=1; DEPLOY=0 ;;
+    --stop|--down|-s) STOP=1; BUILD=0; DEPLOY=0 ;;
+    -h|--help)
+      cat <<EOF
+Usage: $0 [-u|--up] [--build-only|-b] [--stop|-s]
+
+Deploy Aico via docker-compose/deploy using the local image in this repo.
+
+Options:
+  (default)           Redeploy the existing local image (skip build)
+  -u, --up, --ship    Build from source, then deploy
+  -d, --deploy-only   Same as default (redeploy without building)
+  -b, --build-only    Build and tag the image only (skip deploy)
+  -s, --stop, --down  Stop the deployment containers
+
+Environment:
+  AICO_LEGACY_DEPLOY_DIR   Legacy deploy directory for one-time .env migration
+                           (default: ~/docker-lobehub/lobehub-db)
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+require_cmd() {
+  local cmd="$1"
+  local msg="${2:-$cmd is required}"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Error: $msg" >&2
+    exit 1
+  }
+}
+
+cleanup_stage() {
+  [[ -n "$STAGE" && -d "$STAGE" ]] && rm -rf "$STAGE"
+}
+
+wait_for_container() {
+  local name="$1"
+  local timeout="${2:-120}"
+  local elapsed=0
+  local status="missing"
+
+  while (( elapsed < timeout )); do
+    status="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "missing")"
+    case "$status" in
+      running) return 0 ;;
+      exited|dead)
+        echo "Error: container $name is $status" >&2
+        docker logs "$name" 2>&1 | tail -20 >&2 || true
+        return 1
+        ;;
+    esac
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  echo "Error: timed out waiting for container $name (last status: $status)" >&2
+  return 1
+}
+
+wait_for_http() {
+  local url="$1"
+  local timeout="${2:-120}"
+  local elapsed=0
+  local code="000"
+
+  while (( elapsed < timeout )); do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null || echo "000")"
+    if [[ "$code" == "200" || "$code" == "302" ]]; then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  echo "Error: timed out waiting for $url (last HTTP $code)" >&2
+  return 1
+}
+
+require_cmd docker
+require_cmd git
+docker compose version >/dev/null 2>&1 || {
+  echo "Error: docker compose is required." >&2
+  exit 1
+}
+[[ $BUILD -eq 1 ]] && require_cmd bun
+[[ $DEPLOY -eq 1 ]] && require_cmd curl
+
+# One-time migration from a legacy external deploy dir. After deploy/.env exists, edit it directly.
+if [[ ! -f "$DEPLOY_DIR/.env" ]]; then
+  if [[ -f "$LEGACY_DEPLOY_DIR/.env" ]]; then
+    echo "Creating infra-only deploy env from legacy deploy dir → $DEPLOY_DIR/.env"
+    require_cmd python3
+    python3 <<PY
+from pathlib import Path
+
+src = Path("$LEGACY_DEPLOY_DIR/.env")
+dst = Path("$DEPLOY_DIR/.env")
+keep = {
+    'LOBE_PORT', 'RUSTFS_PORT', 'RUSTFS_ADMIN_PORT', 'LOBE_DB_NAME', 'POSTGRES_PASSWORD',
+    'RUSTFS_ACCESS_KEY', 'RUSTFS_SECRET_KEY', 'RUSTFS_LOBE_BUCKET', 'JWKS_KEY',
+}
+out = []
+for line in src.read_text().splitlines():
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#') or '=' not in line:
+        continue
+    key, _ = line.split('=', 1)
+    if key in keep:
+        out.append(line)
+dst.write_text('\n'.join(out) + '\n')
+PY
+  else
+    echo "Missing $DEPLOY_DIR/.env — copy from docker-compose/deploy/.env.example.aico and configure infra secrets." >&2
+    exit 1
+  fi
+fi
+
+if [[ $STOP -eq 1 ]]; then
+  echo "==> Stopping deployment from $DEPLOY_DIR"
+  cd "$DEPLOY_DIR"
+  docker compose \
+    --env-file ../../.env \
+    --env-file .env \
+    -f docker-compose.yml \
+    -f docker-compose.aico.override.yml \
+    down
+  echo "==> Deployment stopped"
+  exit 0
+fi
+
+if [[ $BUILD -eq 1 ]]; then
+  echo "==> Building app (DOCKER=true bun run build:docker)"
+  cd "$ROOT"
+  DOCKER=true bun run build:docker
+
+  required_paths=(
+    "$ROOT/.next/standalone"
+    "$ROOT/.next/static"
+    "$ROOT/public/_spa"
+    "$ROOT/public/_spa-auth"
+    "$ROOT/public/_spa-workbench"
+    "$ROOT/packages/database/migrations"
+    "$ROOT/scripts/migrateServerDB/docker.cjs"
+    "$ROOT/scripts/migrateServerDB/errorHint.js"
+    "$ROOT/scripts/_shared"
+    "$ROOT/scripts/serverLauncher/startServer.js"
+    "$ROOT/scripts/docker/Dockerfile.staged"
+  )
+  for path in "${required_paths[@]}"; do
+    [[ -e "$path" ]] || {
+      echo "Error: missing build artifact: $path" >&2
+      exit 1
+    }
+  done
+
+  echo "==> Packaging Docker image $IMAGE"
+  STAGE="$(mktemp -d)"
+  trap cleanup_stage EXIT
+
+  mkdir -p "$STAGE/.next" "$STAGE/public" "$STAGE/packages/database" \
+    "$STAGE/scripts/migrateServerDB" "$STAGE/scripts/_shared"
+
+  cp -a "$ROOT/.next/standalone/." "$STAGE/"
+  cp -a "$ROOT/.next/static" "$STAGE/.next/static"
+  cp -a "$ROOT/public/_spa" "$ROOT/public/_spa-auth" "$ROOT/public/_spa-workbench" "$STAGE/public/"
+  cp -a "$ROOT/packages/database/migrations" "$STAGE/packages/database/"
+  cp "$ROOT/scripts/migrateServerDB/docker.cjs" "$ROOT/scripts/migrateServerDB/errorHint.js" \
+    "$STAGE/scripts/migrateServerDB/"
+  cp -a "$ROOT/scripts/_shared/." "$STAGE/scripts/_shared/"
+  cp "$ROOT/scripts/serverLauncher/startServer.js" "$STAGE/startServer.js"
+  cp "$ROOT/scripts/docker/Dockerfile.staged" "$STAGE/Dockerfile"
+
+  docker build -t "$IMAGE" -t "aico/lobehub:$TAG" "$STAGE"
+  echo "==> Image ready: $IMAGE (also tagged aico/lobehub:$TAG)"
+fi
+
+if [[ $DEPLOY -eq 1 ]]; then
+  echo "==> Deploying from $DEPLOY_DIR"
+  cd "$DEPLOY_DIR"
+
+  # Stop legacy external deploy if still running
+  if [[ -f "$LEGACY_DEPLOY_DIR/docker-compose.yml" ]]; then
+    (cd "$LEGACY_DEPLOY_DIR" && docker compose down 2>/dev/null) || true
+  fi
+
+  docker compose \
+    --env-file ../../.env \
+    --env-file .env \
+    -f docker-compose.yml \
+    -f docker-compose.aico.override.yml \
+    up -d --force-recreate lobe
+
+  echo "==> Waiting for container $CONTAINER_NAME..."
+  wait_for_container "$CONTAINER_NAME" 120
+
+  APP_PORT="$(grep -E '^LOBE_PORT=' "$DEPLOY_DIR/.env" | cut -d= -f2- || true)"
+  APP_URL="http://127.0.0.1:${APP_PORT:-3210}"
+
+  echo "==> Waiting for HTTP readiness at $APP_URL ..."
+  if wait_for_http "$APP_URL/signin" 120; then
+    echo "==> Deployment healthy"
+    docker logs "$CONTAINER_NAME" 2>&1 | tail -8
+    echo ""
+    echo "App: $APP_URL"
+  else
+    echo "==> Deployment failed readiness check" >&2
+    docker logs "$CONTAINER_NAME" 2>&1 | tail -30 >&2
+    exit 1
+  fi
+fi

--- a/scripts/docker/Dockerfile.staged
+++ b/scripts/docker/Dockerfile.staged
@@ -1,0 +1,11 @@
+FROM node:24-slim
+WORKDIR /app
+RUN ln -sf /usr/local/bin/node /bin/node
+ENV NODE_ENV=production \
+    NODE_OPTIONS="--dns-result-order=ipv4first" \
+    MIDDLEWARE_REWRITE_THROUGH_LOCAL=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3210
+COPY . .
+EXPOSE 3210
+CMD ["node", "startServer.js"]


### PR DESCRIPTION
<!-- Brief and heads-up -->
Adds local Docker ship workflow (`moz` / `deploy-local.sh`), self-host-deploy skill, and related deploy tooling. Also includes the gitignore fix for the deploy data symlink.

| Before | After |
| ------ | ----- |
| Manual compose / upstream image deploy | `moz` / `moz -u` / `moz -s` for local image ship |
| Missing `_spa-auth` in Docker image | `_spa-auth` copied into image |

#### Test

- [x] Tested locally (`moz -u` healthy on http://127.0.0.1:3210)
- [ ] Added/updated tests
- [x] No tests needed (deploy scripts / tooling)

#### 🔗 Related Issue

Closes #59
Closes #60

Plane:
- AICO-42 — https://plane.panafor.com/panaforai/browse/AICO-42
- AICO-43 — https://plane.panafor.com/panaforai/browse/AICO-43