### PR TITLE
✨ feat(aico): show response cost in action bar and refresh wallet remaining

### DIFF
--- a/apps/server/src/routers/lambda/aicoBilling.ts
+++ b/apps/server/src/routers/lambda/aicoBilling.ts
@@ -86,6 +86,8 @@ export const aicoBillingRouter = router({
   /**
    * Personal wallet + each org membership budget as separate spendable sources.
    * Credits never pool — each source has its own remaining balance and managed key.
+   * Personal remaining prefers OpenRouter `limit_remaining`; org remaining syncs
+   * settled usage from OpenRouter when a managed key exists.
    */
   getMyBillingSources: billingProcedure.query(async ({ ctx }) => {
     const [wallet, orgs] = await Promise.all([
@@ -93,7 +95,13 @@ export const aicoBillingRouter = router({
       ctx.organizationModel.listForUser(ctx.userId),
     ]);
 
-    const personalRemaining = Number(wallet.balanceMicroUsd ?? 0);
+    const keyService = ctx.keyService;
+    const personalRemaining = (
+      await keyService.getUserRemaining(ctx.userId).catch(() => ({
+        remainingMicroUsd: Number(wallet.balanceMicroUsd ?? 0),
+      }))
+    ).remainingMicroUsd;
+
     const personal = {
       hasManagedKey: Boolean(wallet.openrouterKeyId),
       isActive: Boolean(wallet.isActive),
@@ -108,6 +116,8 @@ export const aicoBillingRouter = router({
           const members = await ctx.organizationModel.listMembers(org.id);
           const me = members.find((m) => m.userId === ctx.userId && m.status === 'active');
           if (!me) return null;
+
+          await keyService.syncMemberUsage(me.id).catch(() => null);
 
           const budget = await ctx.organizationModel.getMemberBudget(me.id);
           const reservedMicroUsd = Number(budget?.reservedMicroUsd ?? 0);

--- a/apps/server/src/services/aico/chatGuard.ts
+++ b/apps/server/src/services/aico/chatGuard.ts
@@ -144,6 +144,8 @@ export class AicoChatGuard {
       }
     } else if (billingSource === 'organization' && orgMemberId) {
       await this.keyService.syncMemberUsage(orgMemberId).catch(() => null);
+    } else if (billingSource === 'personal') {
+      await this.keyService.getUserRemaining(userId).catch(() => null);
     }
 
     await this.billingModel.recordUsage({

--- a/apps/server/src/services/openrouter/getUserRemaining.test.ts
+++ b/apps/server/src/services/openrouter/getUserRemaining.test.ts
@@ -1,0 +1,136 @@
+/**
+ * getUserRemaining — personal spendable balance from OpenRouter limit_remaining
+ */
+// @vitest-environment node
+import type { LobeChatDatabase } from '@lobechat/database';
+import { getTestDB } from '@lobechat/database/test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AicoBillingModel } from '@/database/models/aicoBilling';
+import { users } from '@/database/schemas';
+import { userWallets, walletTransactions } from '@/database/schemas/aicoOrganization';
+import { AicoOpenRouterKeyService } from '@/server/services/openrouter/keyService';
+import type { OpenRouterManagementClient } from '@/server/services/openrouter/management';
+
+class ControllableOpenRouterClient implements OpenRouterManagementClient {
+  keys = new Map<string, any>();
+
+  createKey: OpenRouterManagementClient['createKey'] = async (params) => {
+    const hash = `ctrl_${crypto.randomUUID().replaceAll('-', '').slice(0, 16)}`;
+    const row = {
+      disabled: false,
+      hash,
+      key: `sk-or-v1-mock-${hash}`,
+      limit: params.limitUsd,
+      limitRemaining: params.limitUsd,
+      name: params.name,
+      usage: 0,
+    };
+    this.keys.set(hash, row);
+    return { ...row };
+  };
+
+  getKey: OpenRouterManagementClient['getKey'] = async (hash) => {
+    const row = this.keys.get(hash);
+    if (!row) throw new Error(`OpenRouter mock key not found: ${hash}`);
+    const { key: _k, ...info } = row;
+    return info;
+  };
+
+  updateKey: OpenRouterManagementClient['updateKey'] = async (params) => {
+    const row = this.keys.get(params.hash);
+    if (!row) throw new Error(`OpenRouter mock key not found: ${params.hash}`);
+    if (params.disabled !== undefined) row.disabled = params.disabled;
+    if (params.limitUsd !== undefined) {
+      row.limit = params.limitUsd;
+      row.limitRemaining = Math.max(0, params.limitUsd - row.usage);
+    }
+    const { key: _k, ...info } = row;
+    return info;
+  };
+}
+
+describe('getUserRemaining', () => {
+  let db: LobeChatDatabase;
+  const userId = 'user_remaining_test';
+
+  beforeEach(async () => {
+    db = await getTestDB();
+    await db.delete(walletTransactions);
+    await db.delete(userWallets);
+    await db.delete(users);
+    await db.insert(users).values({ id: userId, username: 'remaining-user' });
+  });
+
+  afterEach(async () => {
+    await db.delete(walletTransactions);
+    await db.delete(userWallets);
+    await db.delete(users);
+  });
+
+  it('prefers OpenRouter limit_remaining over deposited balance', async () => {
+    const billing = new AicoBillingModel(db);
+    const client = new ControllableOpenRouterClient();
+    const keys = new AicoOpenRouterKeyService(db, client);
+
+    await billing.mockTopupUser({
+      amountMicroUsd: 10_000_000,
+      amountToman: 50_000,
+      createdByUserId: userId,
+      fxRateTomanPerUsd: 50_000,
+      userId,
+    });
+    await keys.ensureUserKey(userId);
+
+    const wallet = await billing.getUserWallet(userId);
+    const keyHash = wallet!.openrouterKeyId!;
+    const key = client.keys.get(keyHash);
+    key.usage = 2.5;
+    key.limitRemaining = 7.5;
+
+    const remaining = await keys.getUserRemaining(userId);
+    expect(remaining.remainingMicroUsd).toBe(7_500_000);
+    expect(remaining.usageMicroUsd).toBe(2_500_000);
+  });
+
+  it('falls back to deposit when OpenRouter key is missing', async () => {
+    const billing = new AicoBillingModel(db);
+    const client = new ControllableOpenRouterClient();
+    const keys = new AicoOpenRouterKeyService(db, client);
+
+    await billing.mockTopupUser({
+      amountMicroUsd: 10_000_000,
+      amountToman: 50_000,
+      createdByUserId: userId,
+      fxRateTomanPerUsd: 50_000,
+      userId,
+    });
+
+    const remaining = await keys.getUserRemaining(userId);
+    expect(remaining.remainingMicroUsd).toBe(10_000_000);
+    expect(remaining.usageMicroUsd).toBeNull();
+  });
+
+  it('falls back to deposit when OpenRouter getKey fails', async () => {
+    const billing = new AicoBillingModel(db);
+    const client = new ControllableOpenRouterClient();
+    const keys = new AicoOpenRouterKeyService(db, client);
+
+    await billing.mockTopupUser({
+      amountMicroUsd: 3_000_000,
+      amountToman: 15_000,
+      createdByUserId: userId,
+      fxRateTomanPerUsd: 50_000,
+      userId,
+    });
+    await billing.updateUserOpenRouterKey({
+      ciphertext: 'cipher',
+      keyId: 'missing-key-hash',
+      userId,
+    });
+
+    const remaining = await keys.getUserRemaining(userId);
+    expect(remaining.remainingMicroUsd).toBe(3_000_000);
+    expect(remaining.usageMicroUsd).toBeNull();
+  });
+});

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -270,6 +270,34 @@ export class AicoOpenRouterKeyService {
    */
   resolveUserApiKey = async (_userId: string): Promise<string | null> => null;
 
+  /**
+   * Spendable remaining for a personal wallet. Prefers OpenRouter
+   * `limit_remaining` (enforced spend left on the managed key); falls back to
+   * deposited `balanceMicroUsd` when no key exists or OR is unreachable.
+   */
+  getUserRemaining = async (
+    userId: string,
+  ): Promise<{ remainingMicroUsd: number; usageMicroUsd: number | null }> => {
+    const wallet = await this.billingModel.getOrCreateUserWallet(userId);
+    const balanceMicroUsd = Number(wallet.balanceMicroUsd ?? 0);
+
+    if (!wallet.openrouterKeyId || this.isStaleManagedKeyId(wallet.openrouterKeyId)) {
+      return { remainingMicroUsd: Math.max(0, balanceMicroUsd), usageMicroUsd: null };
+    }
+
+    try {
+      const info = await this.client.getKey(wallet.openrouterKeyId);
+      const usageMicro = Number(openRouterUsdToMicroFloor(info.usage));
+      const remaining =
+        info.limitRemaining == null
+          ? Math.max(0, balanceMicroUsd - usageMicro)
+          : Number(openRouterUsdToMicroFloor(info.limitRemaining));
+      return { remainingMicroUsd: Math.max(0, remaining), usageMicroUsd: usageMicro };
+    } catch {
+      return { remainingMicroUsd: Math.max(0, balanceMicroUsd), usageMicroUsd: null };
+    }
+  };
+
   syncMemberUsage = async (orgMemberId: string) => {
     const budget = await this.orgModel.getMemberBudget(orgMemberId);
     if (!budget?.openrouterKeyId) return null;

--- a/locales/en-US/aico.json
+++ b/locales/en-US/aico.json
@@ -2,7 +2,7 @@
   "billing.organization": "Organization",
   "billing.personal": "Personal",
   "billing.remaining": "{{amount}} left",
-  "billing.selectHint": "Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.",
+  "billing.selectHint": "Each source has its own balance. The selected source is charged on the next chat.",
   "billing.sourcesTitle": "Billing sources",
   "billing.switchFailed": "Could not switch billing source",
   "billing.switched": "Using {{label}} credits",

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -632,6 +632,8 @@
   "messageAction.continueGeneration": "Continue Generating",
   "messageAction.continueGenerationUnsupported": "The current model doesn’t support continuing an assistant message. Try regenerating instead.",
   "messageAction.copyOperationId": "Copy Operation ID",
+  "messageAction.cost": "Cost",
+  "messageAction.cost": "Cost",
   "messageAction.delAndRegenerate": "Delete and Regenerate",
   "messageAction.deleteDisabledByThreads": "This message has a subtopic and can’t be deleted",
   "messageAction.expand": "Expand Message",

--- a/locales/fa-IR/aico.json
+++ b/locales/fa-IR/aico.json
@@ -1,4 +1,12 @@
 {
+  "billing.organization": "سازمان",
+  "billing.personal": "شخصی",
+  "billing.remaining": "{{amount}} باقی‌مانده",
+  "billing.selectHint": "هر منبع موجودی و کلید جداگانه دارد. با انتخاب منبع، گفتگوی بعدی از همان موجودی کسر می‌شود.",
+  "billing.sourcesTitle": "منابع پرداخت",
+  "billing.switchFailed": "تغییر منبع پرداخت ناموفق بود",
+  "billing.switched": "در حال استفاده از اعتبار {{label}}",
+  "billing.switcherAria": "منبع پرداخت {{label}}، {{remaining}} باقی‌مانده",
   "errors.ALREADY_HAS_ORGANIZATION": "شما از قبل یک سازمان دارید.",
   "errors.BUDGET_EXCEEDED": "سهمیه‌ی شما تمام شده است.",
   "errors.BUDGET_NOT_FOUND": "سهمیه یافت نشد.",

--- a/locales/zh-CN/aico.json
+++ b/locales/zh-CN/aico.json
@@ -2,7 +2,7 @@
   "billing.organization": "组织",
   "billing.personal": "个人",
   "billing.remaining": "剩余 {{amount}}",
-  "billing.selectHint": "每个来源有独立的托管密钥与余额。切换只影响下一次对话扣费的账户。",
+  "billing.selectHint": "每个来源有独立余额。选中的来源将在下一次对话扣费。",
   "billing.sourcesTitle": "计费来源",
   "billing.switchFailed": "无法切换计费来源",
   "billing.switched": "正在使用 {{label}} 额度",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -632,6 +632,8 @@
   "messageAction.continueGeneration": "继续生成",
   "messageAction.continueGenerationUnsupported": "当前模型不支持继续生成助理消息，请尝试重新生成。",
   "messageAction.copyOperationId": "复制 Operation ID",
+  "messageAction.cost": "费用",
+  "messageAction.cost": "费用",
   "messageAction.delAndRegenerate": "删除并重新生成",
   "messageAction.deleteDisabledByThreads": "该消息有子话题，无法删除",
   "messageAction.expand": "展开消息",

--- a/packages/locales/src/default/aico.ts
+++ b/packages/locales/src/default/aico.ts
@@ -243,7 +243,7 @@ export default {
   'billing.personal': 'Personal',
   'billing.remaining': '{{amount}} left',
   'billing.selectHint':
-    'Each source has its own managed key and remaining credit. Switching only changes which balance the next chat uses.',
+    'Each source has its own balance. The selected source is charged on the next chat.',
   'billing.sourcesTitle': 'Billing sources',
   'billing.switchFailed': 'Could not switch billing source',
   'billing.switcherAria': 'Billing source {{label}}, {{remaining}} remaining',

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -593,6 +593,7 @@ export default {
   'messageAction.continueGenerationUnsupported':
     'The current model doesn’t support continuing an assistant message. Try regenerating instead.',
   'messageAction.copyOperationId': 'Copy Operation ID',
+  'messageAction.cost': 'Cost',
   'messageAction.delAndRegenerate': 'Delete and Regenerate',
   'messageAction.interrupted': 'Interrupted',
   'messageAction.interruptedHint': 'What should I do instead?',

--- a/src/app/(backend)/webapi/chat/[provider]/route.test.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.test.ts
@@ -67,6 +67,7 @@ describe('POST handler', () => {
         'test-user-id',
         'test-provider',
         undefined,
+        { billingContext: undefined, modelId: 'test-model' },
       );
     });
 

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -9,14 +9,11 @@ import type { LobeChatDatabase } from '@/database/type';
 import { createTraceOptions, initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import {
   AICO_BILLING_CONTEXT_HEADER,
+  type AicoBillingContext,
   decodeBillingContextHeader,
   parseAicoBillingContext,
-  type AicoBillingContext,
 } from '@/server/services/aico/billingContext';
-import {
-  AicoManagedPolicy,
-  AicoManagedPolicyError,
-} from '@/server/services/aico/managedPolicy';
+import { AicoManagedPolicy, AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
 import { AicoOpenRouterKeyService } from '@/server/services/openrouter/keyService';
 import { type ChatStreamPayload } from '@/types/openai/chat';
 import { createErrorResponse } from '@/utils/errorResponse';
@@ -53,6 +50,7 @@ const recordManagedUsage = async (params: {
 
   let orgId: string | null = null;
   let orgMemberId: string | null = null;
+  const keyService = new AicoOpenRouterKeyService(db);
 
   if (billing.source === 'organization') {
     orgId = billing.organizationId;
@@ -60,8 +58,11 @@ const recordManagedUsage = async (params: {
     const me = members.find((m) => m.userId === userId && m.status === 'active');
     if (me) {
       orgMemberId = me.id;
-      await new AicoOpenRouterKeyService(db).syncMemberUsage(me.id).catch(() => null);
+      await keyService.syncMemberUsage(me.id).catch(() => null);
     }
+  } else {
+    // Warm personal remaining from OpenRouter so the next sources fetch is current.
+    await keyService.getUserRemaining(userId).catch(() => null);
   }
 
   await new AicoBillingModel(db).recordUsage({

--- a/src/features/AicoBilling/BillingSourceSwitcher.tsx
+++ b/src/features/AicoBilling/BillingSourceSwitcher.tsx
@@ -14,7 +14,7 @@ import { useAicoBillingSources } from './useAicoBillingSources';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   check: css`
-    color: ${cssVar.colorPrimary};
+    color: ${cssVar.colorTextSecondary};
   `,
   chevron: css`
     color: ${cssVar.colorTextQuaternary};

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -46,8 +46,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorBgContainer};
   `,
   sourceActive: css`
-    border-color: ${cssVar.colorPrimary};
-    background: ${cssVar.colorPrimaryBg};
+    border-color: ${cssVar.colorBorder};
+    background: ${cssVar.colorFillTertiary};
   `,
   sourceCard: css`
     cursor: pointer;
@@ -60,12 +60,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadiusLG};
 
+    background: transparent;
+
     transition:
       border-color 0.15s ease,
       background 0.15s ease;
 
     &:hover {
-      border-color: ${cssVar.colorPrimaryBorder};
+      border-color: ${cssVar.colorBorder};
+      background: ${cssVar.colorFillQuaternary};
     }
   `,
   sourceGrid: css`

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -9,6 +9,7 @@ import {
   type MessageActionContext,
   type MessageActionSlot,
 } from '../../components/MessageActionBar';
+import MessageCostBadge from '../../components/MessageCostBadge';
 
 const DEFAULT_BAR_WITH_TOOLS: MessageActionSlot[] = ['delAndRegenerate', 'copy'];
 const DEFAULT_BAR: MessageActionSlot[] = ['edit', 'copy'];
@@ -69,6 +70,7 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
   }
 
   const defaultBar = tools ? DEFAULT_BAR_WITH_TOOLS : DEFAULT_BAR;
+  const showCost = !!content && content !== LOADING_FLAT;
 
   return (
     <MessageActionBar
@@ -76,6 +78,9 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
       ctx={ctx}
       leading={<ReactionPicker messageId={id} />}
       menu={actionsConfig?.menu ?? DEFAULT_MENU}
+      trailing={
+        showCost ? <MessageCostBadge metadata={data.metadata} usage={data.usage} /> : undefined
+      }
     />
   );
 });

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -9,6 +9,7 @@ import {
   type MessageActionContext,
   type MessageActionSlot,
 } from '../../components/MessageActionBar';
+import MessageCostBadge from '../../components/MessageCostBadge';
 
 const DEFAULT_BAR_WITH_TOOLS: MessageActionSlot[] = ['delAndRegenerate', 'copy'];
 const DEFAULT_BAR: MessageActionSlot[] = ['edit', 'copy'];
@@ -81,6 +82,7 @@ export const GroupActionsBar = memo<GroupActionsProps>(
         ctx={ctx}
         leading={<ReactionPicker messageId={id} />}
         menu={actionsConfig?.menu ?? DEFAULT_MENU}
+        trailing={<MessageCostBadge metadata={data.metadata} usage={data.usage} />}
       />
     );
   },

--- a/src/features/Conversation/Messages/components/MessageActionBar/index.test.tsx
+++ b/src/features/Conversation/Messages/components/MessageActionBar/index.test.tsx
@@ -82,6 +82,25 @@ describe('MessageActionBar', () => {
     expect(actionGroup).toHaveStyle({ background: 'transparent', borderRadius: '0' });
   });
 
+  it('renders a trailing control inside the shared action container', () => {
+    permissionMock.canEdit = true;
+
+    render(
+      <MessageActionBar
+        bar={['edit', 'copy']}
+        trailing={<button>Cost</button>}
+        ctx={{
+          data: { content: 'hello', role: 'assistant' } as UIChatMessage,
+          id: 'message-1',
+          role: 'assistant',
+        }}
+      />,
+    );
+
+    const container = screen.getByTestId('action-container');
+    expect(container).toContainElement(screen.getByRole('button', { name: 'Cost' }));
+  });
+
   it('keeps read-only comments available to workspace viewers', () => {
     actionMocks.commentsAvailable = true;
     permissionMock.canEdit = false;

--- a/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
+++ b/src/features/Conversation/Messages/components/MessageActionBar/index.tsx
@@ -81,90 +81,97 @@ interface MessageActionBarProps {
   leading?: ReactNode;
   /** Menu slots (shown in the overflow dropdown); defaults to `bar` when omitted */
   menu?: MessageActionSlot[];
+  /** Custom control rendered after the icon group inside the shared action container */
+  trailing?: ReactNode;
 }
 
 /**
  * Universal action bar. Resolves declarative slot keys (`'copy'`, `'edit'`,
  * `'divider'`, ...) against the registry and renders an ActionIconGroup.
  */
-export const MessageActionBar = memo<MessageActionBarProps>(({ ctx, bar, leading, menu }) => {
-  const built = useBuildActions(ctx);
-  const { allowed: canEdit } = usePermission('edit_own_content');
+export const MessageActionBar = memo<MessageActionBarProps>(
+  ({ ctx, bar, leading, menu, trailing }) => {
+    const built = useBuildActions(ctx);
+    const { allowed: canEdit } = usePermission('edit_own_content');
 
-  const effectiveBar = canEdit ? bar : VIEWER_BAR;
-  const effectiveMenu = canEdit ? menu : undefined;
-  const [barSlots, menuSlots] = useMemo(() => {
-    const shouldPromoteComments =
-      Boolean(built.comments) &&
-      !effectiveBar.includes('comments') &&
-      Boolean(effectiveMenu?.includes('comments'));
+    const effectiveBar = canEdit ? bar : VIEWER_BAR;
+    const effectiveMenu = canEdit ? menu : undefined;
+    const [barSlots, menuSlots] = useMemo(() => {
+      const shouldPromoteComments =
+        Boolean(built.comments) &&
+        !effectiveBar.includes('comments') &&
+        Boolean(effectiveMenu?.includes('comments'));
 
-    return [
-      shouldPromoteComments ? [...effectiveBar, 'comments'] : effectiveBar,
-      shouldPromoteComments ? effectiveMenu?.filter((slot) => slot !== 'comments') : effectiveMenu,
-    ];
-  }, [built.comments, effectiveBar, effectiveMenu]);
+      return [
+        shouldPromoteComments ? [...effectiveBar, 'comments'] : effectiveBar,
+        shouldPromoteComments
+          ? effectiveMenu?.filter((slot) => slot !== 'comments')
+          : effectiveMenu,
+      ];
+    }, [built.comments, effectiveBar, effectiveMenu]);
 
-  const barItems = useMemo(() => resolveSlots(barSlots, built), [barSlots, built]);
-  const menuItems = useMemo(
-    () => (menuSlots ? resolveSlots(menuSlots, built) : undefined),
-    [menuSlots, built],
-  );
+    const barItems = useMemo(() => resolveSlots(barSlots, built), [barSlots, built]);
+    const menuItems = useMemo(
+      () => (menuSlots ? resolveSlots(menuSlots, built) : undefined),
+      [menuSlots, built],
+    );
 
-  const items = useMemo(
-    () => barItems.filter((item) => !('disabled' in item && item.disabled)).map(stripHandleClick),
-    [barItems],
-  );
-  // An all-null menu (every slot's action opted out) must collapse to no menu —
-  // ActionIconGroup renders the overflow trigger for any truthy array, even [].
-  const menuStripped = useMemo(
-    () => (menuItems?.length ? menuItems.map(stripHandleClick) : undefined),
-    [menuItems],
-  );
+    const items = useMemo(
+      () => barItems.filter((item) => !('disabled' in item && item.disabled)).map(stripHandleClick),
+      [barItems],
+    );
+    // An all-null menu (every slot's action opted out) must collapse to no menu —
+    // ActionIconGroup renders the overflow trigger for any truthy array, even [].
+    const menuStripped = useMemo(
+      () => (menuItems?.length ? menuItems.map(stripHandleClick) : undefined),
+      [menuItems],
+    );
 
-  const allActions = useMemo(
-    () => buildActionsMap([...barItems, ...(menuItems ?? [])]),
-    [barItems, menuItems],
-  );
+    const allActions = useMemo(
+      () => buildActionsMap([...barItems, ...(menuItems ?? [])]),
+      [barItems, menuItems],
+    );
 
-  const handleAction = useCallback(
-    (event: ActionIconGroupEvent) => {
-      if (event.keyPath && event.keyPath.length > 1) {
-        const parentKey = event.keyPath.at(-1);
-        const childKey = event.keyPath[0];
-        const parent = allActions.get(parentKey!);
-        if (parent && 'children' in parent && parent.children) {
-          const child = parent.children.find((c) => c.key === childKey);
-          child?.handleClick?.();
-          return;
+    const handleAction = useCallback(
+      (event: ActionIconGroupEvent) => {
+        if (event.keyPath && event.keyPath.length > 1) {
+          const parentKey = event.keyPath.at(-1);
+          const childKey = event.keyPath[0];
+          const parent = allActions.get(parentKey!);
+          if (parent && 'children' in parent && parent.children) {
+            const child = parent.children.find((c) => c.key === childKey);
+            child?.handleClick?.();
+            return;
+          }
         }
-      }
-      const action = allActions.get(event.key);
-      action?.handleClick?.();
-    },
-    [allActions],
-  );
+        const action = allActions.get(event.key);
+        action?.handleClick?.();
+      },
+      [allActions],
+    );
 
-  const actionGroup = (
-    <ActionIconGroup items={items} menu={menuStripped} onActionClick={handleAction} />
-  );
+    const actionGroup = (
+      <ActionIconGroup items={items} menu={menuStripped} onActionClick={handleAction} />
+    );
 
-  if (!leading) return actionGroup;
+    if (!leading && !trailing) return actionGroup;
 
-  return (
-    <Block horizontal align={'center'} padding={2}>
-      {leading}
-      <ActionIconGroup
-        items={items}
-        menu={menuStripped}
-        padding={0}
-        style={{ background: 'transparent', border: 'none', borderRadius: 0, boxShadow: 'none' }}
-        variant={'borderless'}
-        onActionClick={handleAction}
-      />
-    </Block>
-  );
-});
+    return (
+      <Block horizontal align={'center'} padding={2}>
+        {leading}
+        <ActionIconGroup
+          items={items}
+          menu={menuStripped}
+          padding={0}
+          style={{ background: 'transparent', border: 'none', borderRadius: 0, boxShadow: 'none' }}
+          variant={'borderless'}
+          onActionClick={handleAction}
+        />
+        {trailing}
+      </Block>
+    );
+  },
+);
 
 MessageActionBar.displayName = 'MessageActionBar';
 

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -1,0 +1,106 @@
+import { type ModelUsage } from '@lobechat/types';
+import { Center, Icon, Tooltip } from '@lobehub/ui';
+import { Popover } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
+import { CircleDollarSignIcon } from 'lucide-react';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+import { formatNumber } from '@/utils/format';
+
+import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    cursor: default;
+
+    height: 28px;
+    padding-inline: 6px;
+    border-radius: 6px;
+
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorTextSecondary};
+
+    :hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  chipInteractive: css`
+    cursor: pointer;
+  `,
+  detailRow: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+
+    min-width: 140px;
+
+    font-size: 12px;
+  `,
+  detailValue: css`
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  `,
+}));
+
+interface MessageCostBadgeProps {
+  metadata?: Record<string, unknown> | null;
+  usage?: ModelUsage;
+}
+
+const MessageCostBadge = memo<MessageCostBadgeProps>(({ usage, metadata }) => {
+  const { t } = useTranslation('chat');
+  const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
+
+  const cost = useMemo(() => resolveMessageCost(usage, metadata), [usage, metadata]);
+
+  if (isShowCredit) return null;
+  if (cost === undefined || cost <= 0) return null;
+
+  const amount = formatMessageCostUsd(cost);
+  const label = t('messageAction.cost');
+  const hasTokenDetail = !!usage?.totalTokens;
+
+  const chip = (
+    <Center
+      horizontal
+      aria-label={`${label}: ${amount}`}
+      className={hasTokenDetail ? `${styles.chip} ${styles.chipInteractive}` : styles.chip}
+      gap={2}
+    >
+      <Icon icon={CircleDollarSignIcon} size={14} />
+      <span>{amount}</span>
+    </Center>
+  );
+
+  if (hasTokenDetail) {
+    return (
+      <Popover
+        content={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 4 }}>
+            <div className={styles.detailRow}>
+              <span>{label}</span>
+              <span className={styles.detailValue}>{amount}</span>
+            </div>
+            <div className={styles.detailRow}>
+              <span>{t('messages.tokenDetails.total')}</span>
+              <span className={styles.detailValue}>{formatNumber(usage!.totalTokens!)}</span>
+            </div>
+          </div>
+        }
+      >
+        {chip}
+      </Popover>
+    );
+  }
+
+  return <Tooltip title={label}>{chip}</Tooltip>;
+});
+
+MessageCostBadge.displayName = 'MessageCostBadge';
+
+export default MessageCostBadge;

--- a/src/features/Conversation/Messages/components/resolveMessageCost.test.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageCost.test.ts
@@ -1,0 +1,30 @@
+import type { ModelUsage } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
+
+describe('resolveMessageCost', () => {
+  it('prefers usage.cost over legacy metadata.cost', () => {
+    expect(resolveMessageCost({ cost: 0.42 } as ModelUsage, { cost: 1.5 })).toBe(0.42);
+  });
+
+  it('falls back to metadata.cost', () => {
+    expect(resolveMessageCost(undefined, { cost: 0.15 })).toBe(0.15);
+  });
+
+  it('returns undefined when missing', () => {
+    expect(resolveMessageCost(undefined, undefined)).toBeUndefined();
+  });
+
+  it('ignores non-finite values', () => {
+    expect(resolveMessageCost({ cost: Number.NaN } as ModelUsage, undefined)).toBeUndefined();
+    expect(resolveMessageCost(undefined, { cost: Number.POSITIVE_INFINITY })).toBeUndefined();
+  });
+});
+
+describe('formatMessageCostUsd', () => {
+  it('formats to two decimal places with a dollar sign', () => {
+    expect(formatMessageCostUsd(0.37)).toBe('$0.37');
+    expect(formatMessageCostUsd(1)).toBe('$1.00');
+  });
+});

--- a/src/features/Conversation/Messages/components/resolveMessageCost.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageCost.ts
@@ -1,0 +1,14 @@
+import { type ModelUsage } from '@lobechat/types';
+
+/** Prefer structured `usage.cost`; fall back to deprecated flat `metadata.cost`. */
+export const resolveMessageCost = (
+  usage?: ModelUsage,
+  metadata?: Record<string, unknown> | null,
+): number | undefined => {
+  if (typeof usage?.cost === 'number' && Number.isFinite(usage.cost)) return usage.cost;
+  const legacy = metadata?.cost;
+  if (typeof legacy === 'number' && Number.isFinite(legacy)) return legacy;
+  return undefined;
+};
+
+export const formatMessageCostUsd = (cost: number) => `$${cost.toFixed(2)}`;

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -500,9 +500,28 @@ class ChatService {
 
     // Managed OpenRouter/Aico chat must send an explicit billing context so the
     // server can pick the personal vs org key (credits are never pooled).
-    const { resolveAicoBillingForRequest } = await import('@/features/AicoBilling');
+    const { AICO_BILLING_SOURCES_SWR_KEY, resolveAicoBillingForRequest } =
+      await import('@/features/AicoBilling');
     const aicoBilling = await resolveAicoBillingForRequest(provider);
     const requestBody = aicoBilling ? { ...payload, aicoBilling } : payload;
+
+    const refreshBillingAfterFinish = aicoBilling
+      ? async () => {
+          const { mutate: globalMutate } = await import('@/libs/swr');
+          void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
+          void globalMutate('aico-my-wallet');
+        }
+      : undefined;
+
+    const onFinish: FetchSSEOptions['onFinish'] | undefined = refreshBillingAfterFinish
+      ? async (content, context) => {
+          try {
+            return await options?.onFinish?.(content, context);
+          } finally {
+            await refreshBillingAfterFinish();
+          }
+        }
+      : options?.onFinish;
 
     return fetchSSE(API_ENDPOINTS.chat(provider), {
       body: JSON.stringify(requestBody),
@@ -511,7 +530,7 @@ class ChatService {
       method: 'POST',
       onAbort: options?.onAbort,
       onErrorHandle: options?.onErrorHandle,
-      onFinish: options?.onFinish,
+      onFinish,
       onMessageHandle: options?.onMessageHandle,
       requestContext: {
         apiMode,


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #125

Plane: [AICO-76](https://plane.panafor.com/panaforai/browse/AICO-76)

#### Description of Change

- Show per-response USD cost (icon + `$x.xx`) in the assistant message action bar
- Personal billing remaining now prefers OpenRouter `limit_remaining` instead of deposited balance only
- Sync org member usage when listing billing sources; warm OR after managed chat
- Invalidate `aico-billing-sources` / `aico-my-wallet` SWR after managed chat `onFinish`

#### Test

- [x] Tested locally via `bun run check` on touched files
- [x] Added/updated tests (`resolveMessageCost`, `getUserRemaining`, action bar trailing, chat route)
- [ ] No tests needed

#### How to Test

1. Send a managed Aico/OpenRouter chat → cost chip appears on the assistant action bar when `usage.cost` is present
2. Watch the billing source switcher remaining decrease after the reply finishes (personal and org)
3. Confirm wallet page refresh after chat without remounting

Made with [Cursor](https://cursor.com)