### PR TITLE
🐛 fix(aico): use Aico logo for OpenRouter models in chat UI

### DIFF
--- a/src/components/Branding/BrandedModelIcon.tsx
+++ b/src/components/Branding/BrandedModelIcon.tsx
@@ -19,7 +19,13 @@ type BrandedModelIconProps = {
  */
 export const BrandedModelIcon = memo<BrandedModelIconProps>(({ model, size = 32, type }) => {
   if (isBrandedOpenRouterModelId(model)) {
-    return <ProductLogo size={size} type={type === 'mono' ? 'mono' : 'flat'} />;
+    return (
+      <ProductLogo
+        size={size}
+        style={{ flex: 'none', height: size, width: size }}
+        type={type === 'mono' ? 'mono' : 'flat'}
+      />
+    );
   }
 
   return <ModelIcon model={model} size={size} type={type} />;

--- a/src/components/Branding/BrandedModelTag.tsx
+++ b/src/components/Branding/BrandedModelTag.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ModelTag } from '@lobehub/icons';
+import { type ModelTagProps } from '@lobehub/icons';
+import { Tag } from '@lobehub/ui';
+import { memo } from 'react';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+
+import { formatBrandedModelId, isBrandedOpenRouterModelId } from './brandedModelId';
+
+/**
+ * ModelTag that swaps OpenRouter-namespace models to the product favicon +
+ * branding-slug id when custom branding is on.
+ */
+export const BrandedModelTag = memo<ModelTagProps>(({ model, type = 'mono', ...rest }) => {
+  if (isBrandedOpenRouterModelId(model)) {
+    return (
+      <Tag icon={<ProductLogo size={14} type={type === 'mono' ? 'mono' : 'flat'} />} {...rest}>
+        {formatBrandedModelId(model)}
+      </Tag>
+    );
+  }
+
+  return <ModelTag model={model} type={type} {...rest} />;
+});
+
+BrandedModelTag.displayName = 'BrandedModelTag';

--- a/src/components/Branding/brandedModelId.test.ts
+++ b/src/components/Branding/brandedModelId.test.ts
@@ -13,6 +13,7 @@ describe('brandedModelId', () => {
 
     expect(getBrandingModelSlug()).toBe(BRANDING_NAME.trim().toLowerCase());
     expect(isBrandedOpenRouterModelId('openrouter/auto')).toBe(true);
+    expect(isBrandedOpenRouterModelId('OpenRouter/auto')).toBe(true);
     expect(formatBrandedModelId('openrouter/auto')).toBe(`${getBrandingModelSlug()}/auto`);
     expect(formatBrandedModelId('deepseek/deepseek-chat')).toBe('deepseek/deepseek-chat');
   });

--- a/src/components/Branding/brandedModelId.ts
+++ b/src/components/Branding/brandedModelId.ts
@@ -2,20 +2,20 @@ import { BRANDING_NAME } from '@lobechat/business-const';
 
 import { isCustomBranding } from '@/const/version';
 
-const OPENROUTER_MODEL_PREFIX = 'openrouter/';
-
 /** Slug used in UI model ids, e.g. `aico` from branding name `Aico`. */
 export const getBrandingModelSlug = (): string => BRANDING_NAME.trim().toLowerCase();
 
 /**
  * True when this model id is an OpenRouter-namespace id that should show as our brand
  * (e.g. `openrouter/auto` → `aico/auto` + ProductLogo).
+ * Matches ModelIcon's `^openrouter` keyword so any OpenRouter-owned id is branded.
  */
 export const isBrandedOpenRouterModelId = (modelId: string): boolean =>
-  isCustomBranding && modelId.toLowerCase().startsWith(OPENROUTER_MODEL_PREFIX);
+  Boolean(isCustomBranding && modelId && /^openrouter\b/i.test(modelId));
 
 /** Display-only id; runtime/API ids stay `openrouter/...`. */
 export const formatBrandedModelId = (modelId: string): string => {
   if (!isBrandedOpenRouterModelId(modelId)) return modelId;
-  return `${getBrandingModelSlug()}/${modelId.slice(OPENROUTER_MODEL_PREFIX.length)}`;
+  const rest = modelId.replace(/^openrouter\/?/i, '');
+  return rest ? `${getBrandingModelSlug()}/${rest}` : getBrandingModelSlug();
 };

--- a/src/components/Branding/index.ts
+++ b/src/components/Branding/index.ts
@@ -4,5 +4,6 @@ export {
   getBrandingModelSlug,
   isBrandedOpenRouterModelId,
 } from './brandedModelId';
+export { BrandedModelTag } from './BrandedModelTag';
 export { OrgBrand } from './OrgBrand';
 export { ProductLogo } from './ProductLogo';

--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -1,8 +1,8 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Center, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo, useCallback } from 'react';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
@@ -92,7 +92,7 @@ const ModelSwitch = memo(() => {
       width={blockSize}
     >
       <div className={styles.icon}>
-        <ModelIcon model={model} size={iconSize} />
+        <BrandedModelIcon model={model} size={iconSize} />
       </div>
     </Center>
   );

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
@@ -1,5 +1,4 @@
 import { getCachedTextInputUnitRate, getWriteCacheInputUnitRate } from '@lobechat/utils';
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -8,6 +7,7 @@ import { type LobeDefaultAiModelListItem } from 'model-bank';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -52,7 +52,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
         justify={'space-between'}
       >
         <Flexbox horizontal align={'center'} gap={8}>
-          <ModelIcon model={id} size={22} />
+          <BrandedModelIcon model={id} size={22} />
           <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
             <Flexbox horizontal align={'center'} gap={8} style={{ lineHeight: '12px' }}>
               {displayName || id}

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -3,7 +3,6 @@ import {
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
-import { ModelIcon } from '@lobehub/icons';
 import { Center, Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
@@ -11,6 +10,7 @@ import { CircleDollarSignIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
@@ -79,7 +79,7 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
         <Center horizontal gap={4}>
           {heteroName || (
             <>
-              <ModelIcon model={model as string} type={'mono'} />
+              <BrandedModelIcon model={model as string} type={'mono'} />
               {modelCard?.displayName || model}
             </>
           )}

--- a/src/features/Conversation/components/History/index.tsx
+++ b/src/features/Conversation/components/History/index.tsx
@@ -1,10 +1,10 @@
-import { ModelTag } from '@lobehub/icons';
 import { Center, Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ScrollText } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelTag } from '@/components/Branding/BrandedModelTag';
 import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useAgentStore } from '@/store/agent/store';
 
@@ -50,7 +50,7 @@ const History = memo(() => {
             <Text type={'secondary'}>{t('historySummary')}</Text>
             {model && (
               <div>
-                <ModelTag model={model} />
+                <BrandedModelTag model={model} />
               </div>
             )}
           </Flexbox>

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,4 +1,3 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Tag, Text, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { Button, Select, type SelectProps, Switch } from '@lobehub/ui/base-ui';
 import { toast } from '@lobehub/ui/base-ui';
@@ -7,6 +6,7 @@ import { type ReactNode } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
@@ -242,7 +242,7 @@ const ModelSelect = memo<ModelSelectProps>(
         label: (
           <Flexbox gap={4}>
             <Flexbox horizontal align={'center'} gap={8}>
-              <ModelIcon model={value.model} size={20} />
+              <BrandedModelIcon model={value.model} size={20} />
               <Text ellipsis style={{ fontSize: 14 }}>
                 {meta?.displayName || value.model}
               </Text>


### PR DESCRIPTION
<!-- Brief and heads-up -->

Settings already branded `openrouter/*` model avatars with the Aico favicon. Chat still rendered the stock OpenRouter flame for Auto Router and related surfaces.

| Before | After |
| ------ | ----- |
| Chat model button / usage / history showed OpenRouter flame for `openrouter/auto` | Same Aico product logo as settings model list |
| Vendor models unchanged | Still show OpenAI / Anthropic / etc. icons |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --lint --test` on touched files (2 passed)
- Select Auto Router in chat → action-bar icon is Aico favicon, not OpenRouter flame
- Confirm GPT-4 / Claude icons unchanged

#### How to Test

1. Open chat model switcher and select **Auto Router** (`openrouter/auto`)
2. Confirm the circular model button in the input action bar shows the Aico logo
3. Send a message and check usage footer / history summary when present
4. Switch to a non-OpenRouter model and confirm vendor icons remain

#### 🔗 Related Issue

Fixes #135

Plane: [AICO-81](https://plane.panafor.com/panaforai/browse/AICO-81)


Made with [Cursor](https://cursor.com)