### PR TITLE
✨ feat(aico): switch personal vs org billing keys with separate remaining credits

### DIFF
--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -24,5 +24,17 @@ COPY scripts/migrateServerDB/errorHint.js ./errorHint.js
 COPY scripts/serverLauncher/startServer.js ./startServer.js
 COPY scripts/_shared ./scripts/_shared
 
+# docker.cjs needs drizzle-orm; Next standalone often omits it (bundled into app).
+# Prefer `moz -u` / deploy-local.sh which copies host node_modules with symlink deref.
+# Fallback: install migration deps in-image when building this Dockerfile directly.
+RUN mkdir -p /tmp/migrate-deps \
+  && cd /tmp/migrate-deps \
+  && npm init -y >/dev/null \
+  && npm install --omit=dev pg drizzle-orm \
+  && mkdir -p /app/node_modules \
+  && cp -a /tmp/migrate-deps/node_modules/drizzle-orm /app/node_modules/drizzle-orm \
+  && (test -e /app/node_modules/pg || cp -a /tmp/migrate-deps/node_modules/pg /app/node_modules/pg) \
+  && rm -rf /tmp/migrate-deps
+
 EXPOSE 3210
 CMD ["node", "startServer.js"]

--- a/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
@@ -288,6 +288,70 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     expect(typeof wallet.balanceMicroUsd).toBe('string');
   });
 
