### PR TITLE
🐛 fix(aico): stop prompting for custom DeepSeek API keys

### DIFF
--- a/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
+++ b/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
@@ -163,7 +163,9 @@ describe('getServerGlobalConfig', () => {
 
     expect(providerConfig[ModelProvider.LobeHub]).toBeUndefined();
     expect(providerConfig[ModelProvider.OpenAI]).toBeUndefined();
-    expect(providerConfig[ModelProvider.DeepSeek].enabled).toBe(true);
+    // Aico: native DeepSeek BYOK off; managed OpenRouter on.
+    expect(providerConfig[ModelProvider.DeepSeek].enabled).toBe(false);
+    expect(providerConfig[ModelProvider.OpenRouter].enabled).toBe(true);
   });
 
   it('should enable gateway mode for business builds', async () => {

--- a/apps/server/src/globalConfig/index.ts
+++ b/apps/server/src/globalConfig/index.ts
@@ -47,7 +47,11 @@ export const getServerGlobalConfig = async () => {
       enabledKey: 'ENABLED_AWS_BEDROCK',
       modelListKey: 'AWS_BEDROCK_MODEL_LIST',
     },
+    // Native DeepSeek BYOK is not used — Aico chats via managed OpenRouter keys.
     deepseek: {
+      enabled: false,
+    },
+    openrouter: {
       enabled: true,
     },
     giteeai: {

--- a/locales/en-US/aico.json
+++ b/locales/en-US/aico.json
@@ -34,6 +34,8 @@
   "errors.TRIAL_PHONE_ALREADY_USED": "Trial has already been used with this phone number.",
   "errors.TRIAL_PHONE_BLOCKED": "This phone number is not eligible for trial.",
   "errors.TRIAL_REQUEST_LIMIT": "Trial request limit has been reached.",
+  "errors.managedKey.description": "Top up your wallet or use organization credit so a managed key can be provisioned. You do not need to enter a provider API key.",
+  "errors.managedKey.title": "{{brandName}} uses managed API keys",
   "errors.verifyPhoneAction": "Verify phone",
   "invite.accept": "Accept invitation",
   "invite.accepted": "You joined the organization",

--- a/locales/fa-IR/aico.json
+++ b/locales/fa-IR/aico.json
@@ -26,6 +26,8 @@
   "errors.TRIAL_PHONE_ALREADY_USED": "دوره آزمایشی با این شماره قبلاً استفاده شده است.",
   "errors.TRIAL_PHONE_BLOCKED": "این شماره برای دوره آزمایشی مجاز نیست.",
   "errors.TRIAL_REQUEST_LIMIT": "سقف درخواست‌های دوره آزمایشی تمام شده است.",
+  "errors.managedKey.description": "کیف پول را شارژ کنید یا از اعتبار سازمان استفاده کنید تا کلید مدیریت‌شده ساخته شود. نیازی به وارد کردن کلید API ارائه‌دهنده نیست.",
+  "errors.managedKey.title": "{{brandName}} از کلیدهای API مدیریت‌شده استفاده می‌کند",
   "errors.verifyPhoneAction": "تأیید موبایل",
   "invite.accept": "پذیرش دعوت‌نامه",
   "invite.accepted": "به سازمان پیوستید",

--- a/locales/zh-CN/aico.json
+++ b/locales/zh-CN/aico.json
@@ -34,6 +34,8 @@
   "errors.TRIAL_PHONE_ALREADY_USED": "该手机号已使用过试用。",
   "errors.TRIAL_PHONE_BLOCKED": "该手机号不符合试用条件。",
   "errors.TRIAL_REQUEST_LIMIT": "试用请求次数已达上限。",
+  "errors.managedKey.description": "请先充值钱包或使用组织额度以开通托管密钥。无需自行填写提供商 API Key。",
+  "errors.managedKey.title": "{{brandName}} 使用托管 API 密钥",
   "errors.verifyPhoneAction": "验证手机号",
   "invite.accept": "接受邀请",
   "invite.accepted": "你已加入组织",

--- a/packages/business/config/src/llm.ts
+++ b/packages/business/config/src/llm.ts
@@ -9,12 +9,10 @@ const enabledOpenCodeZenModels = opencodezenModels
 const providerDefaults: Partial<
   Record<ModelProvider, { enabled?: boolean; enabledModels?: string[]; fetchOnClient?: boolean }>
 > = {
-  [ModelProvider.Anthropic]: { enabled: true },
-  [ModelProvider.DeepSeek]: { enabled: true },
-  [ModelProvider.Google]: { enabled: true },
+  // Aico: only the managed OpenRouter surface is enabled by default (BYOK off).
+  [ModelProvider.OpenRouter]: { enabled: true },
   [ModelProvider.LMStudio]: { fetchOnClient: true },
   [ModelProvider.Ollama]: { fetchOnClient: true },
-  [ModelProvider.OpenAI]: { enabled: true },
   [ModelProvider.OpenCodeZen]: { enabledModels: enabledOpenCodeZenModels },
 };
 

--- a/packages/business/const/src/llm.ts
+++ b/packages/business/const/src/llm.ts
@@ -1,7 +1,9 @@
 export const DEFAULT_EMBEDDING_PROVIDER = 'openai';
 
-export const DEFAULT_MODEL = 'deepseek-v4-pro';
-export const DEFAULT_PROVIDER = 'deepseek';
+/** Default chat model — OpenRouter id; billed via Aico managed wallet/org keys. */
+export const DEFAULT_MODEL = 'deepseek/deepseek-chat-v3.1';
+/** Managed provider surface (shown as Aico); never BYOK DeepSeek. */
+export const DEFAULT_PROVIDER = 'openrouter';
 export const DEFAULT_MINI_MODEL = 'gpt-5.4-mini';
 export const DEFAULT_MINI_PROVIDER = 'openai';
 

--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -15,7 +15,7 @@ export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
  * its own official provider) moves the sub-agent along with the main model
  * instead of leaving it pointed at a provider that build doesn't serve.
  */
-export const DEFAULT_SUB_AGENT_MODEL = 'deepseek-v4-flash';
+export const DEFAULT_SUB_AGENT_MODEL = 'deepseek/deepseek-chat-v3.1';
 
 /**
  * Resolve the model a sub-agent runs on from the spawning agent's

--- a/packages/locales/src/default/aico.ts
+++ b/packages/locales/src/default/aico.ts
@@ -15,6 +15,9 @@ export default {
   'errors.INVITE_NOT_FOUND': 'Invitation not found.',
   'errors.INVITE_NOT_PENDING': 'This invitation can no longer be accepted.',
   'errors.MANAGED_KEY_UNAVAILABLE': 'Managed key is unavailable. Please try again later.',
+  'errors.managedKey.description':
+    'Top up your wallet or use organization credit so a managed key can be provisioned. You do not need to enter a provider API key.',
+  'errors.managedKey.title': '{{brandName}} uses managed API keys',
   'errors.MEMBER_NOT_FOUND': 'Member not found.',
   'errors.MOCK_TOPUP_DISABLED': 'Mock topup is disabled in this environment.',
   'errors.MODEL_NOT_ALLOWED': 'You do not have access to this model.',

--- a/src/features/Conversation/Error/ChatInvalidApiKey.tsx
+++ b/src/features/Conversation/Error/ChatInvalidApiKey.tsx
@@ -7,10 +7,14 @@ import urlJoin from 'url-join';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
+import { useClientDataSWR } from '@/libs/swr';
+import { lambdaClient } from '@/libs/trpc/client';
 import { type GlobalLLMProviderKey } from '@/types/user/settings/modelProvider';
 
 import { useConversationStore } from '../store';
 import BaseErrorForm from './BaseErrorForm';
+import { isAicoManagedProviderMode } from './isAicoManagedProviderMode';
+import ManagedKeyError from './ManagedKeyError';
 
 interface ChatInvalidAPIKeyProps {
   id: string;
@@ -21,6 +25,13 @@ const ChatInvalidAPIKey = memo<ChatInvalidAPIKeyProps>(({ id, provider }) => {
   const navigate = useWorkspaceAwareNavigate();
   const [deleteMessage] = useConversationStore((s) => [s.deleteMessage]);
   const providerName = useProviderName(provider as GlobalLLMProviderKey);
+
+  const { data: managedStatus } = useClientDataSWR('aico-provider-status', () =>
+    lambdaClient.aicoBilling.getManagedProviderStatus.query(),
+  );
+  if (isAicoManagedProviderMode(managedStatus?.managed)) {
+    return <ManagedKeyError onNavigate={() => deleteMessage(id)} />;
+  }
 
   return (
     <BaseErrorForm

--- a/src/features/Conversation/Error/ManagedKeyError.tsx
+++ b/src/features/Conversation/Error/ManagedKeyError.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { BRANDING_NAME } from '@lobechat/business-const';
+import { Button } from '@lobehub/ui/base-ui';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+
+import BaseErrorForm from './BaseErrorForm';
+
+interface ManagedKeyErrorProps {
+  /** Called after navigating away (e.g. delete the error message). */
+  onNavigate?: () => void;
+}
+
+/**
+ * Replaces the BYOK "enter custom API key" unlock card for Aico managed mode.
+ * Chat uses server-provisioned OpenRouter keys from wallet top-up / org allocate.
+ */
+const ManagedKeyError = memo<ManagedKeyErrorProps>(({ onNavigate }) => {
+  const { t } = useTranslation('aico');
+  const navigate = useWorkspaceAwareNavigate();
+
+  return (
+    <BaseErrorForm
+      avatar={<ProductLogo size={40} type={'flat'} />}
+      desc={t('errors.managedKey.description')}
+      title={t('errors.managedKey.title', { brandName: BRANDING_NAME })}
+      action={
+        <Button
+          type={'primary'}
+          onClick={() => {
+            navigate('/wallet');
+            onNavigate?.();
+          }}
+        >
+          {t('nav.wallet')}
+        </Button>
+      }
+    />
+  );
+});
+
+ManagedKeyError.displayName = 'ManagedKeyError';
+
+export default ManagedKeyError;

--- a/src/features/Conversation/Error/isAicoManagedProviderMode.test.ts
+++ b/src/features/Conversation/Error/isAicoManagedProviderMode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAicoManagedProviderMode } from './isAicoManagedProviderMode';
+
+describe('isAicoManagedProviderMode', () => {
+  it('defaults to managed when status is unknown', () => {
+    expect(isAicoManagedProviderMode(undefined)).toBe(true);
+  });
+
+  it('respects explicit managed flag', () => {
+    expect(isAicoManagedProviderMode(true)).toBe(true);
+    expect(isAicoManagedProviderMode(false)).toBe(false);
+  });
+});

