### PR TITLE
🐛 fix(aico): round live FX rates before BigInt in platform financials

### DIFF
--- a/apps/server/src/routers/lambda/platformAdmin.ts
+++ b/apps/server/src/routers/lambda/platformAdmin.ts
@@ -332,20 +332,22 @@ export const platformAdminRouter = router({
       );
       const topups = txs.filter((t) => t.type === 'topup' || t.type === 'manual_credit');
       const totalRevenueToman = topups.reduce((sum, t) => sum + Number(t.amountToman || 0), 0);
-      const totalMicroCredited = topups.reduce((sum, t) => sum + Number(t.amountMicroUsd || 0), 0);
-      const b2cBalanceMicroUsd = wallets.reduce(
-        (sum, w) => sum + Number(w.balanceMicroUsd || 0),
-        0,
+      const totalMicroCredited = Math.trunc(
+        topups.reduce((sum, t) => sum + Number(t.amountMicroUsd || 0), 0),
       );
+      const b2cBalanceMicroUsd = Math.trunc(
+        wallets.reduce((sum, w) => sum + Number(w.balanceMicroUsd || 0), 0),
+      );
+      // SUM/driver may yield a float; FX is integer toman/USD from getTomanPerUsd.
+      const costMicroUsd = Math.trunc(Number(totalOpenRouterCostMicroUsd) || 0);
+      const fxRate = Math.round(fx.rate);
       // Approximate margin in toman using integer FX (floored).
-      const costTomanEstimate = Number(
-        (BigInt(totalOpenRouterCostMicroUsd) * BigInt(fx.rate)) / 1_000_000n,
-      );
+      const costTomanEstimate = Number((BigInt(costMicroUsd) * BigInt(fxRate)) / 1_000_000n);
       const marginToman = totalRevenueToman - costTomanEstimate;
 
       return {
-        b2bBalanceMicroUsd: String(orgBalanceMicroUsd),
-        b2bBalanceUsd: microUsdToDecimalString(orgBalanceMicroUsd),
+        b2bBalanceMicroUsd: String(Math.trunc(Number(orgBalanceMicroUsd) || 0)),
+        b2bBalanceUsd: microUsdToDecimalString(Math.trunc(Number(orgBalanceMicroUsd) || 0)),
         b2cBalanceMicroUsd: String(b2cBalanceMicroUsd),
         b2cBalanceUsd: microUsdToDecimalString(b2cBalanceMicroUsd),
         b2cWalletCount: wallets.length,
@@ -362,9 +364,9 @@ export const platformAdminRouter = router({
           userId: t.userId,
         })),
         to: null as string | null,
-        totalOpenRouterCostMicroUsd: String(totalOpenRouterCostMicroUsd),
-        totalOpenRouterCostUsd: microUsdToDecimalString(totalOpenRouterCostMicroUsd),
-        totalRevenueToman: String(totalRevenueToman),
+        totalOpenRouterCostMicroUsd: String(costMicroUsd),
+        totalOpenRouterCostUsd: microUsdToDecimalString(costMicroUsd),
+        totalRevenueToman: String(Math.trunc(totalRevenueToman)),
         totalUsdCredited: microUsdToDecimalString(totalMicroCredited),
       };
     }),

