### PR TITLE
🐛 fix(aico): always pin tab indicators to physical left

### DIFF
--- a/src/styles/global.rtl.test.ts
+++ b/src/styles/global.rtl.test.ts
@@ -16,17 +16,18 @@ describe('global RTL control fixes', () => {
 
   it('keeps switches LTR under dir=rtl', () => {
     expect(source).toContain("html[dir='rtl'] [role='switch']");
+    expect(source).toContain(":dir(rtl) [role='switch']");
     expect(source).toContain('--switch-dir: 1');
     expect(source).toContain('direction: ltr');
   });
 
-  it('maps Tabs selection indicators to physical left (Response Animation)', () => {
-    expect(source).toContain("html[dir='rtl'] [role='tablist'] > [role='presentation']");
-    expect(source).toContain(":dir(rtl) [role='tablist'] > [role='presentation']");
+  it('maps Tabs selection indicators to physical left (incl. Settings animation)', () => {
+    // Ungated: physical left works in LTR and fixes RTL regardless of html.dir timing
+    expect(source).toContain("[role='tablist'] > [role='presentation']");
     expect(source).toContain('left: var(--active-tab-left) !important');
     expect(source).toContain('inset-inline: auto !important');
     expect(source).toContain(
-      'transition-property: left, inset-block-start, top, width, height, transform !important',
+      'transition-property: left, top, inset-block-start, width, height, transform !important',
     );
     // Prior broken formula used containing-block % and --active-tab-right
     expect(source).not.toContain('var(--active-tab-right)');
@@ -34,10 +35,7 @@ describe('global RTL control fixes', () => {
   });
 
   it('maps Segmented selection indicators to physical left', () => {
-    expect(source).toContain(
-      "html[dir='rtl'] [data-orientation] > [aria-hidden='true']:first-of-type",
-    );
-    expect(source).toContain(":dir(rtl) [data-orientation] > [aria-hidden='true']:first-of-type");
+    expect(source).toContain("[data-orientation] > [aria-hidden='true']:first-of-type");
     expect(source).toContain('left: var(--active-item-left) !important');
     expect(source).toContain('liberty/use-logical-spec');
   });

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -81,11 +81,15 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
    * --switch-dir:-1, so the knob/background animate the wrong way. Keep the
    * control LTR (standard toggle UX) under RTL documents.
    *
-   * Tabs / Segmented indicators (e.g. Settings → Appearance → Response Animation):
-   * JS writes physical offsetLeft into --active-tab-left / --active-item-left, but
-   * component CSS binds logical inset-inline-start. Under RTL the selection pill
-   * shifts away from the active option. Force physical \`left\` to match the JS.
+   * Tabs / Segmented indicators (Settings → Appearance animation, platform/org
+   * admin tabs, etc.): JS writes physical offsetLeft into --active-tab-left /
+   * --active-item-left, but component CSS binds logical inset-inline-start.
+   * Under RTL that mirrors the pill away from the active option. Always force
+   * physical \`left\` (safe in LTR too — left === inset-inline-start there).
+   * Do not gate on html[dir=rtl] only: antd direction=rtl can nest :dir(rtl)
+   * without html.dir matching yet.
    */
+  :dir(rtl) [role='switch'],
   html[dir='rtl'] [role='switch'] {
     --switch-dir: 1;
 
@@ -93,20 +97,18 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
   }
 
   /* stylelint-disable liberty/use-logical-spec -- indicator offsets are physical */
-  :dir(rtl) [role='tablist'] > [role='presentation'],
-  html[dir='rtl'] [role='tablist'] > [role='presentation'] {
+  [role='tablist'] > [role='presentation'] {
     right: auto !important;
     left: var(--active-tab-left) !important;
     inset-inline: auto !important;
-    transition-property: left, inset-block-start, top, width, height, transform !important;
+    transition-property: left, top, inset-block-start, width, height, transform !important;
   }
 
-  :dir(rtl) [data-orientation] > [aria-hidden='true']:first-of-type,
-  html[dir='rtl'] [data-orientation] > [aria-hidden='true']:first-of-type {
+  [data-orientation] > [aria-hidden='true']:first-of-type {
     right: auto !important;
     left: var(--active-item-left) !important;
     inset-inline: auto !important;
-    transition-property: left, inset-block-start, top, width, height, transform !important;
+    transition-property: left, top, inset-block-start, width, height, transform !important;
   }
   /* stylelint-enable liberty/use-logical-spec */
 `;


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### How to Test

1. Set language to Persian (`fa-IR`).
2. Open **Settings → Appearance** and switch animation mode tabs (خاموش / سریع / زیبا) — the grey pill must sit under the blue selected label.
3. Also re-check `/platform` and `/org` tab pills.

#### 🔗 Related Issue

Fixes #119

Plane: [AICO-74](https://plane.panafor.com/panaforai/browse/AICO-74)

Related: #113 / PR #114 (platform/org) — Settings still misaligned after that merge.

#### Description of Change

Always force physical `left: var(--active-tab-left)` on Tabs/Segmented indicators instead of gating only on `html[dir=rtl]`, so Settings animation tabs stay aligned under RTL.

Made with [Cursor](https://cursor.com)