### PR TITLE
🐛 fix: redirect social account link callback to /settings/profile

### DIFF
--- a/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
@@ -78,14 +78,14 @@ export const SSOProvidersList = memo(() => {
     if (isBuiltinProvider(normalizedProvider)) {
       // Use better-auth native linkSocial API for built-in providers
       await linkSocial({
-        callbackURL: '/profile',
+        callbackURL: '/settings/profile',
         provider: normalizedProvider as any,
       });
       return;
     }
 
     await oauth2.link({
-      callbackURL: '/profile',
+      callbackURL: '/settings/profile',
       providerId: normalizedProvider,
     });
   };


### PR DESCRIPTION
<!-- Brief and heads-up -->

Linking a social/SSO account from Settings → Profile used `callbackURL: '/profile'`, which is not an app route. Point the callback at `/settings/profile` so users land back on the profile settings page after OAuth.

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open Settings → Profile while logged in
2. Link an available social/SSO provider
3. Complete OAuth and confirm redirect lands on `/settings/profile`

#### 🔗 Related Issue

Fixes #131

Plane: [AICO-79](https://plane.panafor.com/panaforai/browse/AICO-79)


Made with [Cursor](https://cursor.com)