### PR TITLE
🐛 fix(model-runtime): preserve OpenRouter usage.cost for message cost chip

### DIFF
--- a/packages/model-runtime/src/core/usageConverters/openai.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.test.ts
@@ -588,6 +588,40 @@ describe('convertUsage', () => {
     expect(result.cost).toBeCloseTo(2, 10);
   });
 
+  it('should prefer OpenRouter provider-reported usage.cost over pricing estimate', () => {
+    const pricing: Pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    };
+
+    const usage = {
+      completion_tokens: 500_000,
+      cost: 0.0042,
+      prompt_tokens: 1_000_000,
+      total_tokens: 1_500_000,
+    } as OpenAI.Completions.CompletionUsage & { cost: number };
+
+    const result = convertOpenAIUsage(usage, { pricing });
+
+    expect(result.cost).toBe(0.0042);
+  });
+
+  it('should keep provider-reported cost when model-bank pricing is missing', () => {
+    const usage = {
+      completion_tokens: 10,
+      cost: 0.00015,
+      prompt_tokens: 20,
+      total_tokens: 30,
+    } as OpenAI.Completions.CompletionUsage & { cost: number };
+
+    const result = convertOpenAIUsage(usage);
+
+    expect(result.cost).toBe(0.00015);
+    expect(result.totalTokens).toBe(30);
+  });
+
   it('should enrich response usage with pricing cost when pricing is provided', () => {
     const pricing: Pricing = {
       units: [

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -44,6 +44,29 @@ const readCacheWriteTokens = (details: CacheWriteUsageDetails | undefined): numb
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 };
 
+/**
+ * OpenRouter (and some compatible proxies) report the actual billed USD on
+ * `usage.cost`. Prefer that over model-bank estimates so the message cost chip
+ * matches wallet charge — pricing lookup often misses Aico/OpenRouter model ids.
+ */
+export const readProviderReportedCost = (usage: unknown): number | undefined => {
+  if (!usage || typeof usage !== 'object') return undefined;
+  const cost = (usage as { cost?: unknown }).cost;
+  if (typeof cost !== 'number' || !Number.isFinite(cost) || cost < 0) return undefined;
+  return cost;
+};
+
+const withPricingOrProviderCost = (
+  usage: ModelUsage,
+  pricing: Pricing | undefined,
+  providerUsage: unknown,
+): ModelUsage => {
+  const priced = withUsageCost(usage, pricing);
+  const reported = readProviderReportedCost(providerUsage);
+  if (reported === undefined) return priced;
+  return { ...priced, cost: reported };
+};
+
 const resolveOpenAIInputCacheMissTokens = (params: {
   explicitMissTokens?: number;
   inputCachedTokens?: number;
@@ -128,7 +151,7 @@ export const convertOpenAIUsage = (
 
   log('convertOpenAIUsage data(completion-api): %O', finalData);
 
-  return withUsageCost(finalData as ModelUsage, payload?.pricing);
+  return withPricingOrProviderCost(finalData as ModelUsage, payload?.pricing, usage);
 };
 
 export const convertOpenAIResponseUsage = (
@@ -194,7 +217,8 @@ export const convertOpenAIResponseUsage = (
 
   log('convertOpenAIResponseUsage data(response-api): %O', finalData);
 
-  return withUsageCost(finalData as ModelUsage, payload?.pricing); // Cast because we've built it to match
+  // Cast because we've built it to match; prefer provider-reported cost when present.
+  return withPricingOrProviderCost(finalData as ModelUsage, payload?.pricing, usage);
 };
 
 export const convertOpenAIImageUsage = (


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #133

Plane: [AICO-80](https://plane.panafor.com/panaforai/browse/AICO-80)

Related: #125 / [AICO-76](https://plane.panafor.com/panaforai/browse/AICO-76) (UI chip) — cost was never written onto messages.

#### Description of Change

OpenRouter returns billed USD on stream `usage.cost`. Conversion previously dropped it and only estimated cost from static model-bank pricing. Prefer the provider-reported cost so new assistant messages get `usage.cost` and the action-bar chip shows.

#### Test

- [x] `bun run check` on touched files (24 tests passed)
- [x] Added regression tests for provider cost with/without pricing
- [ ] No tests needed

#### How to Test

1. Deploy this build to chat.panafor.com
2. Send a new managed Aico/OpenRouter chat
3. Confirm the assistant action bar shows `$x.xx` after the reply finishes
4. Older messages still won’t show cost (no backfill)

Made with [Cursor](https://cursor.com)