--- a/src/features/Conversation/Error/isAicoManagedProviderMode.ts
+++ b/src/features/Conversation/Error/isAicoManagedProviderMode.ts
@@ -1,0 +1,4 @@
+/**
+ * Aico fail-closed: until the API says unmanaged, never show BYOK unlock UI.
+ */
+export const isAicoManagedProviderMode = (managed: boolean | undefined): boolean => managed ?? true;

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
@@ -8,8 +8,12 @@ import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import BaseErrorForm from '@/features/Conversation/Error/BaseErrorForm';
+import { isAicoManagedProviderMode } from '@/features/Conversation/Error/isAicoManagedProviderMode';
+import ManagedKeyError from '@/features/Conversation/Error/ManagedKeyError';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
+import { useClientDataSWR } from '@/libs/swr';
+import { lambdaClient } from '@/libs/trpc/client';
 import { type GlobalLLMProviderKey } from '@/types/user/settings/modelProvider';
 
 interface GenerationInvalidAPIKeyProps {
@@ -21,6 +25,13 @@ const GenerationInvalidAPIKey = memo<GenerationInvalidAPIKeyProps>(({ provider, 
   const { t } = useTranslation(['modelProvider', 'error']);
   const navigate = useWorkspaceAwareNavigate();
   const providerName = useProviderName(provider as GlobalLLMProviderKey);
+
+  const { data: managedStatus } = useClientDataSWR('aico-provider-status', () =>
+    lambdaClient.aicoBilling.getManagedProviderStatus.query(),
+  );
+  if (isAicoManagedProviderMode(managedStatus?.managed)) {
+    return <ManagedKeyError onNavigate={onNavigate} />;
+  }
 
   return (
     <BaseErrorForm


### PR DESCRIPTION
#### 💥 Change Type
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)

#### 🔗 Related Issue

Fixes #117

Plane: [AICO-73](https://plane.panafor.com/panaforai/browse/AICO-73)

#### Description of Change

Aico users were shown the BYOK unlock card (“Use custom DeepSeek API Key”). Chat should use managed OpenRouter keys provisioned on wallet top-up / org allocate.

- Replace invalid-key unlock UI with a wallet CTA in managed mode
- Default provider → `openrouter`, default model → `deepseek/deepseek-chat-v3.1`
- Disable native DeepSeek BYOK force-enable; enable OpenRouter by default

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --lint --test` on touched files (11 passed)
- Unit coverage for fail-closed managed-mode helper


Made with [Cursor](https://cursor.com)