+  it('getMyBillingSources returns personal and org sources with separate remaining', async () => {
+    const { eq } = await import('drizzle-orm');
+    const { AicoBillingModel } = await import('@/database/models/aicoBilling');
+    const { OrganizationModel } = await import('@/database/models/organization');
+    const { userWallets } = await import('@/database/schemas/aicoOrganization');
+
+    const ownerCaller = organizationRouter.createCaller(createTestContext(ownerId));
+    const billingCaller = aicoBillingRouter.createCaller(createTestContext(ownerId));
+    const billingModel = new AicoBillingModel(testDB);
+    const orgModel = new OrganizationModel(testDB);
+
+    await billingModel.getOrCreateUserWallet(ownerId);
+    await testDB
+      .update(userWallets)
+      .set({
+        balanceMicroUsd: 1_500_000,
+        balanceToman: 100_000,
+        openrouterKeyId: 'pers-key',
+      })
+      .where(eq(userWallets.userId, ownerId));
+
+    const org = await ownerCaller.create({ name: 'Billing Sources Co' });
+    await orgModel.addManualCredit({
+      amountMicroUsd: 10_000_000,
+      amountToman: 500_000,
+      createdByUserId: ownerId,
+      description: 'test fund',
+      fxRateTomanPerUsd: 50_000,
+      orgId: org.id,
+      type: 'topup',
+    });
+
+    const members = await orgModel.listMembers(org.id);
+    const me = members.find((m) => m.userId === ownerId);
+    expect(me).toBeTruthy();
+
+    await orgModel.allocateMemberCredit({
+      createdByUserId: ownerId,
+      orgId: org.id,
+      orgMemberId: me!.id,
+      period: 'total',
+      periodAmountMicroUsd: 5_000_000,
+    });
+
+    const sources = await billingCaller.getMyBillingSources();
+    expect(sources.sources[0]?.source).toBe('personal');
+    expect(sources.sources[0]?.remainingUsd).toBe('1.500000');
+
+    const orgSource = sources.sources.find(
+      (s) => s.source === 'organization' && s.organizationId === org.id,
+    );
+    expect(orgSource).toBeTruthy();
+    expect(orgSource!.remainingUsd).toBe('5.000000');
+    expect(orgSource!.remainingUsd).not.toBe(sources.sources[0]?.remainingUsd);
+
+    await billingCaller.setBillingPreference({
+      organizationId: org.id,
+      source: 'organization',
+    });
+    const preferred = await billingCaller.getMyBillingSources();
+    expect(preferred.preferredBillingSource).toBe('organization');
+    expect(preferred.preferredOrganizationId).toBe(org.id);
+  });
+
   it('convertToManagement requires a verified phone and rejects a second organization', async () => {
     const strangerCaller = organizationRouter.createCaller(createTestContext(strangerId));
     await expect(strangerCaller.convertToManagement({ name: 'No Phone Co' })).rejects.toMatchObject(

--- a/apps/server/src/routers/lambda/aicoBilling.ts
+++ b/apps/server/src/routers/lambda/aicoBilling.ts
@@ -89,6 +89,69 @@ export const aicoBillingRouter = router({
     };
   }),
 
+  /**
+   * Personal wallet + each org membership budget as separate spendable sources.
+   * Credits never pool — each source has its own remaining balance and managed key.
+   */
+  getMyBillingSources: billingProcedure.query(async ({ ctx }) => {
+    const [wallet, orgs] = await Promise.all([
+      ctx.billingModel.getOrCreateUserWallet(ctx.userId),
+      ctx.organizationModel.listForUser(ctx.userId),
+    ]);
+
+    const personalRemaining = Number(wallet.balanceMicroUsd ?? 0);
+    const personal = {
+      hasManagedKey: Boolean(wallet.openrouterKeyId),
+      isActive: Boolean(wallet.isActive),
+      remainingMicroUsd: String(personalRemaining),
+      remainingUsd: microUsdToDecimalString(personalRemaining),
+      source: 'personal' as const,
+    };
+
+    const organizationSources = (
+      await Promise.all(
+        orgs.map(async (org) => {
+          const members = await ctx.organizationModel.listMembers(org.id);
+          const me = members.find((m) => m.userId === ctx.userId && m.status === 'active');
+          if (!me) return null;
+
+          const budget = await ctx.organizationModel.getMemberBudget(me.id);
+          const reservedMicroUsd = Number(budget?.reservedMicroUsd ?? 0);
+          const settledUsageMicroUsd = Number(budget?.settledUsageMicroUsd ?? 0);
+          const remainingMicroUsd = Math.max(0, reservedMicroUsd - settledUsageMicroUsd);
+          const renewalStatus = budget?.renewalStatus ?? null;
+
+          return {
+            hasManagedKey: Boolean(budget?.openrouterKeyId),
+            isActive: Boolean(budget?.isActive),
+            organizationId: org.id,
+            organizationName: org.name,
+            remainingMicroUsd: String(remainingMicroUsd),
+            remainingUsd: microUsdToDecimalString(remainingMicroUsd),
+            renewalBlocked:
+              renewalStatus === 'renewal_pending' || renewalStatus === 'renewal_failed',
+            source: 'organization' as const,
+          };
+        }),
+      )
+    ).filter(Boolean) as Array<{
+      hasManagedKey: boolean;
+      isActive: boolean;
+      organizationId: string;
+      organizationName: string;
+      remainingMicroUsd: string;
+      remainingUsd: string;
+      renewalBlocked: boolean;
+      source: 'organization';
+    }>;
+
+    return {
+      preferredBillingSource: wallet.preferredBillingSource as 'personal' | 'organization',
+      preferredOrganizationId: wallet.preferredOrganizationId,
+      sources: [personal, ...organizationSources],
+    };
+  }),
+
   getMyPublicCode: billingProcedure.query(async ({ ctx }) => {
     return { publicCode: await ctx.organizationModel.ensureUserPublicCode(ctx.userId) };
   }),

--- a/locales/en-US/aico.json
+++ b/locales/en-US/aico.json
@@ -1,4 +1,12 @@
 {
+  "billing.organization": "Organization",
+  "billing.personal": "Personal",
+  "billing.remaining": "{{amount}} left",
+  "billing.selectHint": "Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.",
+  "billing.sourcesTitle": "Billing sources",
+  "billing.switchFailed": "Could not switch billing source",
+  "billing.switched": "Using {{label}} credits",
+  "billing.switcherAria": "Billing source {{label}}, {{remaining}} remaining",
   "errors.ALREADY_HAS_ORGANIZATION": "You already have an organization.",
   "errors.BUDGET_EXCEEDED": "Your quota has been used up.",
   "errors.BUDGET_NOT_FOUND": "Budget not found.",

--- a/locales/zh-CN/aico.json
+++ b/locales/zh-CN/aico.json
@@ -1,4 +1,12 @@
 {
+  "billing.organization": "组织",
+  "billing.personal": "个人",
+  "billing.remaining": "剩余 {{amount}}",
+  "billing.selectHint": "每个来源有独立的托管密钥与余额。切换只影响下一次对话扣费的账户。",
+  "billing.sourcesTitle": "计费来源",
+  "billing.switchFailed": "无法切换计费来源",
+  "billing.switched": "正在使用 {{label}} 额度",
+  "billing.switcherAria": "计费来源 {{label}}，剩余 {{remaining}}",
   "errors.ALREADY_HAS_ORGANIZATION": "你已经拥有一个组织。",
   "errors.BUDGET_EXCEEDED": "你的额度已用完。",
   "errors.BUDGET_NOT_FOUND": "未找到预算。",

--- a/packages/database/src/models/__tests__/aicoBilling.test.ts
+++ b/packages/database/src/models/__tests__/aicoBilling.test.ts
@@ -42,16 +42,20 @@ describe('AicoBillingModel', () => {
     expect(a.id).toBe(b.id);
   });
 
-  it('updates trial config', async () => {
-    const updated = await model.updateTrialConfig({
-      allowedModelIds: ['openai/gpt-4o-mini'],
-      durationDays: 5,
-      enabled: true,
-      maxRequests: 100,
-      updatedByUserId: userId,
+  it('persists billing preference for SPA pre-select', async () => {
+    const preference = await model.setBillingPreference({
+      organizationId: 'org-pref',
+      source: 'organization',
+      userId,
     });
-    expect(updated.durationDays).toBe(5);
-    expect(updated.maxRequests).toBe(100);
-    expect(JSON.parse(updated.allowedModelIds)).toEqual(['openai/gpt-4o-mini']);
+    expect(preference.preferredBillingSource).toBe('organization');
+    expect(preference.preferredOrganizationId).toBe('org-pref');
+
+    const personal = await model.setBillingPreference({
+      source: 'personal',
+      userId,
+    });
+    expect(personal.preferredBillingSource).toBe('personal');
+    expect(personal.preferredOrganizationId).toBeNull();
   });
 });

--- a/packages/database/src/models/aicoBilling.ts
+++ b/packages/database/src/models/aicoBilling.ts
@@ -259,27 +259,6 @@ export class AicoBillingModel {
     });
   };
 
-  /** UX preference only — never authorize managed requests from this alone. */
-  setBillingPreference = async (params: {
-    preferredBillingSource: 'personal' | 'organization';
-    preferredOrganizationId?: string | null;
-    userId: string;
-  }) => {
-    await this.getOrCreateUserWallet(params.userId);
-    const [row] = await this.db
-      .update(userWallets)
-      .set({
-        preferredBillingSource: params.preferredBillingSource,
-        preferredOrganizationId:
-          params.preferredBillingSource === 'organization'
-            ? (params.preferredOrganizationId ?? null)
-            : null,
-      })
-      .where(eq(userWallets.userId, params.userId))
-      .returning();
-    return row;
-  };
-
   listUserUsage = async (userId: string, limit = 50) => {
     return this.db.query.usageLogs.findMany({
       where: eq(usageLogs.userId, userId),

--- a/packages/locales/src/default/aico.ts
+++ b/packages/locales/src/default/aico.ts
@@ -219,6 +219,16 @@ export default {
   'provider.managed.desc':
     'Models are provided by {{brandName}}. Usage is billed from your wallet or organization credit — no API key setup is required.',
 
+  'billing.organization': 'Organization',
+  'billing.personal': 'Personal',
+  'billing.remaining': '{{amount}} left',
+  'billing.selectHint':
+    'Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.',
+  'billing.sourcesTitle': 'Billing sources',
+  'billing.switchFailed': 'Could not switch billing source',
+  'billing.switcherAria': 'Billing source {{label}}, {{remaining}} remaining',
+  'billing.switched': 'Using {{label}} credits',
+
   'wallet.amountToman': 'Amount (toman)',
   'wallet.balanceToman': 'Paid-in (toman)',
   'wallet.balanceUsd': 'Balance (USD)',

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -420,15 +420,39 @@ if [[ $BUILD -eq 1 ]]; then
   cp "$ROOT/scripts/serverLauncher/startServer.js" "$STAGE/startServer.js"
   cp "$ROOT/scripts/docker/Dockerfile.staged" "$STAGE/Dockerfile"
 
+  # docker.cjs requires drizzle-orm/node-postgres; Next standalone often omits it
+  # because the app bundles ORM usage. Match root Dockerfile (copies drizzle-orm + pg).
+  mkdir -p "$STAGE/node_modules"
+  if [[ ! -e "$ROOT/node_modules/drizzle-orm" ]]; then
+    echo "Error: node_modules/drizzle-orm missing — run pnpm install" >&2
+    exit 1
+  fi
+  # -L: pnpm links into .pnpm; dereference so the image has real package files
+  rm -rf "$STAGE/node_modules/drizzle-orm"
+  cp -aL "$ROOT/node_modules/drizzle-orm" "$STAGE/node_modules/drizzle-orm"
+  if [[ ! -e "$STAGE/node_modules/pg" ]]; then
+    if [[ ! -e "$ROOT/node_modules/pg" ]]; then
+      echo "Error: node_modules/pg missing — run pnpm install" >&2
+      exit 1
+    fi
+    cp -aL "$ROOT/node_modules/pg" "$STAGE/node_modules/pg"
+  fi
+
   docker build -t "$IMAGE" -t "aico/lobehub:$TAG" "$STAGE"
 
   echo "==> Verifying migration packaging in image"
-  for path in /app/docker.cjs /app/errorHint.js /app/migrations /app/startServer.js; do
+  for path in /app/docker.cjs /app/errorHint.js /app/migrations /app/startServer.js /app/node_modules/drizzle-orm; do
     docker run --rm --entrypoint sh "$IMAGE" -c "test -e '$path'" || {
       echo "Error: image missing $path — auto-migrate would fail at boot" >&2
       exit 1
     }
   done
+  docker run --rm --entrypoint node "$IMAGE" -e \
+    "require('drizzle-orm/node-postgres'); require('drizzle-orm/node-postgres/migrator'); require('pg');" \
+    || {
+      echo "Error: image cannot resolve docker.cjs deps (drizzle-orm/pg)" >&2
+      exit 1
+    }
 
   echo "==> Image ready: $IMAGE (also tagged aico/lobehub:$TAG)"
 fi

--- a/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
+++ b/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
@@ -1,10 +1,27 @@
+import { Flexbox } from '@lobehub/ui';
 import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+import { BillingSourceSwitcher } from '@/features/AicoBilling';
 
 export const useBusinessChatInputCostEstimateAlert = (): ReactNode => null;
 
 export const useBusinessChatInputAlerts = (): ReactNode => null;
 
-export const getBusinessChatInputSendAreaPrefix = (sendAreaPrefix?: ReactNode): ReactNode =>
-  sendAreaPrefix;
+/**
+ * Aico billing source switcher sits next to the send area so users can pick
+ * personal vs org credit (separate balances) while chatting.
+ */
+export const getBusinessChatInputSendAreaPrefix = (sendAreaPrefix?: ReactNode): ReactNode => {
+  const switcher = createElement(BillingSourceSwitcher);
+  if (!sendAreaPrefix) return switcher;
+
+  return createElement(
+    Flexbox,
+    { align: 'center', gap: 6, horizontal: true },
+    switcher,
+    sendAreaPrefix,
+  );
+};
 
 export const useBusinessChatInputSendAreaPrefix = getBusinessChatInputSendAreaPrefix;

--- a/src/features/AicoBilling/BillingSourceSwitcher.tsx
+++ b/src/features/AicoBilling/BillingSourceSwitcher.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { Center, Flexbox, Text } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { CheckIcon, ChevronDownIcon, WalletIcon } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { toastAicoError } from '@/business/client/resolveAicoErrorMessage';
+import ActionDropdown from '@/features/ChatInput/ActionBar/components/ActionDropdown';
+
+import { type AicoBillingContext, type AicoBillingSource, formatRemainingUsd } from './types';
+import { useAicoBillingSources } from './useAicoBillingSources';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  check: css`
+    color: ${cssVar.colorPrimary};
+  `,
+  chevron: css`
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  label: css`
+    overflow: hidden;
+
+    max-width: 110px;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  remaining: css`
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorText};
+  `,
+  row: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    width: 100%;
+    min-width: 0;
+  `,
+  trigger: css`
+    cursor: pointer;
+    border-radius: 6px;
+
+    :hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  triggerReadonly: css`
+    cursor: default;
+
+    &:hover {
+      background: transparent;
+    }
+  `,
+}));
+
+const sourceLabel = (
+  source: AicoBillingSource,
+  t: (key: string, opts?: Record<string, string>) => string,
+): string => {
+  if (source.source === 'personal') return t('billing.personal');
+  return source.organizationName || t('billing.organization');
+};
+
+const sourceToContext = (source: AicoBillingSource): AicoBillingContext =>
+  source.source === 'personal'
+    ? { source: 'personal' }
+    : { organizationId: source.organizationId, source: 'organization' };
+
+const BillingSourceSwitcher = memo(() => {
+  const { t } = useTranslation('aico');
+  const [busy, setBusy] = useState(false);
+  const { activeSource, canSwitch, data, isLoading, isSelected, selectSource } =
+    useAicoBillingSources();
+
+  const menuItems = useMemo(() => {
+    if (!data?.sources.length) return [];
+
+    return data.sources.map((source) => {
+      const ctx = sourceToContext(source);
+      const selected = isSelected(ctx);
+      const label = sourceLabel(source, t);
+      const remaining = formatRemainingUsd(source.remainingUsd);
+
+      return {
+        icon: selected ? CheckIcon : WalletIcon,
+        key: source.source === 'personal' ? 'personal' : `org:${source.organizationId}`,
+        label: (
+          <div className={styles.row}>
+            <Flexbox gap={2} style={{ minWidth: 0 }}>
+              <Text
+                style={{
+                  fontSize: 13,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {label}
+              </Text>
+              <Text style={{ fontSize: 11 }} type="secondary">
+                {t('billing.remaining', { amount: remaining })}
+              </Text>
+            </Flexbox>
+            {selected ? <CheckIcon className={styles.check} size={14} /> : null}
+          </div>
+        ),
+        onClick: async () => {
+          if (selected || busy) return;
+          setBusy(true);
+          try {
+            await selectSource(ctx);
+          } catch (err) {
+            toastAicoError(err, t, 'billing.switchFailed');
+          } finally {
+            setBusy(false);
+          }
+        },
+      };
+    });
+  }, [busy, data?.sources, isSelected, selectSource, t]);
+
+  if (isLoading && !activeSource) return null;
+  if (!activeSource) return null;
+
+  const label = sourceLabel(activeSource, t);
+  const remaining = formatRemainingUsd(activeSource.remainingUsd);
+
+  const trigger = (
+    <Center
+      horizontal
+      aria-label={t('billing.switcherAria', { label, remaining })}
+      className={cx(styles.trigger, !canSwitch && styles.triggerReadonly)}
+      gap={4}
+      height={28}
+      paddingInline={6}
+    >
+      <WalletIcon size={12} style={{ opacity: 0.65 }} />
+      <span className={styles.label}>{label}</span>
+      <span className={styles.remaining}>{remaining}</span>
+      {canSwitch ? <ChevronDownIcon className={styles.chevron} size={12} /> : null}
+    </Center>
+  );
+
+  if (!canSwitch) return trigger;
+
+  return (
+    <ActionDropdown menu={{ items: menuItems }} minWidth={240} placement="top" trigger="click">
+      {trigger}
+    </ActionDropdown>
+  );
+});
+
+BillingSourceSwitcher.displayName = 'BillingSourceSwitcher';
+
+export default BillingSourceSwitcher;

--- a/src/features/AicoBilling/index.ts
+++ b/src/features/AicoBilling/index.ts
@@ -1,0 +1,12 @@
+export { default as BillingSourceSwitcher } from './BillingSourceSwitcher';
+export { resolveAicoBillingForRequest } from './resolveBillingForRequest';
+export { getAicoBillingContext, setAicoBillingContext, useAicoBillingStore } from './store';
+export type { AicoBillingContext, AicoBillingSource, AicoBillingSourcesResponse } from './types';
+export {
+  billingContextKey,
+  findBillingSource,
+  formatRemainingUsd,
+  isSameBillingContext,
+  preferenceToBillingContext,
+} from './types';
+export { AICO_BILLING_SOURCES_SWR_KEY, useAicoBillingSources } from './useAicoBillingSources';

--- a/src/features/AicoBilling/resolveBillingForRequest.test.ts
+++ b/src/features/AicoBilling/resolveBillingForRequest.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveAicoBillingForRequest } from './resolveBillingForRequest';
+import { setAicoBillingContext, useAicoBillingStore } from './store';
+
+const getMyBillingSources = vi.fn();
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    aicoBilling: {
+      getMyBillingSources: { query: (...args: unknown[]) => getMyBillingSources(...args) },
+    },
+  },
+}));
+
+describe('resolveAicoBillingForRequest', () => {
+  beforeEach(() => {
+    useAicoBillingStore.setState({ context: null, hydrated: false });
+    getMyBillingSources.mockReset();
+  });
+
+  it('skips non-managed providers', async () => {
+    await expect(resolveAicoBillingForRequest('openai')).resolves.toBeUndefined();
+    expect(getMyBillingSources).not.toHaveBeenCalled();
+  });
+
+  it('returns cached context for aico/openrouter without refetch', async () => {
+    setAicoBillingContext({ source: 'personal' });
+    await expect(resolveAicoBillingForRequest('aico')).resolves.toEqual({ source: 'personal' });
+    await expect(resolveAicoBillingForRequest('openrouter')).resolves.toEqual({
+      source: 'personal',
+    });
+    expect(getMyBillingSources).not.toHaveBeenCalled();
+  });
+
+  it('loads preference when cache is empty', async () => {
+    getMyBillingSources.mockResolvedValue({
+      preferredBillingSource: 'organization',
+      preferredOrganizationId: 'org-9',
+      sources: [
+        {
+          hasManagedKey: true,
+          isActive: true,
+          remainingMicroUsd: '0',
+          remainingUsd: '0.000000',
+          source: 'personal',
+        },
+        {
+          hasManagedKey: true,
+          isActive: true,
+          organizationId: 'org-9',
+          organizationName: 'Nine',
+          remainingMicroUsd: '1000000',
+          remainingUsd: '1.000000',
+          renewalBlocked: false,
+          source: 'organization',
+        },
+      ],
+    });
+
+    await expect(resolveAicoBillingForRequest('aico')).resolves.toEqual({
+      organizationId: 'org-9',
+      source: 'organization',
+    });
+    expect(useAicoBillingStore.getState().context).toEqual({
+      organizationId: 'org-9',
+      source: 'organization',
+    });
+  });
+});

--- a/src/features/AicoBilling/resolveBillingForRequest.ts
+++ b/src/features/AicoBilling/resolveBillingForRequest.ts
@@ -1,0 +1,30 @@
+import { lambdaClient } from '@/libs/trpc/client';
+
+import { getAicoBillingContext, setAicoBillingContext } from './store';
+import {
+  type AicoBillingContext,
+  type AicoBillingSourcesResponse,
+  preferenceToBillingContext,
+} from './types';
+
+const isManagedProvider = (provider: string): boolean =>
+  provider === 'aico' || provider === 'openrouter';
+
+/**
+ * Ensure every managed chat request carries an explicit billing context.
+ * Uses the in-memory selection when hydrated; otherwise loads preference once.
+ */
+export const resolveAicoBillingForRequest = async (
+  provider: string,
+): Promise<AicoBillingContext | undefined> => {
+  if (!isManagedProvider(provider)) return undefined;
+
+  const cached = getAicoBillingContext();
+  if (cached) return cached;
+
+  const data =
+    (await lambdaClient.aicoBilling.getMyBillingSources.query()) as AicoBillingSourcesResponse;
+  const context = preferenceToBillingContext(data);
+  setAicoBillingContext(context);
+  return context;
+};

--- a/src/features/AicoBilling/store.ts
+++ b/src/features/AicoBilling/store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+
+import type { AicoBillingContext } from './types';
+
+interface AicoBillingStoreState {
+  /** Explicit context attached to managed chat requests. */
+  context: AicoBillingContext | null;
+  hydrated: boolean;
+  setContext: (context: AicoBillingContext) => void;
+  setHydrated: (hydrated: boolean) => void;
+}
+
+export const useAicoBillingStore = create<AicoBillingStoreState>((set) => ({
+  context: null,
+  hydrated: false,
+  setContext: (context) => set({ context, hydrated: true }),
+  setHydrated: (hydrated) => set({ hydrated }),
+}));
+
+/** Sync read for chat service (outside React). */
+export const getAicoBillingContext = (): AicoBillingContext | null =>
+  useAicoBillingStore.getState().context;
+
+export const setAicoBillingContext = (context: AicoBillingContext) => {
+  useAicoBillingStore.getState().setContext(context);
+};

--- a/src/features/AicoBilling/types.test.ts
+++ b/src/features/AicoBilling/types.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type AicoBillingSource,
+  billingContextKey,
+  findBillingSource,
+  formatRemainingUsd,
+  isSameBillingContext,
+  preferenceToBillingContext,
+} from './types';
+
+const sources: AicoBillingSource[] = [
+  {
+    hasManagedKey: true,
+    isActive: true,
+    remainingMicroUsd: '1500000',
+    remainingUsd: '1.500000',
+    source: 'personal',
+  },
+  {
+    hasManagedKey: true,
+    isActive: true,
+    organizationId: 'org-1',
+    organizationName: 'Acme',
+    remainingMicroUsd: '50000000',
+    remainingUsd: '50.000000',
+    renewalBlocked: false,
+    source: 'organization',
+  },
+  {
+    hasManagedKey: false,
+    isActive: true,
+    organizationId: 'org-2',
+    organizationName: 'Beta',
+    remainingMicroUsd: '0',
+    remainingUsd: '0.000000',
+    renewalBlocked: false,
+    source: 'organization',
+  },
+];
+
+describe('AicoBilling types helpers', () => {
+  it('preferenceToBillingContext prefers matching org when selected', () => {
+    expect(
+      preferenceToBillingContext({
+        preferredBillingSource: 'organization',
+        preferredOrganizationId: 'org-2',
+        sources,
+      }),
+    ).toEqual({ organizationId: 'org-2', source: 'organization' });
+  });
+
+  it('preferenceToBillingContext falls back to personal', () => {
+    expect(
+      preferenceToBillingContext({
+        preferredBillingSource: 'personal',
+        preferredOrganizationId: null,
+        sources,
+      }),
+    ).toEqual({ source: 'personal' });
+  });
+
+  it('preferenceToBillingContext falls back to first org when preferred org is missing', () => {
+    expect(
+      preferenceToBillingContext({
+        preferredBillingSource: 'organization',
+        preferredOrganizationId: 'missing',
+        sources,
+      }),
+    ).toEqual({ organizationId: 'org-1', source: 'organization' });
+  });
+
+  it('findBillingSource keeps personal and org credits separate', () => {
+    expect(findBillingSource(sources, { source: 'personal' })?.remainingUsd).toBe('1.500000');
+    expect(
+      findBillingSource(sources, { organizationId: 'org-1', source: 'organization' })?.remainingUsd,
+    ).toBe('50.000000');
+  });
+
+  it('isSameBillingContext / billingContextKey distinguish org ids', () => {
+    expect(
+      isSameBillingContext(
+        { organizationId: 'org-1', source: 'organization' },
+        { organizationId: 'org-1', source: 'organization' },
+      ),
+    ).toBe(true);
+    expect(
+      isSameBillingContext(
+        { organizationId: 'org-1', source: 'organization' },
+        { organizationId: 'org-2', source: 'organization' },
+      ),
+    ).toBe(false);
+    expect(billingContextKey({ source: 'personal' })).toBe('personal');
+  });
+
+  it('formatRemainingUsd formats decimal strings', () => {
+    expect(formatRemainingUsd('12.5')).toBe('$12.5000');
+    expect(formatRemainingUsd(undefined)).toBe('$0.0000');
+  });
+});

--- a/src/features/AicoBilling/types.ts
+++ b/src/features/AicoBilling/types.ts
@@ -1,0 +1,75 @@
+export type AicoBillingContext =
+  { source: 'personal' } | { source: 'organization'; organizationId: string };
+
+export type AicoPersonalBillingSource = {
+  hasManagedKey: boolean;
+  isActive: boolean;
+  remainingMicroUsd: string;
+  remainingUsd: string;
+  source: 'personal';
+};
+
+export type AicoOrganizationBillingSource = {
+  hasManagedKey: boolean;
+  isActive: boolean;
+  organizationId: string;
+  organizationName: string;
+  remainingMicroUsd: string;
+  remainingUsd: string;
+  renewalBlocked: boolean;
+  source: 'organization';
+};
+
+export type AicoBillingSource = AicoPersonalBillingSource | AicoOrganizationBillingSource;
+
+export type AicoBillingSourcesResponse = {
+  preferredBillingSource: 'personal' | 'organization';
+  preferredOrganizationId: string | null;
+  sources: AicoBillingSource[];
+};
+
+export const billingContextKey = (ctx: AicoBillingContext): string =>
+  ctx.source === 'personal' ? 'personal' : `organization:${ctx.organizationId}`;
+
+export const isSameBillingContext = (a: AicoBillingContext, b: AicoBillingContext): boolean =>
+  billingContextKey(a) === billingContextKey(b);
+
+export const preferenceToBillingContext = (params: {
+  preferredBillingSource: 'personal' | 'organization';
+  preferredOrganizationId: string | null | undefined;
+  sources: AicoBillingSource[];
+}): AicoBillingContext => {
+  if (params.preferredBillingSource === 'organization' && params.preferredOrganizationId) {
+    const match = params.sources.find(
+      (s) => s.source === 'organization' && s.organizationId === params.preferredOrganizationId,
+    );
+    if (match?.source === 'organization') {
+      return { organizationId: match.organizationId, source: 'organization' };
+    }
+  }
+
+  const firstOrg = params.sources.find((s) => s.source === 'organization');
+  if (params.preferredBillingSource === 'organization' && firstOrg?.source === 'organization') {
+    return { organizationId: firstOrg.organizationId, source: 'organization' };
+  }
+
+  return { source: 'personal' };
+};
+
+export const findBillingSource = (
+  sources: AicoBillingSource[],
+  ctx: AicoBillingContext,
+): AicoBillingSource | undefined => {
+  if (ctx.source === 'personal') {
+    return sources.find((s) => s.source === 'personal');
+  }
+  return sources.find(
+    (s) => s.source === 'organization' && s.organizationId === ctx.organizationId,
+  );
+};
+
+export const formatRemainingUsd = (remainingUsd: string | undefined): string => {
+  const n = Number(remainingUsd ?? 0);
+  if (!Number.isFinite(n)) return '$0.0000';
+  return `$${n.toFixed(4)}`;
+};

--- a/src/features/AicoBilling/useAicoBillingSources.ts
+++ b/src/features/AicoBilling/useAicoBillingSources.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useEffect } from 'react';
+
+import { useClientDataSWR } from '@/libs/swr';
+import { lambdaClient } from '@/libs/trpc/client';
+
+import { useAicoBillingStore } from './store';
+import {
+  type AicoBillingContext,
+  type AicoBillingSourcesResponse,
+  findBillingSource,
+  isSameBillingContext,
+  preferenceToBillingContext,
+} from './types';
+
+export const AICO_BILLING_SOURCES_SWR_KEY = 'aico-billing-sources';
+
+export const useAicoBillingSources = () => {
+  const context = useAicoBillingStore((s) => s.context);
+  const setContext = useAicoBillingStore((s) => s.setContext);
+
+  const { data, error, isLoading, mutate } = useClientDataSWR(
+    AICO_BILLING_SOURCES_SWR_KEY,
+    () =>
+      lambdaClient.aicoBilling.getMyBillingSources.query() as Promise<AicoBillingSourcesResponse>,
+  );
+
+  useEffect(() => {
+    if (!data) return;
+    const preferred = preferenceToBillingContext(data);
+    const current = useAicoBillingStore.getState().context;
+    if (!current || !findBillingSource(data.sources, current)) {
+      setContext(preferred);
+    }
+  }, [data, setContext]);
+
+  const selectSource = useCallback(
+    async (next: AicoBillingContext) => {
+      const previous = useAicoBillingStore.getState().context;
+      setContext(next);
+
+      try {
+        await lambdaClient.aicoBilling.setBillingPreference.mutate(
+          next.source === 'personal'
+            ? { source: 'personal' }
+            : { organizationId: next.organizationId, source: 'organization' },
+        );
+        await mutate();
+      } catch (err) {
+        if (previous) setContext(previous);
+        throw err;
+      }
+    },
+    [mutate, setContext],
+  );
+
+  const activeSource = data && context ? findBillingSource(data.sources, context) : undefined;
+  const canSwitch = (data?.sources.length ?? 0) > 1;
+
+  return {
+    activeContext: context,
+    activeSource,
+    canSwitch,
+    data,
+    error,
+    isLoading,
+    isSelected: (candidate: AicoBillingContext) =>
+      context ? isSameBillingContext(context, candidate) : false,
+    mutate,
+    selectSource,
+  };
+};

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -4,12 +4,19 @@ import { Block, Flexbox, Tag, Text } from '@lobehub/ui';
 import { Button, toast } from '@lobehub/ui/base-ui';
 import { Form, InputNumber, Table } from 'antd';
 import { createStaticStyles } from 'antd-style';
