### PR TITLE
🌐 i18n(aico): default to Persian and limit visible language picker

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -55,7 +55,7 @@
             locale = localStorage.getItem('i18nextLng');
           } catch (_) {}
         }
-        if (!locale) locale = navigator.language || 'en-US';
+        if (!locale) locale = navigator.language || 'fa-IR';
         document.documentElement.lang = locale;
         var rtl = ['ar', 'arc', 'dv', 'fa', 'ha', 'he', 'khw', 'ks', 'ku', 'ps', 'ur', 'yi'];
         document.documentElement.dir =

--- a/apps/desktop/popup.html
+++ b/apps/desktop/popup.html
@@ -55,7 +55,7 @@
           document.documentElement.setAttribute('data-theme', resolvedTheme);
         }
         var urlParams = new URLSearchParams(window.location.search);
-        var locale = urlParams.get('lng') || navigator.language || 'en-US';
+        var locale = urlParams.get('lng') || navigator.language || 'fa-IR';
         document.documentElement.lang = locale;
         var rtl = ['ar', 'arc', 'dv', 'fa', 'ha', 'he', 'khw', 'ks', 'ku', 'ps', 'ur', 'yi'];
         document.documentElement.dir =

--- a/apps/desktop/src/common/systemLanguage.test.ts
+++ b/apps/desktop/src/common/systemLanguage.test.ts
@@ -34,8 +34,8 @@ describe('normalizeSystemLanguage', () => {
     expect(normalizeSystemLanguage(input)).toBe(expected);
   });
 
-  it.each([undefined, '', 'xx-XX'])('falls back to en-US for %s', (input) => {
-    expect(normalizeSystemLanguage(input)).toBe('en-US');
+  it.each([undefined, '', 'xx-XX'])('falls back to fa-IR for %s', (input) => {
+    expect(normalizeSystemLanguage(input)).toBe('fa-IR');
   });
 });
 

--- a/apps/desktop/src/common/systemLanguage.ts
+++ b/apps/desktop/src/common/systemLanguage.ts
@@ -1,6 +1,6 @@
 export const SYSTEM_LANGUAGE_ARG_PREFIX = '--lobe-system-language=';
 
