### PR TITLE
🐛 fix(auth): bind OTP input value into Ant Design Form

### DIFF
--- a/src/features/Auth/OtpCodeInput.tsx
+++ b/src/features/Auth/OtpCodeInput.tsx
@@ -1,5 +1,6 @@
 import { Input } from 'antd';
 import { createStaticStyles } from 'antd-style';
+import type { FocusEventHandler } from 'react';
 
 const styles = createStaticStyles(({ css }) => ({
   otp: css`
@@ -21,9 +22,41 @@ const styles = createStaticStyles(({ css }) => ({
 
 interface OtpCodeInputProps {
   autoFocus?: boolean;
+  disabled?: boolean;
+  id?: string;
+  onBlur?: FocusEventHandler;
+  /** Injected by Form.Item — required for OTP to bind into the form. */
+  onChange?: (value: string) => void;
   size?: 'large' | 'middle' | 'small';
+  status?: 'error' | 'warning';
+  /** Injected by Form.Item — required for OTP to bind into the form. */
+  value?: string;
 }
 
-export const OtpCodeInput = ({ autoFocus, size = 'large' }: OtpCodeInputProps) => (
-  <Input.OTP autoFocus={autoFocus} className={styles.otp} length={6} size={size} />
+/**
+ * Form.Item-compatible OTP input. Must forward value/onChange so Ant Design
+ * Form can read the entered code (otherwise submit always fails "required").
+ */
+export const OtpCodeInput = ({
+  autoFocus,
+  disabled,
+  id,
+  onBlur,
+  onChange,
+  size = 'large',
+  status,
+  value,
+}: OtpCodeInputProps) => (
+  <Input.OTP
+    autoFocus={autoFocus}
+    className={styles.otp}
+    disabled={disabled}
+    id={id}
+    length={6}
+    size={size}
+    status={status}
+    value={value}
+    onBlur={onBlur}
+    onChange={onChange}
+  />
 );


### PR DESCRIPTION
## Summary
- Forward Form.Item `value` / `onChange` (and related control props) through `OtpCodeInput` to Ant Design `Input.OTP`
- Fixes SMS OTP submit always showing “Please enter the verification code” / «لطفاً کد تأیید را وارد کنید»

#### Test
- [x] Tested locally (Form + Input.OTP binding verified in a temporary RTL check before removing disallowed new `.test.tsx`)
- [ ] Added/updated tests
- [x] No tests needed (new React component tests are disallowed; change is prop forwarding only)

#### 🔗 Related Issue
Fixes #137

Plane: [AICO-82](https://plane.panafor.com/panaforai/browse/AICO-82)


Made with [Cursor](https://cursor.com)