### PR TITLE
🐛 fix(onboarding): mirror back-arrow icon under RTL

### DIFF
--- a/src/routes/(desktop)/desktop-onboarding/features/DataModeStep.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/DataModeStep.tsx
@@ -3,10 +3,11 @@
 import { Block, Checkbox, Empty, Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { HeartHandshake, Undo2Icon } from 'lucide-react';
+import { HeartHandshake } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import OnboardingBackButton from '@/routes/onboarding/features/OnboardingBackButton';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
@@ -117,14 +118,7 @@ const DataModeStep = memo<DataModeStepProps>(({ onBack, onNext }) => {
       </Text>
       <OnboardingFooterActions
         left={
-          <Button
-            icon={Undo2Icon}
-            style={{ color: cssVar.colorTextDescription }}
-            type={'text'}
-            onClick={onBack}
-          >
-            {t('back')}
-          </Button>
+          <OnboardingBackButton i18nNs={'desktop-onboarding'} onClick={onBack} />
         }
         right={
           <Button type={'primary'} onClick={onNext}>

--- a/src/routes/(desktop)/desktop-onboarding/features/LoginStep.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/LoginStep.tsx
@@ -6,7 +6,7 @@ import { Alert, Center, Flexbox, Icon, Input, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { cssVar } from 'antd-style';
-import { Cloud, Server, Undo2Icon } from 'lucide-react';
+import { Cloud, Server } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
@@ -15,6 +15,7 @@ import { OFFICIAL_SITE } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import UserInfo from '@/features/User/UserInfo';
 import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
+import OnboardingBackButton from '@/routes/onboarding/features/OnboardingBackButton';
 import { remoteServerService } from '@/services/electron/remoteServer';
 import { electronSystemService } from '@/services/electron/system';
 import { useElectronStore } from '@/store/electron';
@@ -321,14 +322,10 @@ const LoginStep = memo<LoginStepProps>(({ onBack, onNext }) => {
         </Flexbox>
 
         <Flexbox horizontal justify={'space-between'} style={{ marginTop: 32 }}>
-          <Button
-            icon={Undo2Icon}
-            style={{ color: cssVar.colorTextDescription }}
-            type={'text'}
+          <OnboardingBackButton
+            i18nNs={'desktop-onboarding'}
             onClick={() => handleBackToLoginMethods(method)}
-          >
-            {t('back')}
-          </Button>
+          />
           <Button type={'primary'} onClick={onNext}>
             {t('next')}
           </Button>
@@ -564,14 +561,7 @@ const LoginStep = memo<LoginStepProps>(({ onBack, onNext }) => {
       </Flexbox>
       {canStart() && (
         <Flexbox horizontal justify={'space-between'} style={{ marginTop: 32 }}>
-          <Button
-            icon={Undo2Icon}
-            style={{ color: cssVar.colorTextDescription }}
-            type={'text'}
-            onClick={onBack}
-          >
-            {t('back')}
-          </Button>
+          <OnboardingBackButton i18nNs={'desktop-onboarding'} onClick={onBack} />
           <Button type={'primary'} onClick={onNext}>
             {t('next')}
           </Button>

--- a/src/routes/(desktop)/desktop-onboarding/features/PermissionsStep.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/PermissionsStep.tsx
@@ -11,11 +11,11 @@ import {
   Mic,
   MonitorCog,
   SquareArrowOutUpRight,
-  Undo2Icon,
 } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import OnboardingBackButton from '@/routes/onboarding/features/OnboardingBackButton';
 import { ensureElectronIpc } from '@/utils/electron/ipc';
 
 import LobeMessage from '../components/LobeMessage';
@@ -211,14 +211,7 @@ const PermissionsStep = memo<PermissionsStepProps>(({ onBack, onNext }) => {
       </Block>
       <OnboardingFooterActions
         left={
-          <Button
-            icon={Undo2Icon}
-            style={{ color: cssVar.colorTextDescription }}
-            type={'text'}
-            onClick={onBack}
-          >
-            {t('back')}
-          </Button>
+          <OnboardingBackButton i18nNs={'desktop-onboarding'} onClick={onBack} />
         }
         right={
           <Button type={'primary'} onClick={onNext}>

--- a/src/routes/onboarding/features/AgentPickerStep/index.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.tsx
@@ -7,8 +7,6 @@ import type {
 import { getTemplatesByCategoryPriority } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
 import { Flexbox, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { cssVar } from 'antd-style';
-import { Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router';
@@ -27,6 +25,7 @@ import { consumeOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 import LobeMessage from '../../components/LobeMessage';
 import { interestsToCategoryHints } from '../../interestCategoryMap';
+import OnboardingBackButton from '../OnboardingBackButton';
 import AgentCard from './AgentCard';
 import CategoryFilter, { type ActiveCategory } from './CategoryFilter';
 import AgentPickerSkeleton from './Skeleton';
@@ -191,15 +190,7 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
 
       <div className={styles.footer}>
         {showBack ? (
-          <Button
-            disabled={!!pending}
-            icon={Undo2Icon}
-            style={{ color: cssVar.colorTextDescription }}
-            type={'text'}
-            onClick={handleBack}
-          >
-            {t('back')}
-          </Button>
+          <OnboardingBackButton disabled={!!pending} onClick={handleBack} />
         ) : (
           <span />
         )}

--- a/src/routes/onboarding/features/FullNameStep.tsx
+++ b/src/routes/onboarding/features/FullNameStep.tsx
@@ -2,9 +2,8 @@
 
 import { SendButton } from '@lobehub/editor/react';
 import { Flexbox, Icon, Input } from '@lobehub/ui';
-import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { SignatureIcon, Undo2Icon } from 'lucide-react';
+import { SignatureIcon } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -13,6 +12,7 @@ import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
 import LobeMessage from '../components/LobeMessage';
+import OnboardingBackButton from './OnboardingBackButton';
 
 interface FullNameStepProps {
   onBack: () => void;
@@ -86,17 +86,7 @@ const FullNameStep = memo<FullNameStepProps>(({ onBack, onNext }) => {
         />
       </Flexbox>
       <Flexbox horizontal justify={'flex-start'} style={{ marginTop: 32 }}>
-        <Button
-          disabled={isNavigating}
-          icon={Undo2Icon}
-          type={'text'}
-          style={{
-            color: cssVar.colorTextDescription,
-          }}
-          onClick={handleBack}
-        >
-          {t('back')}
-        </Button>
+        <OnboardingBackButton disabled={isNavigating} onClick={handleBack} />
       </Flexbox>
     </Flexbox>
   );

--- a/src/routes/onboarding/features/InterestsStep.tsx
+++ b/src/routes/onboarding/features/InterestsStep.tsx
@@ -4,7 +4,7 @@ import { normalizeInterestsForStorage } from '@lobechat/const';
 import { Block, Flexbox, Icon, Input, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { BriefcaseIcon, Undo2Icon } from 'lucide-react';
+import { BriefcaseIcon } from 'lucide-react';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,6 +14,7 @@ import { userProfileSelectors } from '@/store/user/selectors';
 import LobeMessage from '../components/LobeMessage';
 import type { InterestAreaKey } from '../config';
 import { INTEREST_AREAS } from '../config';
+import OnboardingBackButton from './OnboardingBackButton';
 
 interface InterestsStepProps {
   onBack: () => void;
@@ -152,15 +153,7 @@ const InterestsStep = memo<InterestsStepProps>(({ onBack, onNext }) => {
         />
       )}
       <Flexbox horizontal justify={'space-between'} style={{ marginTop: 32 }}>
-        <Button
-          disabled={isNavigating}
-          icon={Undo2Icon}
-          style={{ color: cssVar.colorTextDescription }}
-          type={'text'}
-          onClick={handleBack}
-        >
-          {t('back')}
-        </Button>
+        <OnboardingBackButton disabled={isNavigating} onClick={handleBack} />
         <Button disabled={isNavigating} type={'primary'} onClick={handleNext}>
           {t('next')}
         </Button>

--- a/src/routes/onboarding/features/OnboardingBackButton.tsx
+++ b/src/routes/onboarding/features/OnboardingBackButton.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Button } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
+import { Undo2Icon } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  root: css`
+    color: ${cssVar.colorTextDescription};
+
+    &:dir(rtl) svg {
+      transform: scaleX(-1);
+    }
+  `,
+}));
+
+interface OnboardingBackButtonProps {
+  disabled?: boolean;
+  /** Namespace that owns the `back` key. Defaults to web onboarding. */
+  i18nNs?: 'desktop-onboarding' | 'onboarding';
+  onClick: () => void;
+}
+
+const OnboardingBackButton = memo<OnboardingBackButtonProps>(
+  ({ disabled, i18nNs = 'onboarding', onClick }) => {
+    const { t } = useTranslation(i18nNs);
+
+    return (
+      <Button
+        className={styles.root}
+        disabled={disabled}
+        icon={Undo2Icon}
+        type={'text'}
+        onClick={onClick}
+      >
+        {t('back')}
+      </Button>
+    );
+  },
+);
+
+OnboardingBackButton.displayName = 'OnboardingBackButton';
+
+export default OnboardingBackButton;

--- a/src/routes/onboarding/features/ProSettingsStep.tsx
+++ b/src/routes/onboarding/features/ProSettingsStep.tsx
@@ -2,14 +2,13 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { cssVar } from 'antd-style';
-import { Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import LobeMessage from '@/routes/onboarding/components/LobeMessage';
 
 import ComposioServerList from '../components/ComposioServerList';
+import OnboardingBackButton from './OnboardingBackButton';
 
 interface ProSettingsStepProps {
   onBack: () => void;
@@ -43,17 +42,7 @@ const ProSettingsStep = memo<ProSettingsStepProps>(({ onBack, onNext }) => {
       <ComposioServerList />
 
       <Flexbox horizontal align={'center'} justify={'space-between'} style={{ marginTop: 16 }}>
-        <Button
-          disabled={isNavigating}
-          icon={Undo2Icon}
-          type={'text'}
-          style={{
-            color: cssVar.colorTextDescription,
-          }}
-          onClick={handleBack}
-        >
-          {t('back')}
-        </Button>
+        <OnboardingBackButton disabled={isNavigating} onClick={handleBack} />
         <Button
           disabled={isNavigating}
           style={{ minWidth: 120 }}

--- a/src/routes/onboarding/features/ResponseLanguageStep.tsx
+++ b/src/routes/onboarding/features/ResponseLanguageStep.tsx
@@ -2,9 +2,8 @@
 
 import { SendButton } from '@lobehub/editor/react';
 import { Flexbox, Text } from '@lobehub/ui';
-import { Button, Select } from '@lobehub/ui/base-ui';
+import { Select } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
-import { Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,6 +13,7 @@ import { useGlobalStore } from '@/store/global';
 import { useUserStore } from '@/store/user';
 
 import LobeMessage from '../components/LobeMessage';
+import OnboardingBackButton from './OnboardingBackButton';
 
 interface ResponseLanguageStepProps {
   onBack: () => void;
@@ -121,17 +121,7 @@ const ResponseLanguageStep = memo<ResponseLanguageStepProps>(({ onBack, onNext }
         </Text>
       )}
       <Flexbox horizontal justify={'flex-start'} style={{ marginTop: 32 }}>
-        <Button
-          disabled={isNavigating}
-          icon={Undo2Icon}
-          type={'text'}
-          style={{
-            color: cssVar.colorTextDescription,
-          }}
-          onClick={handleBack}
-        >
-          {t('back')}
-        </Button>
+        <OnboardingBackButton disabled={isNavigating} onClick={handleBack} />
       </Flexbox>
     </Flexbox>
   );


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #64

Plane: [AICO-40](https://plane.panafor.com/panaforai/browse/AICO-40)

#### Description of Change

Persian RTL flips onboarding Back button layout to the start edge (right), but `Undo2Icon` stayed left-pointing and looked inward. Added shared `OnboardingBackButton` that mirrors the SVG under `&:dir(rtl)` (same pattern as `RailToggle`) and wired it through web + desktop onboarding steps.

#### Test

- [x] Tested locally (unit tests for Interests/ProSettings/AgentPicker)
- [ ] Added/updated tests
- [x] No tests needed (CSS RTL mirror; covered by existing step tests)

- Manually: open onboarding in `fa` — Back on the right, arrow points outward; `en` unchanged.