-export const FALLBACK_LOCALE = 'en-US';
+export const FALLBACK_LOCALE = 'fa-IR';
 
 const SUPPORTED_LOCALES = [
   'ar',

--- a/index.auth.html
+++ b/index.auth.html
@@ -69,8 +69,8 @@
         var hl = new URLSearchParams(location.search).get('hl');
         var m = document.cookie.match(/(?:^|;\s*)LOBE_LOCALE=([^;]*)/);
         var cookie = m ? decodeURIComponent(m[1]) : '';
-        var locale = hl || cookie || navigator.language || 'en-US';
-        if (locale === 'auto') locale = navigator.language || 'en-US';
+        var locale = hl || cookie || 'fa-IR';
+        if (locale === 'auto') locale = navigator.language || 'fa-IR';
         if (hl && !cookie) {
           document.cookie =
             'LOBE_LOCALE=' + encodeURIComponent(hl) + ';path=/;max-age=7776000;SameSite=Lax';

--- a/index.html
+++ b/index.html
@@ -99,8 +99,8 @@
         var hl = new URLSearchParams(location.search).get('hl');
         var m = document.cookie.match(/(?:^|;\s*)LOBE_LOCALE=([^;]*)/);
         var cookie = m ? decodeURIComponent(m[1]) : '';
-        var locale = hl || cookie || navigator.language || 'en-US';
-        if (locale === 'auto') locale = navigator.language || 'en-US';
+        var locale = hl || cookie || 'fa-IR';
+        if (locale === 'auto') locale = navigator.language || 'fa-IR';
         if (hl && !cookie) {
           document.cookie =
             'LOBE_LOCALE=' + encodeURIComponent(hl) + ';path=/;max-age=7776000;SameSite=Lax';

--- a/index.mobile.html
+++ b/index.mobile.html
@@ -47,8 +47,8 @@
         var hl = new URLSearchParams(location.search).get('hl');
         var m = document.cookie.match(/(?:^|;\s*)LOBE_LOCALE=([^;]*)/);
         var cookie = m ? decodeURIComponent(m[1]) : '';
-        var locale = hl || cookie || navigator.language || 'en-US';
-        if (locale === 'auto') locale = navigator.language || 'en-US';
+        var locale = hl || cookie || 'fa-IR';
+        if (locale === 'auto') locale = navigator.language || 'fa-IR';
         if (hl && !cookie) {
           document.cookie =
             'LOBE_LOCALE=' + encodeURIComponent(hl) + ';path=/;max-age=7776000;SameSite=Lax';

--- a/packages/desktop-bridge/src/routeVariants.ts
+++ b/packages/desktop-bridge/src/routeVariants.ts
@@ -1,6 +1,6 @@
 // Shared route variants utilities for desktop and web builds
 
-export const DEFAULT_LANG = 'en-US';
+export const DEFAULT_LANG = 'fa-IR';
 
 // Supported locales (keep aligned with web resources)
 export const locales = [

--- a/packages/locales/src/create.ts
+++ b/packages/locales/src/create.ts
@@ -1,23 +1,23 @@
+import { BRANDING_CLOUD_NAME, BRANDING_EMAIL, BRANDING_NAME, ORG_NAME } from '@lobechat/const';
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
-import chat from '@/../locales/en-US/chat.json';
-import common from '@/../locales/en-US/common.json';
-import error from '@/../locales/en-US/error.json';
-import home from '@/../locales/en-US/home.json';
+import chat from '@/../locales/fa-IR/chat.json';
+import common from '@/../locales/fa-IR/common.json';
+import error from '@/../locales/fa-IR/error.json';
+import home from '@/../locales/fa-IR/home.json';
 import { DEFAULT_LANG } from '@/const/locale';
 import { getDebugConfig } from '@/envs/debug';
 // Sync load bundled fallback resources without Suspense on first render.
 // Use src/locales/default/*.ts as the runtime fallback source, then overlay
-// locales/en-US/*.json so dev-preview JSON can still customize English copy
+// locales/fa-IR/*.json so dev-preview JSON can still customize Persian copy
 // without dropping newly added default keys.
 import defaultChat from '@/locales/default/chat';
 import defaultCommon from '@/locales/default/common';
 import defaultError from '@/locales/default/error';
 import defaultHome from '@/locales/default/home';
-import { BRANDING_CLOUD_NAME, BRANDING_EMAIL, BRANDING_NAME, ORG_NAME } from '@lobechat/const';
 import { normalizeLocale } from '@/locales/resources';
 import { applyDocumentDirection } from '@/utils/client/applyDocumentDirection';
 import { isOnServerSide } from '@/utils/env';
@@ -86,11 +86,11 @@ export const createI18nNext = (lang?: string) => {
         defaultNS: ['error', 'common', 'chat'],
         fallbackLng: DEFAULT_LANG,
         initAsync,
-        // Keep init synchronous so components can render with bundled en-US resources
+        // Keep init synchronous so components can render with bundled fa-IR resources
         // before the user's actual language finishes loading in the background.
         ns: [],
 
-        // Preload default language (en-US) synchronously to avoid Suspense on first render
+        // Preload default language (fa-IR) synchronously to avoid Suspense on first render
         resources: {
           ...bundledLanguageResources,
         },
@@ -107,7 +107,7 @@ export const createI18nNext = (lang?: string) => {
           escapeValue: false,
         },
         // Re-render components when new language resources are loaded from backend,
-        // so preloaded en-US fallback gets replaced by the user's actual language.
+        // so preloaded fa-IR fallback gets replaced by the user's actual language.
         react: {
           bindI18nStore: 'added',
           useSuspense: false,

--- a/packages/locales/src/resources.test.ts
+++ b/packages/locales/src/resources.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { normalizeLocale } from './resources';
 
 describe('normalizeLocale', () => {
-  it('should return "en-US" when locale is undefined', () => {
-    expect(normalizeLocale()).toBe('en-US');
+  it('should return "fa-IR" when locale is undefined', () => {
+    expect(normalizeLocale()).toBe('fa-IR');
   });
 
   it('should return "zh-CN" when locale is "zh-CN"', () => {
@@ -42,8 +42,8 @@ describe('normalizeLocale', () => {
     expect(normalizeLocale('zh-TW')).toBe('zh-TW');
   });
 
-  it('should return the input locale for unknown locales', () => {
-    expect(normalizeLocale('unknown')).toBe('en-US');
+  it('should return the default locale for unknown locales', () => {
+    expect(normalizeLocale('unknown')).toBe('fa-IR');
     expect(normalizeLocale('fr')).toBe('fr-FR');
   });
 });

--- a/packages/locales/src/resources.ts
+++ b/packages/locales/src/resources.ts
@@ -53,7 +53,14 @@ type LocaleOptions = {
   value: Locales;
 }[];
 
+/** Locales shown in language pickers (others remain supported but hidden). */
+export const VISIBLE_LOCALES = ['fa-IR', 'en-US', 'fr-FR'] as const satisfies readonly Locales[];
+
 export const localeOptions: LocaleOptions = [
+  {
+    label: 'فارسی',
+    value: 'fa-IR',
+  },
   {
     label: 'English',
     value: 'en-US',
@@ -122,10 +129,10 @@ export const localeOptions: LocaleOptions = [
     label: 'Български',
     value: 'bg-BG',
   },
-  {
-    label: 'فارسی',
-    value: 'fa-IR',
-  },
 ] as LocaleOptions;
+
+export const visibleLocaleOptions = localeOptions.filter((option) =>
+  VISIBLE_LOCALES.includes(option.value),
+);
 
 export const supportLocales: string[] = [...locales, 'en', 'zh'];

--- a/src/app/spa-auth/[locale]/[[...path]]/route.ts
+++ b/src/app/spa-auth/[locale]/[[...path]]/route.ts
@@ -9,7 +9,7 @@ import { type AuthSPAServerConfig } from '@/types/spaServerConfig';
 import { buildSeoMeta } from './seoMeta';
 
 export function generateStaticParams() {
-  const staticLocales: Locales[] = ['en-US', 'zh-CN'];
+  const staticLocales: Locales[] = ['fa-IR', 'en-US'];
 
   return staticLocales.map((locale) => ({ locale }));
 }

--- a/src/app/spa-workbench/[locale]/[[...path]]/route.ts
+++ b/src/app/spa-workbench/[locale]/[[...path]]/route.ts
@@ -10,7 +10,7 @@ import { getServerGlobalConfig } from '@/server/globalConfig';
 import { type SPAClientEnv, type SPAServerConfig } from '@/types/spaServerConfig';
 
 export function generateStaticParams() {
-  const staticLocales: Locales[] = ['en-US', 'zh-CN'];
+  const staticLocales: Locales[] = ['fa-IR', 'en-US'];
 
   return staticLocales.map((locale) => ({ locale }));
 }

--- a/src/app/spa/[variants]/[[...path]]/route.ts
+++ b/src/app/spa/[variants]/[[...path]]/route.ts
@@ -16,7 +16,7 @@ import { RouteVariants } from '@/utils/server/routeVariants';
 
 export function generateStaticParams() {
   const mobileOptions = isDesktop ? [false] : [true, false];
-  const staticLocales: Locales[] = ['en-US', 'zh-CN'];
+  const staticLocales: Locales[] = ['fa-IR', 'en-US'];
 
   const variants: { variants: string }[] = [];
 

--- a/src/const/locale.ts
+++ b/src/const/locale.ts
@@ -1,6 +1,6 @@
 import { supportLocales } from '@/locales/resources';
 
-export const DEFAULT_LANG = 'en-US';
+export const DEFAULT_LANG = 'fa-IR';
 export const LOBE_LOCALE_COOKIE = 'LOBE_LOCALE';
 
 /**

--- a/src/features/AuthShell/AuthLangButton.tsx
+++ b/src/features/AuthShell/AuthLangButton.tsx
@@ -12,7 +12,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { LOBE_LOCALE_COOKIE } from '@/const/locale';
-import { localeOptions, normalizeLocale } from '@/locales/resources';
+import { normalizeLocale, visibleLocaleOptions } from '@/locales/resources';
 import { applyDocumentDirection } from '@/utils/client/applyDocumentDirection';
 
 const setCookieSimple = (key: string, value: string, days: number) => {
@@ -27,7 +27,7 @@ const AuthLangButton = memo<{ size?: number }>((props) => {
 
   const items = useMemo<DropdownMenuCheckboxItem[]>(
     () =>
-      localeOptions.map((item) => ({
+      visibleLocaleOptions.map((item) => ({
         checked: current === item.value,
         closeOnClick: true,
         key: item.value,

--- a/src/features/AuthShell/AuthLocale.tsx
+++ b/src/features/AuthShell/AuthLocale.tsx
@@ -4,6 +4,7 @@ import { ConfigProvider } from 'antd';
 import { memo, type PropsWithChildren, useEffect, useState } from 'react';
 import { isRtlLang } from 'rtl-detect';
 
+import { DEFAULT_LANG } from '@/const/locale';
 import { applyDocumentDirection } from '@/utils/client/applyDocumentDirection';
 
 import { createAuthI18n } from './createAuthI18n';
@@ -14,7 +15,7 @@ interface AuthLocaleProps extends PropsWithChildren {
 
 const AuthLocale = memo<AuthLocaleProps>(({ children, defaultLang }) => {
   const [i18n] = useState(() => createAuthI18n(defaultLang));
-  const [lang, setLang] = useState(defaultLang ?? 'en-US');
+  const [lang, setLang] = useState(defaultLang ?? DEFAULT_LANG);
 
   if (!i18n.instance.isInitialized) {
     i18n.init();

--- a/src/features/AuthShell/AuthShell.tsx
+++ b/src/features/AuthShell/AuthShell.tsx
@@ -6,6 +6,7 @@ import { memo, type PropsWithChildren } from 'react';
 import BusinessAuthProvider from '@/business/client/BusinessAuthProvider';
 import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyticsProviderWrapper';
 import { mapFeatureFlagsEnvToState } from '@/config/featureFlags';
+import { DEFAULT_LANG } from '@/const/locale';
 import type { AuthSPAServerConfig } from '@/types/spaServerConfig';
 
 import AuthContainer from './AuthContainer';
@@ -15,7 +16,7 @@ import AuthThemeLite from './AuthThemeLite';
 
 const AuthShell = memo<PropsWithChildren>(({ children }) => {
   const serverConfig = window.__SERVER_CONFIG__ as unknown as AuthSPAServerConfig | undefined;
-  const locale = document.documentElement.lang || 'en-US';
+  const locale = document.documentElement.lang || DEFAULT_LANG;
 
   return (
     <AuthLocale defaultLang={locale}>

--- a/src/features/AuthShell/createAuthI18n.test.ts
+++ b/src/features/AuthShell/createAuthI18n.test.ts
@@ -41,7 +41,6 @@ describe('createAuthI18n', () => {
   it('boots with Persian when document lang is already fa-IR', async () => {
     const { init, instance } = createAuthI18n('fa-IR');
     await init({ initAsync: false });
-    await instance.reloadResources(['fa-IR'], ['auth']);
 
     expect(instance.t('betterAuth.verifyPhone.title', { ns: 'auth' })).toBe(
       'فعال‌سازی دوره آزمایشی — تأیید موبایل',

--- a/src/features/AuthShell/createAuthI18n.ts
+++ b/src/features/AuthShell/createAuthI18n.ts
@@ -2,6 +2,12 @@ import i18next from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
+import faAuth from '@/../locales/fa-IR/auth.json';
+import faAuthError from '@/../locales/fa-IR/authError.json';
+import faCommon from '@/../locales/fa-IR/common.json';
+import faError from '@/../locales/fa-IR/error.json';
+import faMarketAuth from '@/../locales/fa-IR/marketAuth.json';
+import faOauth from '@/../locales/fa-IR/oauth.json';
 import { DEFAULT_LANG } from '@/const/locale';
 import defaultAuth from '@/locales/default/auth';
 import defaultAuthError from '@/locales/default/authError';
@@ -11,6 +17,14 @@ import defaultMarketAuth from '@/locales/default/marketAuth';
 import defaultOauth from '@/locales/default/oauth';
 import { normalizeLocale } from '@/locales/resources';
 
+const mergeNamespace = (
+  fallbackResources: Record<string, unknown>,
+  localeResources: Record<string, unknown>,
+) => ({
+  ...fallbackResources,
+  ...localeResources,
+});
+
 const defaultResources = {
   auth: defaultAuth,
   authError: defaultAuthError,
@@ -18,6 +32,15 @@ const defaultResources = {
   error: defaultError,
   marketAuth: defaultMarketAuth,
   oauth: defaultOauth,
+};
+
+const bundledDefaultResources = {
+  auth: mergeNamespace(defaultAuth, faAuth),
+  authError: mergeNamespace(defaultAuthError, faAuthError),
+  common: mergeNamespace(defaultCommon, faCommon),
+  error: mergeNamespace(defaultError, faError),
+  marketAuth: mergeNamespace(defaultMarketAuth, faMarketAuth),
+  oauth: mergeNamespace(defaultOauth, faOauth),
 };
 
 type AuthI18nNamespace = keyof typeof defaultResources;
@@ -120,7 +143,7 @@ export const createAuthI18n = (lang?: string) => {
         keySeparator: false,
         lng: lang,
         ns: [],
-        // Bundle en-US synchronously so the first render never suspends: with the
+        // Bundle fa-IR synchronously so the first render never suspends: with the
         // default useSuspense=true and no Suspense boundary above AuthShell, every
         // retry of the initial mount re-creates this instance and the auth SPA
         // remounts forever with a blank #root.
@@ -129,7 +152,7 @@ export const createAuthI18n = (lang?: string) => {
           bindI18nStore: 'added',
           useSuspense: false,
         },
-        resources: { [DEFAULT_LANG]: defaultResources },
+        resources: { [DEFAULT_LANG]: bundledDefaultResources },
         // Silence the Locize promotional console.info printed on init (i18next >= 25)
         showSupportNotice: false,
       });

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/translate.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/translate.ts
@@ -3,7 +3,7 @@ import { LanguagesIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { localeOptions } from '@/locales/resources';
+import { visibleLocaleOptions } from '@/locales/resources';
 
 import { useConversationStore } from '../../../../store';
 import { defineAction } from '../defineAction';
@@ -23,7 +23,7 @@ export const translateAction = defineAction({
 
     return useMemo(
       () => ({
-        children: localeOptions.map((i) => ({
+        children: visibleLocaleOptions.map((i) => ({
           handleClick: () => translateMessage(ctx.id, i.value),
           key: i.value,
           label: t(`lang.${i.value}`, { ns: 'common' }),

--- a/src/features/Conversation/hooks/useChatListActionsBar.tsx
+++ b/src/features/Conversation/hooks/useChatListActionsBar.tsx
@@ -19,7 +19,7 @@ import {
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { localeOptions } from '@/locales/resources';
+import { visibleLocaleOptions } from '@/locales/resources';
 
 const translateStyle = css`
   .ant-dropdown-menu-sub {
@@ -134,7 +134,7 @@ export const useChatListActionsBar = ({
         sfSymbol: 'square.and.arrow.up',
       },
       translate: {
-        children: localeOptions.map((i) => ({
+        children: visibleLocaleOptions.map((i) => ({
           key: i.value,
           label: t(`lang.${i.value}`),
         })),

--- a/src/features/DevDock/registerBuiltinItems.ts
+++ b/src/features/DevDock/registerBuiltinItems.ts
@@ -17,7 +17,7 @@ import {
 
 import { isDesktop } from '@/const/version';
 import FlagOverrideBadge from '@/features/DevFeatureFlagPanel/Badge';
-import { localeOptions } from '@/locales/resources';
+import { visibleLocaleOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 import type { LocaleMode } from '@/types/locale';
@@ -139,7 +139,7 @@ export const registerBuiltinDevDockItems = () => {
         { label: 'auto · Follow system', value: 'auto' },
         // Dev tool — the locale code is what you actually want to read here, the
         // native name is only there to tell the CJK variants apart at a glance.
-        ...localeOptions.map((item) => ({
+        ...visibleLocaleOptions.map((item) => ({
           label: `${item.value} · ${item.label}`,
           value: item.value,
         })),

--- a/src/features/User/UserPanel/LangButton.tsx
+++ b/src/features/User/UserPanel/LangButton.tsx
@@ -5,7 +5,7 @@ import { ChevronRight, Languages } from 'lucide-react';
 import { memo, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { localeOptions } from '@/locales/resources';
+import { visibleLocaleOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 import { electronStylish } from '@/styles/electron';
@@ -40,7 +40,7 @@ const LangButton = memo<{ placement?: DropdownMenuProps['placement']; size?: num
         type: 'checkbox',
       };
 
-      const localeItems = localeOptions.map<DropdownMenuCheckboxItem>((item) => ({
+      const localeItems = visibleLocaleOptions.map<DropdownMenuCheckboxItem>((item) => ({
         checked: language === item.value,
         closeOnClick: true,
         key: item.value,

--- a/src/features/WorkbenchShell/WorkbenchLocale.tsx
+++ b/src/features/WorkbenchShell/WorkbenchLocale.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { memo, type PropsWithChildren, useEffect, useState } from 'react';
 import { isRtlLang } from 'rtl-detect';
 
+import { DEFAULT_LANG } from '@/const/locale';
 import type { DayjsLocaleGlobEntry } from '@/utils/dayjsLocale';
 import { loadDayjsLocaleModule, normalizeDayjsLocale } from '@/utils/dayjsLocale';
 import { getAntdLocale } from '@/utils/locale';
@@ -46,7 +47,7 @@ interface WorkbenchLocaleProps extends PropsWithChildren {
 
 const WorkbenchLocale = memo<WorkbenchLocaleProps>(({ children, defaultLang }) => {
   const [i18n] = useState(() => createWorkbenchI18n(defaultLang));
-  const [lang, setLang] = useState(defaultLang ?? 'en-US');
+  const [lang, setLang] = useState(defaultLang ?? DEFAULT_LANG);
   const [antdLocale, setAntdLocale] = useState<any>();
 
   if (!i18n.instance.isInitialized) void i18n.init();
@@ -58,7 +59,7 @@ const WorkbenchLocale = memo<WorkbenchLocaleProps>(({ children, defaultLang }) =
       setAntdLocale(nextAntdLocale);
     };
 
-    void applyLocale(i18n.instance.language || defaultLang || 'en-US');
+    void applyLocale(i18n.instance.language || defaultLang || DEFAULT_LANG);
     i18n.instance.on('languageChanged', applyLocale);
 
     return () => {

--- a/src/features/WorkbenchShell/WorkbenchShell.tsx
+++ b/src/features/WorkbenchShell/WorkbenchShell.tsx
@@ -4,6 +4,7 @@ import { ModalHost, ToastHost, TooltipGroup } from '@lobehub/ui/base-ui';
 import { StyleProvider } from 'antd-style';
 import { memo, type PropsWithChildren } from 'react';
 
+import { DEFAULT_LANG } from '@/const/locale';
 import { ServerConfigStoreProvider } from '@/store/serverConfig/Provider';
 import type { SPAServerConfig } from '@/types/spaServerConfig';
 
@@ -12,7 +13,7 @@ import WorkbenchTheme from './WorkbenchTheme';
 
 const WorkbenchShell = memo<PropsWithChildren>(({ children }) => {
   const serverConfig: SPAServerConfig | undefined = window.__SERVER_CONFIG__;
-  const locale = document.documentElement.lang || 'en-US';
+  const locale = document.documentElement.lang || DEFAULT_LANG;
 
   return (
     <WorkbenchLocale defaultLang={locale}>

--- a/src/features/WorkbenchShell/createWorkbenchI18n.ts
+++ b/src/features/WorkbenchShell/createWorkbenchI18n.ts
@@ -2,6 +2,8 @@ import i18next from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
 import { initReactI18next } from 'react-i18next';
 
+import faCommon from '@/../locales/fa-IR/common.json';
+import faError from '@/../locales/fa-IR/error.json';
 import { DEFAULT_LANG } from '@/const/locale';
 import defaultCommon from '@/locales/default/common';
 import defaultError from '@/locales/default/error';
@@ -9,9 +11,17 @@ import { normalizeLocale } from '@/locales/resources';
 import { unwrapESMModule } from '@/utils/esm/unwrapESMModule';
 import { loadI18nNamespaceModule } from '@/utils/i18n/loadI18nNamespaceModule';
 
+const mergeNamespace = (
+  fallbackResources: Record<string, unknown>,
+  localeResources: Record<string, unknown>,
+) => ({
+  ...fallbackResources,
+  ...localeResources,
+});
+
 const defaultResources = {
-  common: defaultCommon,
-  error: defaultError,
+  common: mergeNamespace(defaultCommon, faCommon),
+  error: mergeNamespace(defaultError, faError),
 };
 
 const loadWorkbenchNamespace = async (lng: string, ns: string) => {

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -8,6 +8,7 @@ import { Component, type CSSProperties, lazy, memo, type PropsWithChildren, Susp
 
 import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyticsProviderWrapper';
 import { DragUploadProvider } from '@/components/DragUploadZone/DragUploadProvider';
+import { DEFAULT_LANG } from '@/const/locale';
 import { isDesktop } from '@/const/version';
 import { useDevDockMounted } from '@/hooks/useDevDockMounted';
 import AuthProvider from '@/layout/AuthProvider';
@@ -75,7 +76,7 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
   const postRenderReady = usePostRenderReady();
   const serverConfig: SPAServerConfig | undefined = window.__SERVER_CONFIG__;
 
-  const locale = document.documentElement.lang || 'en-US';
+  const locale = document.documentElement.lang || DEFAULT_LANG;
   const isMobile =
     (serverConfig?.isMobile ?? typeof __MOBILE__ !== 'undefined') ? __MOBILE__ : false;
 

--- a/src/routes/(main)/settings/common/features/Common/Common.tsx
+++ b/src/routes/(main)/settings/common/features/Common/Common.tsx
@@ -15,7 +15,7 @@ import { imageUrl } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { SettingsSearchAnchor } from '@/features/SettingsSearch/anchor';
 import { useSaveState } from '@/hooks/useSaveState';
-import { localeOptions } from '@/locales/resources';
+import { visibleLocaleOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
@@ -88,7 +88,7 @@ const Common = memo(() => {
               defaultValue={language}
               options={[
                 { label: t('settingCommon.lang.autoMode'), value: 'auto' },
-                ...localeOptions,
+                ...visibleLocaleOptions,
               ]}
               style={{
                 width: '50%',
@@ -166,7 +166,7 @@ const Common = memo(() => {
           <Flexbox horizontal justify={'flex-end'}>
             <Select
               allowClear
-              options={localeOptions}
+              options={visibleLocaleOptions}
               placeholder={t('settingCommon.responseLanguage.placeholder')}
               value={general?.responseLanguage || undefined}
               style={{

--- a/src/routes/onboarding/features/ResponseLanguageStep.tsx
+++ b/src/routes/onboarding/features/ResponseLanguageStep.tsx
@@ -8,7 +8,7 @@ import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { Locales } from '@/locales/resources';
-import { localeOptions, normalizeLocale } from '@/locales/resources';
+import { normalizeLocale, visibleLocaleOptions } from '@/locales/resources';
 import { useGlobalStore } from '@/store/global';
 import { useUserStore } from '@/store/user';
 
@@ -83,7 +83,7 @@ const ResponseLanguageStep = memo<ResponseLanguageStepProps>(({ onBack, onNext }
       <Flexbox horizontal align={'center'} gap={12}>
         <Select
           showSearch
-          options={localeOptions}
+          options={visibleLocaleOptions}
           size="large"
           value={value}
           optionRender={(item) => (

--- a/src/utils/i18n/loadI18nNamespaceModule.desktop.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.desktop.ts
@@ -28,6 +28,9 @@ export const loadI18nNamespaceModule = async (
   const { defaultLang, normalizeLocale, lng, ns } = params;
 
   if (lng === defaultLang) {
+    const localeMod = localeModules[getLocaleKey(defaultLang, ns)];
+    if (localeMod) return localeMod;
+
     const mod = defaultModules[getDefaultKey(ns)];
     if (!mod) throw new Error(`Missing default namespace: ${ns}`);
     return mod;

--- a/src/utils/i18n/loadI18nNamespaceModule.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.ts
@@ -8,7 +8,7 @@ export interface LoadI18nNamespaceModuleParams {
 export const loadI18nNamespaceModule = async (params: LoadI18nNamespaceModuleParams) => {
   const { defaultLang, normalizeLocale, lng, ns } = params;
 
-  if (lng === defaultLang) return import(`@/locales/default/${ns}`);
+  if (lng === defaultLang) return import(`@/../locales/${defaultLang}/${ns}.json`);
 
   try {
     return import(`@/../locales/${normalizeLocale(lng)}/${ns}.json`);

--- a/src/utils/i18n/loadI18nNamespaceModule.vite.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.vite.ts
@@ -25,6 +25,10 @@ export const loadI18nNamespaceModule = async (
   const { defaultLang, normalizeLocale, lng, ns } = params;
 
   if (lng === defaultLang) {
+    const localeKey = getLocaleKey(defaultLang, ns);
+    const loadLocale = localeLoaders[localeKey];
+    if (loadLocale) return loadLocale();
+
     const key = getDefaultKey(ns);
     const load = defaultLoaders[key];
     if (!load) throw new Error(`Missing default namespace: ${ns}`);

--- a/src/utils/locale.test.ts
+++ b/src/utils/locale.test.ts
@@ -26,41 +26,48 @@ describe('parseBrowserLanguage', () => {
     return headers;
   };
 
-  describe('when DEFAULT_LANG is en-US', () => {
+  describe('when DEFAULT_LANG is fa-IR', () => {
+    it('should return fa-IR regardless of accept-language header', () => {
+      expect(parseBrowserLanguage(createHeaders())).toBe('fa-IR');
+      expect(parseBrowserLanguage(createHeaders('en-US,en;q=0.9'))).toBe('fa-IR');
+      expect(parseBrowserLanguage(createHeaders('zh-CN,zh;q=0.9,en;q=0.8'))).toBe('fa-IR');
+    });
+  });
+
+  describe('when defaultLang is en-US', () => {
     it('should return en-US for empty accept-language header', () => {
       const headers = createHeaders();
-      expect(parseBrowserLanguage(headers)).toBe('en-US');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('en-US');
     });
 
     it('should return en-US for English language preference', () => {
       const headers = createHeaders('en-US,en;q=0.9');
-      expect(parseBrowserLanguage(headers)).toBe('en-US');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('en-US');
     });
 
     it('should handle Arabic language special case', () => {
       const headers = createHeaders('ar-SA,ar;q=0.9');
-      expect(parseBrowserLanguage(headers)).toBe('ar');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('ar');
     });
 
     it('should convert ar-EG to ar', () => {
       const headers = createHeaders('ar-EG,ar;q=0.9');
-      expect(parseBrowserLanguage(headers)).toBe('ar');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('ar');
     });
 
     it('should handle multiple language preferences', () => {
       const headers = createHeaders('zh-CN,zh;q=0.9,en;q=0.8');
-      // This expectation might need to be adjusted based on your locales configuration
-      expect(parseBrowserLanguage(headers)).toBe('zh-CN');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('zh-CN');
     });
 
     it('should normalize simplified Chinese script language preferences', () => {
       const headers = createHeaders('zh-Hans-CN,zh-Hans;q=0.9,en;q=0.8');
-      expect(parseBrowserLanguage(headers)).toBe('zh-CN');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('zh-CN');
     });
 
     it('should normalize traditional Chinese script language preferences', () => {
       const headers = createHeaders('zh-Hant-TW,zh-Hant;q=0.9,en;q=0.8');
-      expect(parseBrowserLanguage(headers)).toBe('zh-TW');
+      expect(parseBrowserLanguage(headers, 'en-US')).toBe('zh-TW');
     });
   });
 
@@ -74,12 +81,12 @@ describe('parseBrowserLanguage', () => {
   describe('error handling', () => {
     it('should handle invalid accept-language header format', () => {
       const headers = createHeaders('invalid-format');
-      expect(parseBrowserLanguage(headers)).toBe('en-US');
+      expect(parseBrowserLanguage(headers)).toBe('fa-IR');
     });
 
     it('should handle empty Headers object', () => {
       const headers = new Headers();
-      expect(parseBrowserLanguage(headers)).toBe('en-US');
+      expect(parseBrowserLanguage(headers)).toBe('fa-IR');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Set `DEFAULT_LANG` to `fa-IR` across web, auth, workbench, and desktop boot paths
- Bundle Persian locale resources synchronously on first paint to eliminate the English flash before fa-IR loads
- Expose only Persian, English, and French in language pickers via `visibleLocaleOptions`; other locales remain supported internally

## Test plan

- [x] Clear site cookies/localStorage and reload — UI should open in Persian with no English flash
- [x] Language picker shows only فارسی / English / Français (+ auto mode where applicable)
- [x] Switching to English or French still works
- [x] `bun run check` on changed locale files passes

#### 🔗 Related Issue

Fixes #95

Plane: [AICO-55](https://plane.panafor.com/panaforai/browse/AICO-55)


Made with [Cursor](https://cursor.com)