### PR TITLE
✨ feat(i18n): apply Vazirmatn globally when locale is fa-IR

### DIFF
--- a/src/features/AuthShell/AuthThemeLite.tsx
+++ b/src/features/AuthShell/AuthThemeLite.tsx
@@ -2,7 +2,7 @@
 
 import 'antd/dist/reset.css';
 
-import { ConfigProvider, ThemeProvider } from '@lobehub/ui';
+import { ConfigProvider, FontLoader, ThemeProvider } from '@lobehub/ui';
 import { ToastHost } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { domMax, LazyMotion } from 'motion/react';
@@ -12,6 +12,7 @@ import { memo } from 'react';
 
 import AntdStaticMethods from '@/components/AntdStaticMethods';
 import { useIsDark } from '@/hooks/useIsDark';
+import { useLocaleThemeFont } from '@/hooks/useLocaleThemeFont';
 import Image from '@/libs/next/Image';
 import Link from '@/libs/next/Link';
 
@@ -22,6 +23,7 @@ interface AuthThemeLiteProps extends PropsWithChildren {
 const AuthThemeLite = memo<AuthThemeLiteProps>(({ children, globalCDN }) => {
   const isDark = useIsDark();
   const currentAppearance = isDark ? 'dark' : 'light';
+  const { fontFamily, fontURL } = useLocaleThemeFont();
 
   return (
     <ThemeProvider
@@ -32,8 +34,12 @@ const AuthThemeLite = memo<AuthThemeLiteProps>(({ children, globalCDN }) => {
       style={{ height: '100%' }}
       theme={{
         cssVar: { key: 'lobe-vars' },
+        token: {
+          fontFamily,
+        },
       }}
     >
+      {!!fontURL && <FontLoader url={fontURL} />}
       <App style={{ height: '100%' }}>
         <AntdStaticMethods />
         <ConfigProvider

--- a/src/features/WorkbenchShell/WorkbenchTheme.tsx
+++ b/src/features/WorkbenchShell/WorkbenchTheme.tsx
@@ -3,6 +3,7 @@
 import 'antd/dist/reset.css';
 
 import ConfigProvider from '@lobehub/ui/es/ConfigProvider/index';
+import FontLoader from '@lobehub/ui/es/FontLoader/index';
 import ThemeProvider from '@lobehub/ui/es/ThemeProvider/index';
 import { App } from 'antd';
 import { domMax, LazyMotion } from 'motion/react';
@@ -11,12 +12,14 @@ import { memo, type PropsWithChildren } from 'react';
 
 import AntdStaticMethods from '@/components/AntdStaticMethods';
 import { useIsDark } from '@/hooks/useIsDark';
+import { useLocaleThemeFont } from '@/hooks/useLocaleThemeFont';
 import Image from '@/libs/next/Image';
 import Link from '@/libs/next/Link';
 
 const WorkbenchTheme = memo<PropsWithChildren>(({ children }) => {
   const isDark = useIsDark();
   const appearance = isDark ? 'dark' : 'light';
+  const { fontFamily, fontURL } = useLocaleThemeFont();
 
   return (
     <ThemeProvider
@@ -25,8 +28,14 @@ const WorkbenchTheme = memo<PropsWithChildren>(({ children }) => {
       defaultAppearance={appearance}
       defaultThemeMode={appearance}
       style={{ height: '100%', minHeight: '100dvh', width: '100%' }}
-      theme={{ cssVar: { key: 'lobe-vars' } }}
+      theme={{
+        cssVar: { key: 'lobe-vars' },
+        token: {
+          fontFamily,
+        },
+      }}
     >
+      {!!fontURL && <FontLoader url={fontURL} />}
       <App style={{ height: '100%' }}>
         <AntdStaticMethods />
         <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>

--- a/src/hooks/useLocaleThemeFont.ts
+++ b/src/hooks/useLocaleThemeFont.ts
@@ -1,0 +1,50 @@
+import { useTheme } from 'antd-style';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { resolveUILocale } from '@/libs/getUILocaleAndResources.utils';
+import {
+  getLocaleFontConfig,
+  mergeThemeFontFamily,
+} from '@/utils/client/localeFont';
+
+export interface UseLocaleThemeFontOptions {
+  customFontFamily?: string;
+  customFontURL?: string;
+  /** When set, used instead of i18n/document locale (e.g. global store language with `'auto'`). */
+  language?: string;
+}
+
+export interface LocaleThemeFontResult {
+  fontFamily: string | undefined;
+  fontURL: string | undefined;
+}
+
+export const useLocaleThemeFont = (
+  options: UseLocaleThemeFontOptions = {},
+): LocaleThemeFontResult => {
+  const { customFontFamily, customFontURL, language } = options;
+  const antdTheme = useTheme();
+  const { i18n } = useTranslation();
+
+  const resolvedLocale = useMemo(() => {
+    if (language !== undefined) {
+      return resolveUILocale(language).normalizedLocale;
+    }
+
+    const lang =
+      i18n.resolvedLanguage ||
+      i18n.language ||
+      (typeof document !== 'undefined' ? document.documentElement.lang : undefined);
+
+    return resolveUILocale(lang || 'auto').normalizedLocale;
+  }, [i18n.language, i18n.resolvedLanguage, language]);
+
+  const localeFont = getLocaleFontConfig(resolvedLocale);
+  const primaryFontFamily = customFontFamily ?? localeFont?.fontFamily;
+
+  return {
+    fontFamily: mergeThemeFontFamily(primaryFontFamily, antdTheme.fontFamily),
+    fontURL: customFontURL ?? localeFont?.fontURL,
+  };
+};

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -5,7 +5,7 @@ import 'antd/dist/reset.css';
 import { type NeutralColors, type PrimaryColors } from '@lobehub/ui';
 import { ConfigProvider, FontLoader, ThemeProvider } from '@lobehub/ui';
 import { ConfigProvider as AntdConfigProvider } from 'antd';
-import { createStaticStyles, cx, useTheme } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import * as m from 'motion/react-m';
 import { type ReactNode } from 'react';
 import { memo, useEffect, useState } from 'react';
@@ -14,6 +14,7 @@ import AntdStaticMethods from '@/components/AntdStaticMethods';
 import Link from '@/components/Link';
 import { LOBE_THEME_NEUTRAL_COLOR, LOBE_THEME_PRIMARY_COLOR } from '@/const/theme';
 import { useIsDark } from '@/hooks/useIsDark';
+import { useLocaleThemeFont } from '@/hooks/useLocaleThemeFont';
 import { getUILocaleAndResources } from '@/libs/getUILocaleAndResources';
 import type { UILocaleResources } from '@/libs/getUILocaleAndResources.utils';
 import { resolveUILocale } from '@/libs/getUILocaleAndResources.utils';
@@ -105,7 +106,7 @@ const AppTheme = memo<AppThemeProps>(
   }) => {
     const language = useGlobalStore(systemStatusSelectors.language);
     const documentDir = getDocumentDirection(language);
-    const antdTheme = useTheme();
+    const { fontFamily, fontURL } = useLocaleThemeFont({ customFontFamily, customFontURL, language });
     const isDark = useIsDark();
 
     const [primaryColor, neutralColor, animationMode] = useUserStore((s) => [
@@ -161,15 +162,13 @@ const AppTheme = memo<AppThemeProps>(
         theme={{
           cssVar: { key: 'lobe-vars' },
           token: {
-            fontFamily: customFontFamily
-              ? `${customFontFamily},${antdTheme.fontFamily}`
-              : undefined,
+            fontFamily,
             motion: animationMode !== 'disabled',
             motionUnit: animationMode === 'agile' ? 0.05 : 0.1,
           },
         }}
       >
-        {!!customFontURL && <FontLoader url={customFontURL} />}
+        {!!fontURL && <FontLoader url={fontURL} />}
         <GlobalStyle />
         <AntdStaticMethods />
         <ConfigProvider

--- a/src/utils/client/localeFont.test.ts
+++ b/src/utils/client/localeFont.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLocaleFontConfig, mergeThemeFontFamily } from './localeFont';
+
+describe('getLocaleFontConfig', () => {
+  it('returns Vazirmatn config for fa-IR', () => {
+    const config = getLocaleFontConfig('fa-IR');
+
+    expect(config).toEqual({
+      fontFamily: 'Vazirmatn',
+      fontURL: 'https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn@v33.003/Vazirmatn-font-face.css',
+    });
+  });
+
+  it('returns Vazirmatn config for fa prefix', () => {
+    expect(getLocaleFontConfig('fa')?.fontFamily).toBe('Vazirmatn');
+  });
+
+  it('returns null for en-US', () => {
+    expect(getLocaleFontConfig('en-US')).toBeNull();
+  });
+
+  it('returns null for zh-CN', () => {
+    expect(getLocaleFontConfig('zh-CN')).toBeNull();
+  });
+});
+
+describe('mergeThemeFontFamily', () => {
+  it('prepends primary font to the base stack', () => {
+    expect(mergeThemeFontFamily('Vazirmatn', 'Geist,sans-serif')).toBe('Vazirmatn,Geist,sans-serif');
+  });
+
+  it('returns undefined when primary font is absent', () => {
+    expect(mergeThemeFontFamily(undefined, 'Geist,sans-serif')).toBeUndefined();
+  });
+});

--- a/src/utils/client/localeFont.ts
+++ b/src/utils/client/localeFont.ts
@@ -1,0 +1,24 @@
+import { type Locales, normalizeLocale } from '@/locales/resources';
+
+export interface LocaleFontConfig {
+  fontFamily: string;
+  fontURL: string;
+}
+
+export const LOCALE_FONT_CONFIG: Partial<Record<Locales, LocaleFontConfig>> = {
+  'fa-IR': {
+    fontFamily: 'Vazirmatn',
+    fontURL: 'https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn@v33.003/Vazirmatn-font-face.css',
+  },
+};
+
+export const getLocaleFontConfig = (locale?: string): LocaleFontConfig | null => {
+  const normalized = normalizeLocale(locale);
+
+  return LOCALE_FONT_CONFIG[normalized] ?? null;
+};
+
+export const mergeThemeFontFamily = (
+  primary: string | undefined,
+  baseFontFamily: string,
+): string | undefined => (primary ? `${primary},${baseFontFamily}` : undefined);


### PR DESCRIPTION
## Summary

- Add locale-aware font config mapping fa-IR to Vazirmatn
- Introduce useLocaleThemeFont hook for shared theme token + FontLoader wiring
- Wire into AppTheme, AuthThemeLite, and WorkbenchTheme
- Other locales keep the default Geist/CJK stack unchanged

## Test

- [x] Added unit tests for localeFont utility
- [x] bunx vitest run src/utils/client/localeFont.test.ts
- [ ] Manual: switch language to فارسی and verify Vazirmatn across UI
- [ ] Manual: switch back to en-US / zh-CN and verify default fonts

#### 🔗 Related Issue

Fixes #92

Plane: [AICO-54](https://plane.panafor.com/panaforai/browse/AICO-54)

Made with [Cursor](https://cursor.com)