### PR TITLE
fix(aico): show billing wallet switcher on Home before first message

### DIFF
--- a/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
+++ b/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
@@ -11,6 +11,11 @@ export const useBusinessChatInputAlerts = (): ReactNode => null;
 /**
  * Aico billing source switcher sits next to the send area so users can pick
  * personal vs org credit (separate balances) while chatting.
+ *
+ * Conversation ChatInput injects this automatically. Home and other surfaces
+ * that render DesktopChatInput directly must pass
+ * `sendAreaPrefix={getBusinessChatInputSendAreaPrefix()}` so the wallet can be
+ * chosen before the first message.
  */
 export const getBusinessChatInputSendAreaPrefix = (sendAreaPrefix?: ReactNode): ReactNode => {
   const switcher = createElement(BillingSourceSwitcher);

--- a/src/features/Home/InputArea/EditorInput.test.tsx
+++ b/src/features/Home/InputArea/EditorInput.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import HomeEditorInput from './EditorInput';
+
+const getBusinessChatInputSendAreaPrefix = vi.fn(() => <div data-testid="aico-billing-switcher" />);
+
+vi.mock('@/business/client/hooks/useBusinessChatInputSendAreaPrefix', () => ({
+  getBusinessChatInputSendAreaPrefix: (...args: unknown[]) =>
+    getBusinessChatInputSendAreaPrefix(...args),
+}));
+
+vi.mock('@/features/ChatInput/ActionBar', () => ({
+  default: () => <div data-testid="action-bar" />,
+}));
+
+vi.mock('@/features/ChatInput', () => ({
+  ChatInputProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DesktopChatInput: ({ sendAreaPrefix }: { sendAreaPrefix?: React.ReactNode }) => (
+    <div data-testid="desktop-chat-input">{sendAreaPrefix}</div>
+  ),
+}));
+
+vi.mock('./ModeSelect', () => ({
+  default: () => <div data-testid="mode-select" />,
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: { setState: vi.fn() },
+}));
+
+describe('HomeEditorInput billing switcher', () => {
+  beforeEach(() => {
+    getBusinessChatInputSendAreaPrefix.mockClear();
+  });
+
+  it('exposes the billing source switcher before the first message', () => {
+    render(
+      <HomeEditorInput
+        initialValue=""
+        isAgentConfigLoading={false}
+        loading={false}
+        mode="chat"
+        send={async () => {}}
+        onModeChange={() => {}}
+        onValueChange={() => {}}
+      />,
+    );
+
+    expect(getBusinessChatInputSendAreaPrefix).toHaveBeenCalled();
+    expect(screen.getByTestId('aico-billing-switcher')).toBeInTheDocument();
+  });
+});

--- a/src/features/Home/InputArea/EditorInput.tsx
+++ b/src/features/Home/InputArea/EditorInput.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { PlusIcon } from 'lucide-react';
 import { memo, type ReactNode, useMemo } from 'react';
 
+import { getBusinessChatInputSendAreaPrefix } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
 import {
   type ActionKeys,
   ChatInputProvider,
@@ -92,6 +93,7 @@ const HomeEditorInput = memo<HomeEditorInputProps>(
           initialContent={initialValue}
           inputContainerProps={inputContainerProps}
           placeholder={placeholder}
+          sendAreaPrefix={getBusinessChatInputSendAreaPrefix()}
           showControlBar={false}
           leftContent={
             <Flexbox horizontal align={'center'} gap={2}>


### PR DESCRIPTION
#### 🔗 Related Issue
- Fixes #80
- Plane: [AICO-51](https://plane.panafor.com/panaforai/browse/AICO-51)

#### 📝 Summary
- Home composer renders `DesktopChatInput` directly and skipped `sendAreaPrefix`, so the personal/org billing switcher never appeared before the first message
- Wire `getBusinessChatInputSendAreaPrefix()` into Home `EditorInput` and add a regression test

#### 🧪 Test plan
- [ ] Open Home with a user that has personal + org credit; switcher is visible before sending
- [ ] Select org (or personal), send first message; spend uses the selected source
- [ ] `bun run check --lint --test src/features/Home/InputArea/EditorInput.tsx src/features/Home/InputArea/EditorInput.test.tsx`


Made with [Cursor](https://cursor.com)