--- a/apps/server/src/services/aico/fxService.test.ts
+++ b/apps/server/src/services/aico/fxService.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetFxCacheForTests,
+  __setFxLiveFetchImplForTests,
+  getTomanPerUsd,
+  toIntegerTomanPerUsd,
+} from './fxService';
+
+afterEach(() => {
+  __resetFxCacheForTests();
+  __setFxLiveFetchImplForTests(async () => {
+    throw new Error('live FX disabled in test default');
+  });
+});
+
+describe('toIntegerTomanPerUsd', () => {
+  it('rounds fractional live FX rates so BigInt conversion is safe', () => {
+    // Regression: platformAdmin.getPlatformFinancials did BigInt(fx.rate) on
+    // 126510.0632387 (IRR/10) and threw RangeError.
+    expect(toIntegerTomanPerUsd(126_510.063_238_7)).toBe(126_510);
+    expect(() => BigInt(toIntegerTomanPerUsd(126_510.063_238_7))).not.toThrow();
+  });
+
+  it('rejects non-positive / non-finite rates', () => {
+    expect(() => toIntegerTomanPerUsd(0)).toThrow('INVALID_FX_RATE');
+    expect(() => toIntegerTomanPerUsd(-1)).toThrow('INVALID_FX_RATE');
+    expect(() => toIntegerTomanPerUsd(Number.NaN)).toThrow('INVALID_FX_RATE');
+  });
+});
+
+describe('getTomanPerUsd', () => {
+  it('caches an integer live rate (never returns a float)', async () => {
+    __setFxLiveFetchImplForTests(async () => 126_510.063_238_7);
+    const first = await getTomanPerUsd();
+    expect(first).toEqual({ rate: 126_510, source: 'live' });
+    expect(Number.isInteger(first.rate)).toBe(true);
+
+    // Cache hit still integer.
+    const second = await getTomanPerUsd();
+    expect(second).toEqual({ rate: 126_510, source: 'live' });
+  });
+
+  it('falls back to env integer rate when live fetch fails', async () => {
+    __setFxLiveFetchImplForTests(async () => {
+      throw new Error('network down');
+    });
+    const result = await getTomanPerUsd();
+    expect(result.source).toBe('env');
+    expect(Number.isInteger(result.rate)).toBe(true);
+    expect(result.rate).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/src/services/aico/fxService.ts
+++ b/apps/server/src/services/aico/fxService.ts
@@ -3,6 +3,7 @@ import { aicoEnv } from '@/envs/aico';
 export type FxRateSource = 'live' | 'env';
 
 export interface TomanPerUsdRate {
+  /** Positive integer toman per 1 USD — safe for BigInt / integer money math. */
   rate: number;
   source: FxRateSource;
 }
@@ -12,6 +13,18 @@ const LIVE_FX_URL = 'https://open.er-api.com/v6/latest/USD';
 const FETCH_TIMEOUT_MS = 4000;
 
 let cached: { expiresAt: number; rate: number } | null = null;
+
+/**
+ * Live FX feeds return floats (e.g. IRR/10 → 126510.0632387). Integer money
+ * math and `BigInt(rate)` require a positive integer toman-per-USD.
+ */
+export const toIntegerTomanPerUsd = (rate: number): number => {
+  const rounded = Math.round(rate);
+  if (!Number.isFinite(rounded) || rounded <= 0) {
+    throw new Error('INVALID_FX_RATE');
+  }
+  return rounded;
+};
 
 /** Allows tests to swap the live-fetch implementation without network access. */
 let fetchLiveRateImpl = async (): Promise<number> => {
@@ -36,6 +49,7 @@ let fetchLiveRateImpl = async (): Promise<number> => {
  * Toman-per-USD rate for topup conversion. Tries a live lookup (15min cache),
  * falling back to `AICO_TOMAN_PER_USD` on any failure — USD wallet balances
  * are the source of truth, so a stale/fallback FX rate never blocks a topup.
+ * Always returns an integer rate so callers can safely use BigInt / FX math.
  */
 export const getTomanPerUsd = async (): Promise<TomanPerUsdRate> => {
   const now = Date.now();
@@ -44,11 +58,11 @@ export const getTomanPerUsd = async (): Promise<TomanPerUsdRate> => {
   }
 
   try {
-    const rate = await fetchLiveRateImpl();
+    const rate = toIntegerTomanPerUsd(await fetchLiveRateImpl());
     cached = { expiresAt: now + CACHE_TTL_MS, rate };
     return { rate, source: 'live' };
   } catch {
-    return { rate: aicoEnv.AICO_TOMAN_PER_USD, source: 'env' };
+    return { rate: toIntegerTomanPerUsd(aicoEnv.AICO_TOMAN_PER_USD), source: 'env' };
   }
 };
 


### PR DESCRIPTION
#### 🐛 Bug Fix

- [x] Bug fix

#### 🔗 Related Issue

Fixes #78

#### Description of Change

`platformAdmin.getPlatformFinancials` crashed with:

`RangeError: The number 126510.0632387 cannot be converted to a BigInt because it is not an integer`

The live FX feed returns fractional toman-per-USD (IRR/10). The handler passed that float to `BigInt(fx.rate)`.

- Round rates to positive integers in `getTomanPerUsd` via `toIntegerTomanPerUsd`
- Truncate/round micro-USD and FX inputs in `getPlatformFinancials` before `BigInt`
- Regression tests for the fractional-rate case

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/services/aico/fxService.test.ts
```


Made with [Cursor](https://cursor.com)