### PR TITLE
💄 style(aico): replace LobeHub leftovers in chat appearance branding

### DIFF
--- a/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/LinkIconPreview.tsx
+++ b/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/LinkIconPreview.tsx
@@ -4,9 +4,12 @@ import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { Trans } from 'react-i18next';
 
-import { OFFICIAL_SITE } from '@/const/url';
+import { OFFICIAL_DOMAIN, OFFICIAL_SITE } from '@/const/url';
 import { type LobeLinkKind } from '@/features/Conversation/Markdown/plugins/Link/parse';
 import LinkRender from '@/features/Conversation/Markdown/plugins/Link/Render';
+
+const SAMPLE_GITHUB_REPO = 'Panafor-Ai-Team/Aico';
+const SAMPLE_GITHUB_HREF = `https://github.com/${SAMPLE_GITHUB_REPO}`;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   bubble: css`
@@ -50,19 +53,13 @@ const LinkIconPreview = memo(() => (
       i18nKey="settingChatAppearance.linkIcon.previewMessage"
       ns="setting"
       components={{
-        repo: (
-          <SampleLink
-            href="https://github.com/lobehub/lobehub"
-            kind="github"
-            label="lobehub/lobehub"
-          />
-        ),
+        repo: <SampleLink href={SAMPLE_GITHUB_HREF} kind="github" label={SAMPLE_GITHUB_REPO} />,
         site: (
           <SampleLink
-            domain="lobehub.com"
+            domain={OFFICIAL_DOMAIN}
             href={OFFICIAL_SITE}
             kind="generic"
-            label="lobehub.com"
+            label={OFFICIAL_DOMAIN}
           />
         ),
       }}

--- a/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/index.tsx
+++ b/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BRANDING_NAME } from '@lobechat/business-const';
 import {
   Flexbox,
   FormGroup,
@@ -24,6 +25,9 @@ import ChatTransitionPreview from './ChatTransitionPreview';
 import HighlighterPreview from './HighlighterPreview';
 import LinkIconPreview from './LinkIconPreview';
 import MermaidPreview from './MermaidPreview';
+
+const brandedThemeLabel = (id: string, displayName: string) =>
+  id === 'lobe-theme' ? `${BRANDING_NAME} Theme` : displayName;
 
 const ChatAppearance = memo(() => {
   const { t } = useTranslation('setting');
@@ -177,7 +181,7 @@ const ChatAppearance = memo(() => {
             <Select
               value={general.highlighterTheme}
               options={highlighterThemes.map((item) => ({
-                label: item.displayName,
+                label: brandedThemeLabel(item.id, item.displayName),
                 value: item.id,
               }))}
               style={{
@@ -201,7 +205,7 @@ const ChatAppearance = memo(() => {
             <Select
               value={general.mermaidTheme}
               options={mermaidThemes.map((item) => ({
-                label: item.displayName,
+                label: brandedThemeLabel(item.id, item.displayName),
                 value: item.id,
               }))}
               style={{


### PR DESCRIPTION
<!-- Brief and heads-up -->

Replace remaining LobeHub branding in chat appearance settings with Aico defaults.

| Before | After |
| ------ | ----- |
| Link preview showed `lobehub.com` / `lobehub/lobehub` | Official site domain + `Panafor-Ai-Team/Aico` |
| Highlighter/Mermaid option labeled **Lobe Theme** | **Aico Theme** via `BRANDING_NAME` |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### How to Test

1. Open Settings → Chat Appearance
2. Confirm the message-link icon preview no longer mentions LobeHub
3. Confirm Code Highlight Theme / Mermaid Theme default option reads **Aico Theme**

#### 🔗 Related Issue

Fixes #115

Plane: [AICO-72](https://plane.panafor.com/panaforai/browse/AICO-72)


Made with [Cursor](https://cursor.com)