### PR TITLE
🐛 fix(aico): correct RTL tab indicator on platform and org pages

### DIFF
--- a/src/features/AicoPanels/panelStyles.ts
+++ b/src/features/AicoPanels/panelStyles.ts
@@ -82,17 +82,18 @@ export const aicoPanelStyles = createStaticStyles(({ css, cssVar }) => ({
     -webkit-overflow-scrolling: touch;
   `,
   tabs: css`
-    overflow-x: auto;
     width: 100%;
     min-width: 0;
 
-    -webkit-overflow-scrolling: touch;
-
-    /* Keep tab labels on one scrollable row on narrow screens */
+    /* Scroll on tablist so base-ui indicator offsets include scrollLeft */
     [role='tablist'] {
+      overflow-x: auto;
       flex-wrap: nowrap;
-      width: max-content;
-      min-width: 100%;
+
+      width: 100%;
+      max-width: 100%;
+
+      -webkit-overflow-scrolling: touch;
     }
   `,
 }));

--- a/src/features/OrgAdmin/OrgAdminMembers.tsx
+++ b/src/features/OrgAdmin/OrgAdminMembers.tsx
@@ -18,6 +18,7 @@ import {
   type FxTopupFormValues,
   resolveFxTopupPayload,
 } from '@/features/AicoBilling/FxTopupFields';
+import { aicoPanelStyles } from '@/features/AicoPanels';
 import { buildPhoneVerifyRedirectUrl, isValidIranianPhoneNumber } from '@/libs/better-auth/phone';
 import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
@@ -265,16 +266,18 @@ export const OrgAdminMembers = () => {
         />
       </div>
 
-      <Tabs
-        activeKey={tab}
-        items={[
-          { key: 'overview', label: t('org.tabs.overview') },
-          { key: 'members', label: t('org.tabs.members') },
-          { key: 'teams', label: t('org.tabs.teams') },
-          { key: 'wallet', label: t('org.tabs.wallet') },
-        ]}
-        onChange={setTab}
-      />
+      <div className={aicoPanelStyles.tabs}>
+        <Tabs
+          activeKey={tab}
+          items={[
+            { key: 'overview', label: t('org.tabs.overview') },
+            { key: 'members', label: t('org.tabs.members') },
+            { key: 'teams', label: t('org.tabs.teams') },
+            { key: 'wallet', label: t('org.tabs.wallet') },
+          ]}
+          onChange={setTab}
+        />
+      </div>
 
       {tab === 'overview' && (
         <Flexbox gap={16}>

--- a/src/styles/global.rtl.test.ts
+++ b/src/styles/global.rtl.test.ts
@@ -22,8 +22,12 @@ describe('global RTL control fixes', () => {
 
   it('maps Tabs selection indicators to physical left (Response Animation)', () => {
     expect(source).toContain("html[dir='rtl'] [role='tablist'] > [role='presentation']");
+    expect(source).toContain(":dir(rtl) [role='tablist'] > [role='presentation']");
     expect(source).toContain('left: var(--active-tab-left) !important');
-    expect(source).toContain('inset-inline-start: unset !important');
+    expect(source).toContain('inset-inline: auto !important');
+    expect(source).toContain(
+      'transition-property: left, inset-block-start, top, width, height, transform !important',
+    );
     // Prior broken formula used containing-block % and --active-tab-right
     expect(source).not.toContain('var(--active-tab-right)');
     expect(source).not.toContain('(var(--active-tab-width) - 100%)');
@@ -33,6 +37,7 @@ describe('global RTL control fixes', () => {
     expect(source).toContain(
       "html[dir='rtl'] [data-orientation] > [aria-hidden='true']:first-of-type",
     );
+    expect(source).toContain(":dir(rtl) [data-orientation] > [aria-hidden='true']:first-of-type");
     expect(source).toContain('left: var(--active-item-left) !important');
     expect(source).toContain('liberty/use-logical-spec');
   });

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -93,16 +93,20 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
   }
 
   /* stylelint-disable liberty/use-logical-spec -- indicator offsets are physical */
+  :dir(rtl) [role='tablist'] > [role='presentation'],
   html[dir='rtl'] [role='tablist'] > [role='presentation'] {
+    right: auto !important;
     left: var(--active-tab-left) !important;
-    inset-inline-start: unset !important;
-    transition-property: left, inset-block-start, width, height, transform;
+    inset-inline: auto !important;
+    transition-property: left, inset-block-start, top, width, height, transform !important;
   }
 
+  :dir(rtl) [data-orientation] > [aria-hidden='true']:first-of-type,
   html[dir='rtl'] [data-orientation] > [aria-hidden='true']:first-of-type {
+    right: auto !important;
     left: var(--active-item-left) !important;
-    inset-inline-start: unset !important;
-    transition-property: left, inset-block-start, width, height;
+    inset-inline: auto !important;
+    transition-property: left, inset-block-start, top, width, height, transform !important;
   }
   /* stylelint-enable liberty/use-logical-spec */
 `;

--- a/src/utils/client/applyDocumentDirection.test.ts
+++ b/src/utils/client/applyDocumentDirection.test.ts
@@ -18,4 +18,15 @@ describe('applyDocumentDirection', () => {
     applyDocumentDirection('en-US');
     expect(document.documentElement.dir).toBe('ltr');
   });
+
+  it('resolves auto locale from document lang for direction', () => {
+    document.documentElement.lang = 'fa-IR';
+
+    applyDocumentDirection('auto');
+    expect(document.documentElement.dir).toBe('rtl');
+
+    document.documentElement.lang = 'en-US';
+    applyDocumentDirection('auto');
+    expect(document.documentElement.dir).toBe('ltr');
+  });
 });

--- a/src/utils/client/applyDocumentDirection.ts
+++ b/src/utils/client/applyDocumentDirection.ts
@@ -1,9 +1,27 @@
 import { isRtlLang } from 'rtl-detect';
 
-export const getDocumentDirection = (lang?: string) => (isRtlLang(lang ?? '') ? 'rtl' : 'ltr');
+import { getSystemLanguage } from '@/utils/client/systemLanguage';
+
+const getDocumentLocale = () => {
+  if (typeof document === 'undefined') return;
+
+  return document.documentElement.lang || undefined;
+};
+
+/** Resolve LocaleMode `auto` to the effective language used for layout direction. */
+export const resolveDirectionLanguage = (lang?: string) => {
+  if (!lang || lang === 'auto') {
+    return getDocumentLocale() ?? getSystemLanguage();
+  }
+
+  return lang;
+};
+
+export const getDocumentDirection = (lang?: string) =>
+  isRtlLang(resolveDirectionLanguage(lang) ?? '') ? 'rtl' : 'ltr';
 
 export const applyDocumentDirection = (lang?: string) => {
-  if (typeof document === 'undefined' || !lang) return;
+  if (typeof document === 'undefined') return;
 
   document.documentElement.dir = getDocumentDirection(lang);
 };


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### How to Test

1. Set language to Persian (`fa-IR`).
2. Open `/platform` and `/org`.
3. Switch between tabs — the selection pill should move toward the selected tab (not the opposite direction).
4. Also verify Settings → Appearance animation tabs still track correctly under RTL.

#### 🔗 Related Issue

Fixes #113

Plane: [AICO-71](https://plane.panafor.com/panaforai/browse/AICO-71)

#### Description of Change

Under RTL, `@lobehub/ui` Tabs position the sliding indicator with physical `--active-tab-left` but logical `inset-inline-start`, which mirrors the pill away from the active tab on Platform/Org admin. Also fix `auto` locale resolving to LTR for document direction, and move horizontal scroll onto the tablist so indicator offsets stay in sync.

Made with [Cursor](https://cursor.com)