### PR TITLE
🐛 fix(onboarding): surface Composio connect failures and open OAuth reliably

### DIFF
--- a/locales/en-US/onboarding.json
+++ b/locales/en-US/onboarding.json
@@ -107,6 +107,8 @@
   "interests.title2": "This will help me know you better",
   "interests.title3": "Take your time, I'll get to know you better",
   "next": "Next",
+  "proSettings.connectors.connectFailed": "Could not start the connection. Please try again.",
+  "proSettings.connectors.popupBlocked": "Connection popup blocked. Allow popups in your browser to continue.",
   "proSettings.connectors.title": "Connect Your Favorite Tools",
   "responseLanguage.hint": "After selecting a language, AI responses will use that language, and the interface language will also sync",
   "responseLanguage.saveFailed": "Failed to save. Please try again.",

--- a/locales/fa-IR/onboarding.json
+++ b/locales/fa-IR/onboarding.json
@@ -187,6 +187,8 @@
   "modeSelection.title2": "سبک یا حرفه‌ای — انتخاب با توئه!",
   "modeSelection.title3": "بهم بگو تا بتونم دقیقاً برات تنظیمش کنم~",
   "next": "بعدی",
+  "proSettings.connectors.connectFailed": "نتوانستیم اتصال را شروع کنیم. لطفاً دوباره تلاش کنید.",
+  "proSettings.connectors.popupBlocked": "پنجره اتصال مسدود شده است. برای ادامه، پاپ‌آپ‌ها را در مرورگر خود فعال کنید.",
   "proSettings.connectors.title": "ابزارهای مورد علاقه‌ات رو وصل کن",
   "proSettings.devMode.title": "حالت توسعه‌دهنده",
   "proSettings.model.fixed": "مدل پیش‌فرض در این محیط به {{provider}}/{{model}} تنظیم شده است.",

--- a/locales/zh-CN/onboarding.json
+++ b/locales/zh-CN/onboarding.json
@@ -107,6 +107,8 @@
   "interests.title2": "这将帮助我更好地了解你",
   "interests.title3": "慢慢来，我会逐渐了解你",
   "next": "下一步",
+  "proSettings.connectors.connectFailed": "无法开始连接，请重试。",
+  "proSettings.connectors.popupBlocked": "连接弹窗被阻止。请在浏览器中允许弹窗后继续。",
   "proSettings.connectors.title": "连接你常用的工具",
   "responseLanguage.hint": "切换后，助理回复语言会同步更新；界面语言也会随之切换",
   "responseLanguage.saveFailed": "保存失败，请重试。",