+import { CheckIcon, WalletIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { toastAicoError } from '@/business/client/resolveAicoErrorMessage';
 import StatisticCard from '@/components/StatisticCard';
+import {
+  type AicoBillingContext,
+  type AicoBillingSource,
+  formatRemainingUsd,
+  useAicoBillingSources,
+} from '@/features/AicoBilling';
 import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
 
@@ -29,7 +36,45 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: ${cssVar.borderRadiusLG};
     background: ${cssVar.colorBgContainer};
   `,
+  sourceActive: css`
+    border-color: ${cssVar.colorPrimary};
+    background: ${cssVar.colorPrimaryBg};
+  `,
+  sourceCard: css`
+    cursor: pointer;
+
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    padding: 12px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
+
+    transition:
+      border-color 0.15s ease,
+      background 0.15s ease;
+
+    &:hover {
+      border-color: ${cssVar.colorPrimaryBorder};
+    }
+  `,
+  sourceGrid: css`
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 12px;
+  `,
 }));
+
+const sourceToContext = (source: AicoBillingSource): AicoBillingContext =>
+  source.source === 'personal'
+    ? { source: 'personal' }
+    : { organizationId: source.organizationId, source: 'organization' };
+
+const sourceTitle = (source: AicoBillingSource, t: (key: string) => string): string => {
+  if (source.source === 'personal') return t('billing.personal');
+  return source.organizationName || t('billing.organization');
+};
 
 export const AicoWallet = () => {
   const { t } = useTranslation('aico');
@@ -52,6 +97,8 @@ export const AicoWallet = () => {
     lambdaClient.aicoBilling.getManagedProviderStatus.query(),
   );
 
+  const { canSwitch, data: billingSources, isSelected, selectSource } = useAicoBillingSources();
+
   return (
     <Flexbox className={styles.page} gap={20}>
       <Flexbox gap={4}>
@@ -66,11 +113,11 @@ export const AicoWallet = () => {
 
       <div className={styles.grid}>
         <StatisticCard
-          statistic={{ value: `$${wallet?.balanceUsd?.toFixed(4) ?? '0'}` }}
+          statistic={{ value: `$${Number(wallet?.balanceUsd ?? 0).toFixed(4)}` }}
           title={t('wallet.balanceUsd')}
         />
         <StatisticCard
-          statistic={{ value: wallet?.balanceToman?.toLocaleString() ?? 0 }}
+          statistic={{ value: Number(wallet?.balanceToman ?? 0).toLocaleString() }}
           title={t('wallet.balanceToman')}
         />
         <StatisticCard
@@ -83,6 +130,59 @@ export const AicoWallet = () => {
           }}
         />
       </div>
+
+      {billingSources && billingSources.sources.length > 0 ? (
+        <Block className={styles.section} variant="outlined">
+          <Flexbox gap={12}>
+            <Text strong>{t('billing.sourcesTitle')}</Text>
+            <Text type="secondary">{t('billing.selectHint')}</Text>
+            <div className={styles.sourceGrid}>
+              {billingSources.sources.map((source) => {
+                const ctx = sourceToContext(source);
+                const selected = isSelected(ctx);
+                const title = sourceTitle(source, t);
+                const remaining = formatRemainingUsd(source.remainingUsd);
+
+                return (
+                  <button
+                    className={`${styles.sourceCard}${selected ? ` ${styles.sourceActive}` : ''}`}
+                    disabled={busy || (selected && !canSwitch)}
+                    key={source.source === 'personal' ? 'personal' : source.organizationId}
+                    type="button"
+                    onClick={async () => {
+                      if (selected || busy) return;
+                      setBusy(true);
+                      try {
+                        await selectSource(ctx);
+                        toast.success(t('billing.switched', { label: title }));
+                        await mutateWallet();
+                      } catch (err) {
+                        toastAicoError(err, t, 'billing.switchFailed');
+                      } finally {
+                        setBusy(false);
+                      }
+                    }}
+                  >
+                    <Flexbox horizontal align="center" justify="space-between">
+                      <Flexbox horizontal align="center" gap={6}>
+                        <WalletIcon size={14} />
+                        <Text strong>{title}</Text>
+                      </Flexbox>
+                      {selected ? <CheckIcon size={14} /> : null}
+                    </Flexbox>
+                    <Text style={{ fontSize: 18, fontVariantNumeric: 'tabular-nums' }}>
+                      {remaining}
+                    </Text>
+                    <Text style={{ fontSize: 12 }} type="secondary">
+                      {source.hasManagedKey ? t('wallet.keyProvisioned') : t('wallet.keyPending')}
+                    </Text>
+                  </button>
+                );
+              })}
+            </div>
+          </Flexbox>
+        </Block>
+      ) : null}
 
       <Block className={styles.section} variant="outlined">
         <Flexbox gap={16}>
@@ -197,7 +297,7 @@ export const AicoWallet = () => {
               {
                 dataIndex: 'amountToman',
                 title: t('wallet.columns.toman'),
-                render: (v: number) => v?.toLocaleString?.() ?? v,
+                render: (v: number | string) => Number(v ?? 0).toLocaleString(),
               },
               {
                 dataIndex: 'createdAt',

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -498,8 +498,14 @@ class ChatService {
       responseAnimation,
     ].reduce((acc, cur) => merge(acc, standardizeAnimationStyle(cur)), {});
 
+    // Managed OpenRouter/Aico chat must send an explicit billing context so the
+    // server can pick the personal vs org key (credits are never pooled).
+    const { resolveAicoBillingForRequest } = await import('@/features/AicoBilling');
+    const aicoBilling = await resolveAicoBillingForRequest(provider);
+    const requestBody = aicoBilling ? { ...payload, aicoBilling } : payload;
+
     return fetchSSE(API_ENDPOINTS.chat(provider), {
-      body: JSON.stringify(payload),
+      body: JSON.stringify(requestBody),
       fetcher,
       headers,
       method: 'POST',


### PR DESCRIPTION
#### 💥 Change Type / 改动类型

- [x] ✨ `feat`: New Feature / 新功能
- [x] 🐛 `fix`: Bug Fix / 修复

#### 📝 Description / 描述

Lets users with a personal wallet and org member budgets choose which key/balance to spend from while chatting. Each source shows its own remaining credits (never pooled). Managed chat requests now send explicit `aicoBilling` context.

Also fixes local `moz -u` Docker packaging so `docker.cjs` can resolve `drizzle-orm/node-postgres` (Next standalone often omits it), which was breaking DB migration at container boot.

#### 🔗 Related Issue / 相关 Issue

Fixes #74

Plane: [AICO-48](https://plane.panafor.com/panaforai/browse/AICO-48)

#### 🧪 How to Test / 测试

- [x] Unit / integration tests for preference, sources API, and client resolver
- [x] `moz -u` packaging includes drizzle-orm; container migrates and `/signin` returns 200
- [ ] Manual: user with personal + org credit sees switcher next to send, remaining USD per source
- [ ] Manual: switching source changes which balance is charged on next managed chat
- [ ] Manual: Wallet page lists both sources with separate remaining

Made with [Cursor](https://cursor.com)