### PR TITLE
🔧 fix(deploy): auto-restart rustfs after host reboot

### DIFF
--- a/docker-compose/deploy/docker-compose.yml
+++ b/docker-compose/deploy/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       retries: 30
     command:
       ['--access-key', '${RUSTFS_ACCESS_KEY}', '--secret-key', '${RUSTFS_SECRET_KEY}', '/data']
+    restart: always
     networks:
       - lobe-network
 

--- a/docker-compose/dev/docker-compose.yml
+++ b/docker-compose/dev/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       timeout: 3s
       retries: 30
     command: ['--access-key','${RUSTFS_ACCESS_KEY}','--secret-key','${RUSTFS_SECRET_KEY}','/data']
+    restart: always
     env_file:
       - .env
 


### PR DESCRIPTION
<!-- Brief and heads-up -->
Add `restart: always` to `rustfs` so S3 comes back after host reboot, matching Postgres/Redis/lobe. `rustfs-init` stays one-shot (`restart: no`).

| Before | After |
| ------ | ----- |
| `rustfs` stays stopped after reboot (no restart policy) | `rustfs` auto-starts with the rest of the stack |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Fixes #68

Plane: [AICO-45](https://plane.panafor.com/panaforai/browse/AICO-45)


Made with [Cursor](https://cursor.com)