--- a/packages/locales/src/default/onboarding.ts
+++ b/packages/locales/src/default/onboarding.ts
@@ -135,6 +135,9 @@ export default {
   'interests.title2': 'This will help me know you better',
   'interests.title3': "Take your time, I'll get to know you better",
   'next': 'Next',
+  'proSettings.connectors.connectFailed': 'Could not start the connection. Please try again.',
+  'proSettings.connectors.popupBlocked':
+    'Connection popup blocked. Allow popups in your browser to continue.',
   'proSettings.connectors.title': 'Connect Your Favorite Tools',
   'responseLanguage.hint':
     'After selecting a language, AI responses will use that language, and the interface language will also sync',

--- a/src/routes/onboarding/components/ComposioServerList/components/ComposioServerItem.tsx
+++ b/src/routes/onboarding/components/ComposioServerList/components/ComposioServerItem.tsx
@@ -23,15 +23,18 @@ interface ComposioServerItemProps {
 
 const ComposioServerItem = memo<ComposioServerItemProps>(
   ({ identifier, label, server, appSlug, icon }) => {
-    const { isWaitingAuth, openOAuthWindow } = useComposioOAuth({
+    const { cancelOAuthWindow, isWaitingAuth, openOAuthWindow, prepareOAuthWindow } =
+      useComposioOAuth({
       serverStatus: server?.status,
-    });
+      });
 
     const { isConnecting, handleConnect, handleReauthorize } = useComposioServerActions({
       appSlug,
       identifier,
       label,
       onAuthRequired: openOAuthWindow,
+      onBeforeAuth: prepareOAuthWindow,
+      onCancelAuth: cancelOAuthWindow,
       server,
     });
 

--- a/src/routes/onboarding/components/ComposioServerList/components/ServerStatusControl.tsx
+++ b/src/routes/onboarding/components/ComposioServerList/components/ServerStatusControl.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { CheckIcon, CircleX, Loader2 } from 'lucide-react';
+import { CheckIcon, CircleAlert, CircleX, Loader2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -34,7 +34,13 @@ const ServerStatusControl = memo<ServerStatusControlProps>(
       }
 
       case ComposioServerStatus.PENDING_AUTH: {
-        return null;
+        return (
+          <Icon
+            color={cssVar.colorWarning}
+            icon={CircleAlert}
+            title={t('tools.composio.authRequired', { defaultValue: 'Authentication Required' })}
+          />
+        );
       }
 
       case ComposioServerStatus.ERROR: {

--- a/src/routes/onboarding/components/ComposioServerList/hooks/useComposioOAuth.test.ts
+++ b/src/routes/onboarding/components/ComposioServerList/hooks/useComposioOAuth.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ComposioServerStatus } from '@/store/tool/slices/composioStore';
+
+import { ComposioOAuthPopupBlockedError, useComposioOAuth } from './useComposioOAuth';
+
+const mockToolState = vi.hoisted(() => ({
+  refreshComposioConnectionStatus: vi.fn(),
+}));
+
+vi.mock('@/store/tool', () => ({
+  useToolStore: <T,>(selector: (state: typeof mockToolState) => T) => selector(mockToolState),
+}));
+
+describe('useComposioOAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws a popup-blocked error when a blank popup cannot be opened', () => {
+    vi.spyOn(window, 'open').mockReturnValue(null);
+
+    const { result } = renderHook(() => useComposioOAuth({}));
+
+    expect(() => result.current.prepareOAuthWindow('gmail')).toThrow(ComposioOAuthPopupBlockedError);
+    expect(result.current.isWaitingAuth).toBe(false);
+  });
+
+  it('reuses a pre-opened popup and navigates it to the OAuth URL', () => {
+    const popup = {
+      close: vi.fn(),
+      closed: false,
+      location: { href: 'about:blank' },
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popup);
+
+    const { result, unmount } = renderHook(() => useComposioOAuth({}));
+
+    act(() => {
+      result.current.prepareOAuthWindow('gmail');
+      result.current.openOAuthWindow('https://example.com/oauth', 'gmail', popup);
+    });
+
+    expect(popup.location.href).toBe('https://example.com/oauth');
+    expect(result.current.isWaitingAuth).toBe(true);
+
+    unmount();
+  });
+
+  it('cancels the popup when the connection becomes active', () => {
+    const popup = {
+      close: vi.fn(),
+      closed: false,
+      location: { href: 'about:blank' },
+    } as unknown as Window;
+
+    vi.spyOn(window, 'open').mockReturnValue(popup);
+
+    const { result, rerender } = renderHook(
+      ({ serverStatus }) => useComposioOAuth({ serverStatus }),
+      {
+        initialProps: { serverStatus: undefined as ComposioServerStatus | undefined },
+      },
+    );
+
+    act(() => {
+      result.current.prepareOAuthWindow('gmail');
+    });
+
+    rerender({ serverStatus: ComposioServerStatus.ACTIVE });
+
+    expect(result.current.isWaitingAuth).toBe(false);
+  });
+});

--- a/src/routes/onboarding/components/ComposioServerList/hooks/useComposioOAuth.ts
+++ b/src/routes/onboarding/components/ComposioServerList/hooks/useComposioOAuth.ts
@@ -6,9 +6,17 @@ import { ComposioServerStatus } from '@/store/tool/slices/composioStore';
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
 const WINDOW_CLOSED_POLL_TIMEOUT_MS = 4000; // Shorter timeout when window is closed
+const OAUTH_WINDOW_FEATURES = 'width=600,height=700';
 
 interface UseComposioOAuthProps {
   serverStatus?: ComposioServerStatus;
+}
+
+export class ComposioOAuthPopupBlockedError extends Error {
+  constructor() {
+    super('Composio OAuth popup was blocked');
+    this.name = 'ComposioOAuthPopupBlockedError';
+  }
 }
 
 export const useComposioOAuth = ({ serverStatus }: UseComposioOAuthProps) => {
@@ -20,6 +28,14 @@ export const useComposioOAuth = ({ serverStatus }: UseComposioOAuthProps) => {
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const refreshComposioConnectionStatus = useToolStore((s) => s.refreshComposioConnectionStatus);
+
+  const closeOAuthWindow = useCallback((oauthWindow?: Window | null) => {
+    try {
+      oauthWindow?.close();
+    } catch {
+      // Ignore cross-origin close restrictions.
+    }
+  }, []);
 
   const cleanup = useCallback(() => {
     if (windowCheckIntervalRef.current) {
@@ -37,6 +53,11 @@ export const useComposioOAuth = ({ serverStatus }: UseComposioOAuthProps) => {
     oauthWindowRef.current = null;
     setIsWaitingAuth(false);
   }, []);
+
+  const cancelOAuthWindow = useCallback(() => {
+    closeOAuthWindow(oauthWindowRef.current);
+    cleanup();
+  }, [cleanup, closeOAuthWindow]);
 
   useEffect(() => {
     return () => {
@@ -104,23 +125,54 @@ export const useComposioOAuth = ({ serverStatus }: UseComposioOAuthProps) => {
   );
 
   const openOAuthWindow = useCallback(
-    (redirectUrl: string, serverName: string) => {
+    (redirectUrl: string, serverName: string, oauthWindow?: Window | null) => {
+      const popup = oauthWindow ?? oauthWindowRef.current;
+
+      if (popup && !popup.closed) {
+        oauthWindowRef.current = popup;
+        setIsWaitingAuth(true);
+        popup.location.href = redirectUrl;
+        return;
+      }
+
       cleanup();
       setIsWaitingAuth(true);
 
-      const oauthWindow = window.open(redirectUrl, '_blank', 'width=600,height=700');
-      if (oauthWindow) {
-        oauthWindowRef.current = oauthWindow;
-        startWindowMonitor(oauthWindow, serverName);
-      } else {
-        startFallbackPolling(serverName);
+      const nextWindow = window.open(redirectUrl, '_blank', OAUTH_WINDOW_FEATURES);
+      if (!nextWindow) {
+        setIsWaitingAuth(false);
+        throw new ComposioOAuthPopupBlockedError();
       }
+
+      oauthWindowRef.current = nextWindow;
+      startWindowMonitor(nextWindow, serverName);
     },
-    [cleanup, startWindowMonitor, startFallbackPolling],
+    [cleanup, startWindowMonitor],
+  );
+
+  const prepareOAuthWindow = useCallback(
+    (serverName: string) => {
+      cleanup();
+      setIsWaitingAuth(true);
+
+      const oauthWindow = window.open('about:blank', '_blank', OAUTH_WINDOW_FEATURES);
+      if (!oauthWindow) {
+        setIsWaitingAuth(false);
+        throw new ComposioOAuthPopupBlockedError();
+      }
+
+      oauthWindowRef.current = oauthWindow;
+      startWindowMonitor(oauthWindow, serverName);
+
+      return oauthWindow;
+    },
+    [cleanup, startWindowMonitor],
   );
 
   return {
+    cancelOAuthWindow,
     isWaitingAuth,
     openOAuthWindow,
+    prepareOAuthWindow,
   };
 };

--- a/src/routes/onboarding/components/ComposioServerList/hooks/useComposioServerActions.test.ts
+++ b/src/routes/onboarding/components/ComposioServerList/hooks/useComposioServerActions.test.ts
@@ -1,0 +1,175 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ComposioServerStatus } from '@/store/tool/slices/composioStore';
+
+import { ComposioOAuthPopupBlockedError } from './useComposioOAuth';
+import { useComposioServerActions } from './useComposioServerActions';
+
+const mockToolState = vi.hoisted(() => ({
+  createComposioConnection: vi.fn(),
+  reauthorizeComposioConnection: vi.fn(),
+  refreshComposioConnectionStatus: vi.fn(),
+}));
+
+const mockUserState = vi.hoisted(() => ({
+  toggleInboxAgentDefaultPlugin: vi.fn(),
+}));
+
+const mockToast = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('@/store/tool', () => ({
+  useToolStore: <T,>(selector: (state: typeof mockToolState) => T) => selector(mockToolState),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: <T,>(selector: (state: typeof mockUserState) => T) => selector(mockUserState),
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  toast: mockToast,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      (
+        {
+          'proSettings.connectors.connectFailed': 'Could not start the connection. Please try again.',
+          'proSettings.connectors.popupBlocked':
+            'Connection popup blocked. Allow popups in your browser to continue.',
+        } as Record<string, string>
+      )[key] || key,
+  }),
+}));
+
+describe('useComposioServerActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a connect error when createComposioConnection returns nothing', async () => {
+    mockToolState.createComposioConnection.mockResolvedValue(undefined);
+
+    const onCancelAuth = vi.fn();
+    const onBeforeAuth = vi.fn(() => null);
+
+    const { result } = renderHook(() =>
+      useComposioServerActions({
+        appSlug: 'gmail',
+        identifier: 'gmail',
+        label: 'Gmail',
+        onBeforeAuth,
+        onCancelAuth,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    expect(onBeforeAuth).toHaveBeenCalledWith('gmail');
+    expect(onCancelAuth).toHaveBeenCalled();
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Could not start the connection. Please try again.',
+    );
+  });
+
+  it('opens OAuth before pinning the default plugin', async () => {
+    mockToolState.createComposioConnection.mockResolvedValue({
+      identifier: 'gmail',
+      redirectUrl: 'https://example.com/oauth',
+      status: ComposioServerStatus.PENDING_AUTH,
+    });
+
+    const order: string[] = [];
+    const oauthWindow = {} as Window;
+    const onBeforeAuth = vi.fn(() => {
+      order.push('prepare');
+      return oauthWindow;
+    });
+    const onAuthRequired = vi.fn(() => {
+      order.push('auth');
+    });
+    mockUserState.toggleInboxAgentDefaultPlugin.mockImplementation(async () => {
+      order.push('pin');
+    });
+
+    const { result } = renderHook(() =>
+      useComposioServerActions({
+        appSlug: 'gmail',
+        identifier: 'gmail',
+        label: 'Gmail',
+        onAuthRequired,
+        onBeforeAuth,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    expect(onAuthRequired).toHaveBeenCalledWith(
+      'https://example.com/oauth',
+      'gmail',
+      oauthWindow,
+    );
+    expect(order).toEqual(['prepare', 'auth', 'pin']);
+  });
+
+  it('shows a popup-blocked message when pre-opening the popup fails', async () => {
+    const { result } = renderHook(() =>
+      useComposioServerActions({
+        appSlug: 'gmail',
+        identifier: 'gmail',
+        label: 'Gmail',
+        onBeforeAuth: () => {
+          throw new ComposioOAuthPopupBlockedError();
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleConnect();
+    });
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Connection popup blocked. Allow popups in your browser to continue.',
+    );
+    expect(mockToolState.createComposioConnection).not.toHaveBeenCalled();
+  });
+
+  it('shows a connect error when reauthorization has no fresh OAuth URL', async () => {
+    mockToolState.reauthorizeComposioConnection.mockResolvedValue({
+      identifier: 'gmail',
+      redirectUrl: undefined,
+      status: ComposioServerStatus.PENDING_AUTH,
+    });
+
+    const onCancelAuth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useComposioServerActions({
+        appSlug: 'gmail',
+        identifier: 'gmail',
+        label: 'Gmail',
+        onCancelAuth,
+        server: {
+          identifier: 'gmail',
+          status: ComposioServerStatus.PENDING_AUTH,
+        } as any,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleReauthorize();
+    });
+
+    expect(onCancelAuth).toHaveBeenCalled();
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Could not start the connection. Please try again.',
+    );
+  });
+});

--- a/src/routes/onboarding/components/ComposioServerList/hooks/useComposioServerActions.ts
+++ b/src/routes/onboarding/components/ComposioServerList/hooks/useComposioServerActions.ts
@@ -1,14 +1,20 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from '@lobehub/ui/base-ui';
 
 import { useToolStore } from '@/store/tool';
 import { type ComposioServer, ComposioServerStatus } from '@/store/tool/slices/composioStore';
 import { useUserStore } from '@/store/user';
 
+import { ComposioOAuthPopupBlockedError } from './useComposioOAuth';
+
 interface UseComposioServerActionsProps {
   appSlug: string;
   identifier: string;
   label: string;
-  onAuthRequired?: (redirectUrl: string, serverIdentifier: string) => void;
+  onAuthRequired?: (redirectUrl: string, serverIdentifier: string, oauthWindow?: Window | null) => void;
+  onBeforeAuth?: (serverIdentifier: string) => Window | null;
+  onCancelAuth?: () => void;
   server?: ComposioServer;
 }
 
@@ -18,37 +24,67 @@ export const useComposioServerActions = ({
   label,
   server,
   onAuthRequired,
+  onBeforeAuth,
+  onCancelAuth,
 }: UseComposioServerActionsProps) => {
   const [isConnecting, setIsConnecting] = useState(false);
+  const { t } = useTranslation('onboarding');
 
   const createComposioConnection = useToolStore((s) => s.createComposioConnection);
   const refreshComposioConnectionStatus = useToolStore((s) => s.refreshComposioConnectionStatus);
   const reauthorizeComposioConnection = useToolStore((s) => s.reauthorizeComposioConnection);
   const toggleDefaultPlugin = useUserStore((s) => s.toggleInboxAgentDefaultPlugin);
 
+  const notifyConnectError = () => {
+    toast.error(t('proSettings.connectors.connectFailed'));
+  };
+
+  const notifyPopupBlocked = () => {
+    toast.error(t('proSettings.connectors.popupBlocked'));
+  };
+
   const handleConnect = async () => {
     if (server) return;
 
     setIsConnecting(true);
     try {
+      const oauthWindow = onBeforeAuth?.(identifier);
       const newServer = await createComposioConnection({
         appSlug,
         identifier,
         label,
       });
 
-      if (newServer) {
-        const newPluginId = newServer.identifier;
-        await toggleDefaultPlugin(newPluginId);
+      if (!newServer) {
+        onCancelAuth?.();
+        notifyConnectError();
+        return;
+      }
 
-        if (newServer.status === ComposioServerStatus.ACTIVE) {
-          await refreshComposioConnectionStatus(newServer.identifier);
-        } else if (newServer.redirectUrl) {
-          onAuthRequired?.(newServer.redirectUrl, newServer.identifier);
-        }
+      if (newServer.status === ComposioServerStatus.ACTIVE) {
+        onCancelAuth?.();
+        await refreshComposioConnectionStatus(newServer.identifier);
+      } else if (newServer.redirectUrl) {
+        onAuthRequired?.(newServer.redirectUrl, newServer.identifier, oauthWindow);
+      } else {
+        onCancelAuth?.();
+        notifyConnectError();
+        return;
+      }
+
+      try {
+        await toggleDefaultPlugin(newServer.identifier);
+      } catch (error) {
+        console.error('[Composio] Failed to pin default plugin after connect:', error);
       }
     } catch (error) {
+      onCancelAuth?.();
       console.error('[Composio] Failed to connect server:', error);
+      if (error instanceof ComposioOAuthPopupBlockedError) {
+        notifyPopupBlocked();
+      } else {
+        notifyConnectError();
+      }
     } finally {
       setIsConnecting(false);
     }
@@ -61,12 +97,23 @@ export const useComposioServerActions = ({
 
     setIsConnecting(true);
     try {
+      const oauthWindow = onBeforeAuth?.(server.identifier);
       const newServer = await reauthorizeComposioConnection(server.identifier);
-      if (newServer?.redirectUrl) {
-        onAuthRequired?.(newServer.redirectUrl, newServer.identifier);
+      if (!newServer?.redirectUrl) {
+        onCancelAuth?.();
+        notifyConnectError();
+        return;
       }
+
+      onAuthRequired?.(newServer.redirectUrl, newServer.identifier, oauthWindow);
     } catch (error) {
+      onCancelAuth?.();
       console.error('[Composio] Failed to re-authorize server:', error);
+      if (error instanceof ComposioOAuthPopupBlockedError) {
+        notifyPopupBlocked();
+      } else {
+        notifyConnectError();
+      }
     } finally {
       setIsConnecting(false);
     }


### PR DESCRIPTION
<!-- Brief and heads-up -->

Hardens Classic onboarding account connect so failures and popup blocks are visible, and OAuth opens inside the user gesture.

#### Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

How to test:
1. Open Classic onboarding Pro Settings (connectors step).
2. Click Gmail/etc. — OAuth popup should open (blank first, then redirect).
3. Block popups — toast: popup blocked.
4. Force createConnection failure — toast: connect failed; blank popup closes.
5. Incomplete auth should show pending (warning) affordance, not blank idle.

#### 🔗 Related Issue

Fixes #62

Plane: [AICO-38](https://plane.panafor.com/panaforai/browse/AICO-38)