### PR TITLE
🙈 chore(ui): hide platform admin nav entry (URL-only)

### DIFF
--- a/src/business/client/features/User/useBusinessMeCells.tsx
+++ b/src/business/client/features/User/useBusinessMeCells.tsx
@@ -1,4 +1,4 @@
-import { Building2, Shield, Wallet } from 'lucide-react';
+import { Building2, Wallet } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -6,6 +6,7 @@ import { type CellProps } from '@/components/Cell';
 
 /**
  * Aico billing / org surfaces on the mobile Me home list.
+ * `/platform` stays reachable by URL only (no list entry).
  */
 export default function useBusinessMeCells(): CellProps[] {
   const { t } = useTranslation('aico');
@@ -23,12 +24,6 @@ export default function useBusinessMeCells(): CellProps[] {
       key: 'aico-org',
       label: t('nav.org'),
       onClick: () => navigate('/org'),
-    },
-    {
-      icon: Shield,
-      key: 'aico-platform',
-      label: t('nav.platform'),
-      onClick: () => navigate('/platform'),
     },
     { type: 'divider' },
   ];

--- a/src/business/client/features/User/useBusinessMenuItems.test.ts
+++ b/src/business/client/features/User/useBusinessMenuItems.test.ts
@@ -19,7 +19,7 @@ describe('useBusinessMenuItems', () => {
     expect(result.current).toEqual([]);
   });
 
-  it('exposes wallet, org, and platform links when signed in', () => {
+  it('exposes wallet and org links when signed in (platform is URL-only)', () => {
     const { result } = renderHook(() => useBusinessMenuItems(true));
     const keys = (result.current ?? []).map((item) =>
       item && typeof item === 'object' && 'key' in item ? item.key : undefined,
@@ -27,6 +27,6 @@ describe('useBusinessMenuItems', () => {
 
     expect(keys).toContain('aico-wallet');
     expect(keys).toContain('aico-org');
-    expect(keys).toContain('aico-platform');
+    expect(keys).not.toContain('aico-platform');
   });
 });

--- a/src/business/client/features/User/useBusinessMenuItems.tsx
+++ b/src/business/client/features/User/useBusinessMenuItems.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@lobehub/ui';
-import { Building2, Shield, Wallet } from 'lucide-react';
+import { Building2, Wallet } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { type MenuProps } from '@/components/Menu';
@@ -7,7 +7,8 @@ import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 
 /**
  * Aico billing / org surfaces in the user avatar menu.
- * Personal-only routes (`/wallet`, `/org`, `/platform`) — never workspace-prefixed.
+ * Personal-only routes (`/wallet`, `/org`) — never workspace-prefixed.
+ * `/platform` stays reachable by URL only (no menu entry).
  */
 export default function useBusinessMenuItems(isSignin: boolean | undefined): MenuProps['items'] {
   const { t } = useTranslation('aico');
@@ -31,15 +32,6 @@ export default function useBusinessMenuItems(isSignin: boolean | undefined): Men
       label: (
         <WorkspaceLink escape to="/org">
           {t('nav.org')}
-        </WorkspaceLink>
-      ),
-    },
-    {
-      icon: <Icon icon={Shield} />,
-      key: 'aico-platform',
-      label: (
-        <WorkspaceLink escape to="/platform">
-          {t('nav.platform')}
         </WorkspaceLink>
       ),
     },

--- a/src/features/OrgAdmin/OrgAdminMembers.tsx
+++ b/src/features/OrgAdmin/OrgAdminMembers.tsx
@@ -722,8 +722,6 @@ export const OrgAdminMembers = () => {
 
       <Text type="secondary">
         <Link to="/wallet">{t('org.linkWallet')}</Link>
-        {' · '}
-        <Link to="/platform">{t('org.linkPlatform')}</Link>
       </Text>
     </Flexbox>
   );


### PR DESCRIPTION
<!-- Brief and heads-up -->
Hide the Platform admin entry from user menu, mobile Me, and org footer so the panel is harder to discover. `/platform` remains reachable by URL for platform admins.

| Before | After |
| ------ | ----- |
| Platform admin in avatar menu / Me / org footer | No nav entry; open `/platform` by URL |

#### Test

- [x] Tested locally (`moz -u` deploy; menu no longer shows Platform admin)
- [x] Added/updated tests (`useBusinessMenuItems.test.ts`)
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #66

Plane: [AICO-44](https://plane.panafor.com/panaforai/browse/AICO-44)

Made with [Cursor](https://cursor.com)