### PR TITLE
🐛 fix(aico): Persian billing sources copy and neutral selection

### DIFF
--- a/locales/en-US/aico.json
+++ b/locales/en-US/aico.json
@@ -2,7 +2,7 @@
   "billing.organization": "Organization",
   "billing.personal": "Personal",
   "billing.remaining": "{{amount}} left",
-  "billing.selectHint": "Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.",
+  "billing.selectHint": "Each source has its own balance. The selected source is charged on the next chat.",
   "billing.sourcesTitle": "Billing sources",
   "billing.switchFailed": "Could not switch billing source",
   "billing.switched": "Using {{label}} credits",

--- a/locales/fa-IR/aico.json
+++ b/locales/fa-IR/aico.json
@@ -1,4 +1,12 @@
 {
+  "billing.organization": "سازمان",
+  "billing.personal": "شخصی",
+  "billing.remaining": "{{amount}} باقی‌مانده",
+  "billing.selectHint": "هر منبع موجودی و کلید جداگانه دارد. با انتخاب منبع، گفتگوی بعدی از همان موجودی کسر می‌شود.",
+  "billing.sourcesTitle": "منابع پرداخت",
+  "billing.switchFailed": "تغییر منبع پرداخت ناموفق بود",
+  "billing.switched": "در حال استفاده از اعتبار {{label}}",
+  "billing.switcherAria": "منبع پرداخت {{label}}، {{remaining}} باقی‌مانده",
   "errors.ALREADY_HAS_ORGANIZATION": "شما از قبل یک سازمان دارید.",
   "errors.BUDGET_EXCEEDED": "سهمیه‌ی شما تمام شده است.",
   "errors.BUDGET_NOT_FOUND": "سهمیه یافت نشد.",

--- a/locales/zh-CN/aico.json
+++ b/locales/zh-CN/aico.json
@@ -2,7 +2,7 @@
   "billing.organization": "组织",
   "billing.personal": "个人",
   "billing.remaining": "剩余 {{amount}}",
-  "billing.selectHint": "每个来源有独立的托管密钥与余额。切换只影响下一次对话扣费的账户。",
+  "billing.selectHint": "每个来源有独立余额。选中的来源将在下一次对话扣费。",
   "billing.sourcesTitle": "计费来源",
   "billing.switchFailed": "无法切换计费来源",
   "billing.switched": "正在使用 {{label}} 额度",

--- a/packages/locales/src/default/aico.ts
+++ b/packages/locales/src/default/aico.ts
@@ -243,7 +243,7 @@ export default {
   'billing.personal': 'Personal',
   'billing.remaining': '{{amount}} left',
   'billing.selectHint':
-    'Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.',
+    'Each source has its own balance. The selected source is charged on the next chat.',
   'billing.sourcesTitle': 'Billing sources',
   'billing.switchFailed': 'Could not switch billing source',
   'billing.switcherAria': 'Billing source {{label}}, {{remaining}} remaining',

--- a/src/features/AicoBilling/BillingSourceSwitcher.tsx
+++ b/src/features/AicoBilling/BillingSourceSwitcher.tsx
@@ -14,7 +14,7 @@ import { useAicoBillingSources } from './useAicoBillingSources';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   check: css`
-    color: ${cssVar.colorPrimary};
+    color: ${cssVar.colorTextSecondary};
   `,
   chevron: css`
     color: ${cssVar.colorTextQuaternary};

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -46,8 +46,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorBgContainer};
   `,
   sourceActive: css`
-    border-color: ${cssVar.colorPrimary};
-    background: ${cssVar.colorPrimaryBg};
+    border-color: ${cssVar.colorBorder};
+    background: ${cssVar.colorFillTertiary};
   `,
   sourceCard: css`
     cursor: pointer;
@@ -60,12 +60,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadiusLG};
 
+    background: transparent;
+
     transition:
       border-color 0.15s ease,
       background 0.15s ease;
 
     &:hover {
-      border-color: ${cssVar.colorPrimaryBorder};
+      border-color: ${cssVar.colorBorder};
+      background: ${cssVar.colorFillQuaternary};
     }
   `,
   sourceGrid: css`


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #126

Plane: [AICO-77](https://plane.panafor.com/panaforai/browse/AICO-77)

#### Description of Change

- Add missing `billing.*` Persian strings in `locales/fa-IR/aico.json`
- Clarify billing select hint (EN/ZH/default source)
- Replace primary-blue selected/hover styles on wallet billing source cards with neutral fill/border
- Neutralize selected check color in `BillingSourceSwitcher`

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Open wallet under `fa-IR` — titles/hints show Persian, not raw keys
- Select personal vs org source — no blue highlight; selection still clear via check/neutral border


Made with [Cursor](https://cursor.com)