### PR TITLE
📝 docs(auth): align OAuth env names in .env.example with Better Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -400,17 +400,19 @@ AICO_TOMAN_PER_USD=50000
 # Authorized redirect URIs:
 # - Development: http://localhost:3210/api/auth/callback/google
 # - Production: https://yourdomain.com/api/auth/callback/google
-# GOOGLE_CLIENT_ID=xxxxx.apps.googleusercontent.com
-# GOOGLE_CLIENT_SECRET=GOCSPX-xxxxxxxxxxxxxxxxxxxx
+# AUTH_GOOGLE_ID=xxxxx.apps.googleusercontent.com
+# AUTH_GOOGLE_SECRET=GOCSPX-xxxxxxxxxxxxxxxxxxxx
 
 # GitHub OAuth Configuration (for Better-Auth)
 # Get credentials from: https://github.com/settings/developers
 # Create a new OAuth App with:
-# Authorized callback URL:
+# Homepage URL: http://localhost:3210 (or your APP_URL)
+# Authorization callback URL:
 # - Development: http://localhost:3210/api/auth/callback/github
 # - Production: https://yourdomain.com/api/auth/callback/github
-# GITHUB_CLIENT_ID=Ov23xxxxxxxxxxxxx
-# GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+# AUTH_SSO_PROVIDERS=github
+# AUTH_GITHUB_ID=Ov23xxxxxxxxxxxxx
+# AUTH_GITHUB_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # AWS Cognito OAuth Configuration (for Better-Auth)
 # Get credentials from: https://console.aws.amazon.com/cognito


### PR DESCRIPTION
## Summary

- Replace obsolete `GITHUB_CLIENT_*` / `GOOGLE_CLIENT_*` placeholders in `.env.example` with the Better Auth names (`AUTH_GITHUB_*`, `AUTH_GOOGLE_*`)
- Document Homepage URL and `AUTH_SSO_PROVIDERS=github` for GitHub OAuth App setup

## Test plan

- [x] No tests needed (docs / example env only)
- [ ] Confirm `.env.example` names match `packages/env/src/auth.ts` and `src/libs/better-auth/sso/providers/github.ts`

#### 🔗 Related Issue

Fixes #82

Plane: [AICO-52](https://plane.panafor.com/panaforai/browse/AICO-52/)


Made with [Cursor](https://cursor.com)