### PR TITLE
✨ feat(aico): icon-only message cost with precise hover details

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -76,16 +76,18 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
     <MessageActionBar
       bar={actionsConfig?.bar ?? defaultBar}
       ctx={ctx}
-      leading={<ReactionPicker messageId={id} />}
       menu={actionsConfig?.menu ?? DEFAULT_MENU}
-      trailing={
-        showCost ? (
-          <MessageCostBadge
-            metadata={data.metadata}
-            performance={data.performance}
-            usage={data.usage}
-          />
-        ) : undefined
+      leading={
+        <>
+          <ReactionPicker messageId={id} />
+          {showCost ? (
+            <MessageCostBadge
+              metadata={data.metadata}
+              performance={data.performance}
+              usage={data.usage}
+            />
+          ) : null}
+        </>
       }
     />
   );

--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -79,7 +79,13 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
       leading={<ReactionPicker messageId={id} />}
       menu={actionsConfig?.menu ?? DEFAULT_MENU}
       trailing={
-        showCost ? <MessageCostBadge metadata={data.metadata} usage={data.usage} /> : undefined
+        showCost ? (
+          <MessageCostBadge
+            metadata={data.metadata}
+            performance={data.performance}
+            usage={data.usage}
+          />
+        ) : undefined
       }
     />
   );

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -82,7 +82,13 @@ export const GroupActionsBar = memo<GroupActionsProps>(
         ctx={ctx}
         leading={<ReactionPicker messageId={id} />}
         menu={actionsConfig?.menu ?? DEFAULT_MENU}
-        trailing={<MessageCostBadge metadata={data.metadata} usage={data.usage} />}
+        trailing={
+          <MessageCostBadge
+            metadata={data.metadata}
+            performance={data.performance}
+            usage={data.usage}
+          />
+        }
       />
     );
   },

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -80,14 +80,16 @@ export const GroupActionsBar = memo<GroupActionsProps>(
       <MessageActionBar
         bar={actionsConfig?.bar ?? defaultBar}
         ctx={ctx}
-        leading={<ReactionPicker messageId={id} />}
         menu={actionsConfig?.menu ?? DEFAULT_MENU}
-        trailing={
-          <MessageCostBadge
-            metadata={data.metadata}
-            performance={data.performance}
-            usage={data.usage}
-          />
+        leading={
+          <>
+            <ReactionPicker messageId={id} />
+            <MessageCostBadge
+              metadata={data.metadata}
+              performance={data.performance}
+              usage={data.usage}
+            />
+          </>
         }
       />
     );

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -1,5 +1,5 @@
-import { type ModelUsage } from '@lobechat/types';
-import { Center, Icon, Tooltip } from '@lobehub/ui';
+import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
+import { Center, Flexbox, Icon } from '@lobehub/ui';
 import { Popover } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { CircleDollarSignIcon } from 'lucide-react';
@@ -14,91 +14,153 @@ import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
-    cursor: default;
+    cursor: pointer;
 
+    width: 28px;
     height: 28px;
-    padding-inline: 6px;
     border-radius: 6px;
 
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
     color: ${cssVar.colorTextSecondary};
 
     :hover {
       background: ${cssVar.colorFillTertiary};
     }
   `,
-  chipInteractive: css`
-    cursor: pointer;
+  costValue: css`
+    font-size: 13px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorText};
   `,
   detailRow: css`
     display: flex;
-    gap: 12px;
+    gap: 16px;
     align-items: center;
     justify-content: space-between;
 
-    min-width: 140px;
+    min-width: 200px;
 
     font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
   `,
   detailValue: css`
     font-weight: 500;
     font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorText};
+  `,
+  sectionTitle: css`
+    margin-block-end: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    color: ${cssVar.colorTextDescription};
   `,
 }));
 
+type DetailRow = { key: string; label: string; value: string };
+
+const buildUsageDetailRows = (
+  usage: ModelUsage | undefined,
+  performance: ModelPerformance | undefined,
+  t: (key: string) => string,
+): DetailRow[] => {
+  if (!usage) return [];
+
+  const rows: DetailRow[] = [];
+  const push = (key: string, label: string, value: number | undefined) => {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return;
+    rows.push({ key, label, value: formatNumber(value) });
+  };
+
+  push('input', t('messages.tokenDetails.inputTitle'), usage.totalInputTokens);
+  push('inputText', t('messages.tokenDetails.inputText'), usage.inputTextTokens);
+  push('inputCached', t('messages.tokenDetails.inputCached'), usage.inputCachedTokens);
+  push(
+    'inputWriteCached',
+    t('messages.tokenDetails.inputWriteCached'),
+    usage.inputWriteCacheTokens,
+  );
+  push('inputUncached', t('messages.tokenDetails.inputUncached'), usage.inputCacheMissTokens);
+  push('inputAudio', t('messages.tokenDetails.inputAudio'), usage.inputAudioTokens);
+  push('inputCitation', t('messages.tokenDetails.inputCitation'), usage.inputCitationTokens);
+  push('inputTool', t('messages.tokenDetails.inputTool'), usage.inputToolTokens);
+
+  push('output', t('messages.tokenDetails.outputTitle'), usage.totalOutputTokens);
+  push('outputText', t('messages.tokenDetails.outputText'), usage.outputTextTokens);
+  push('reasoning', t('messages.tokenDetails.reasoning'), usage.outputReasoningTokens);
+  push('outputAudio', t('messages.tokenDetails.outputAudio'), usage.outputAudioTokens);
+  push('outputImage', t('messages.tokenDetails.outputImage'), usage.outputImageTokens);
+
+  push('total', t('messages.tokenDetails.total'), usage.totalTokens);
+
+  if (performance?.tps) {
+    rows.push({
+      key: 'tps',
+      label: t('messages.tokenDetails.speed.tps.title'),
+      value: formatNumber(performance.tps, 1),
+    });
+  }
+  if (performance?.ttft) {
+    rows.push({
+      key: 'ttft',
+      label: t('messages.tokenDetails.speed.ttft.title'),
+      value: `${formatNumber(performance.ttft / 1000, 2)}s`,
+    });
+  }
+
+  return rows;
+};
+
 interface MessageCostBadgeProps {
   metadata?: Record<string, unknown> | null;
+  performance?: ModelPerformance;
   usage?: ModelUsage;
 }
 
-const MessageCostBadge = memo<MessageCostBadgeProps>(({ usage, metadata }) => {
+const MessageCostBadge = memo<MessageCostBadgeProps>(({ usage, metadata, performance }) => {
   const { t } = useTranslation('chat');
   const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
 
   const cost = useMemo(() => resolveMessageCost(usage, metadata), [usage, metadata]);
+  const detailRows = useMemo(
+    () => buildUsageDetailRows(usage, performance, t),
+    [usage, performance, t],
+  );
 
   if (isShowCredit) return null;
   if (cost === undefined || cost <= 0) return null;
 
   const amount = formatMessageCostUsd(cost);
   const label = t('messageAction.cost');
-  const hasTokenDetail = !!usage?.totalTokens;
 
-  const chip = (
-    <Center
-      horizontal
-      aria-label={`${label}: ${amount}`}
-      className={hasTokenDetail ? `${styles.chip} ${styles.chipInteractive}` : styles.chip}
-      gap={2}
-    >
-      <Icon icon={CircleDollarSignIcon} size={14} />
-      <span>{amount}</span>
-    </Center>
-  );
-
-  if (hasTokenDetail) {
-    return (
-      <Popover
-        content={
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: 4 }}>
-            <div className={styles.detailRow}>
-              <span>{label}</span>
-              <span className={styles.detailValue}>{amount}</span>
-            </div>
-            <div className={styles.detailRow}>
-              <span>{t('messages.tokenDetails.total')}</span>
-              <span className={styles.detailValue}>{formatNumber(usage!.totalTokens!)}</span>
-            </div>
+  return (
+    <Popover
+      placement="top"
+      trigger="hover"
+      content={
+        <Flexbox gap={12} style={{ minWidth: 220, padding: 4 }}>
+          <div>
+            <div className={styles.sectionTitle}>{label}</div>
+            <div className={styles.costValue}>{amount}</div>
           </div>
-        }
-      >
-        {chip}
-      </Popover>
-    );
-  }
 
-  return <Tooltip title={label}>{chip}</Tooltip>;
+          {detailRows.length > 0 && (
+            <Flexbox gap={6}>
+              {detailRows.map((row) => (
+                <div className={styles.detailRow} key={row.key}>
+                  <span>{row.label}</span>
+                  <span className={styles.detailValue}>{row.value}</span>
+                </div>
+              ))}
+            </Flexbox>
+          )}
+        </Flexbox>
+      }
+    >
+      <Center horizontal aria-label={`${label}: ${amount}`} className={styles.chip}>
+        <Icon icon={CircleDollarSignIcon} size={14} />
+      </Center>
+    </Popover>
+  );
 });
 
 MessageCostBadge.displayName = 'MessageCostBadge';

--- a/src/features/Conversation/Messages/components/resolveMessageCost.test.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageCost.test.ts
@@ -23,8 +23,18 @@ describe('resolveMessageCost', () => {
 });
 
 describe('formatMessageCostUsd', () => {
-  it('formats to two decimal places with a dollar sign', () => {
+  it('keeps at least two decimals for typical amounts', () => {
     expect(formatMessageCostUsd(0.37)).toBe('$0.37');
     expect(formatMessageCostUsd(1)).toBe('$1.00');
+  });
+
+  it('preserves micro-USD precision for small OpenRouter charges', () => {
+    expect(formatMessageCostUsd(0.00015)).toBe('$0.00015');
+    expect(formatMessageCostUsd(0.0042)).toBe('$0.0042');
+  });
+
+  it('trims trailing zeros beyond two places', () => {
+    expect(formatMessageCostUsd(0.12)).toBe('$0.12');
+    expect(formatMessageCostUsd(1.23)).toBe('$1.23');
   });
 });

--- a/src/features/Conversation/Messages/components/resolveMessageCost.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageCost.ts
@@ -11,4 +11,16 @@ export const resolveMessageCost = (
   return undefined;
 };
 
-export const formatMessageCostUsd = (cost: number) => `$${cost.toFixed(2)}`;
+/**
+ * Format USD with micro-precision (up to 6 dp). Trims trailing zeros but keeps
+ * at least 2 fractional digits so small OpenRouter charges stay accurate.
+ */
+export const formatMessageCostUsd = (cost: number): string => {
+  if (!Number.isFinite(cost)) return '$0.00';
+  const fixed = Math.abs(cost).toFixed(6);
+  const [whole, frac = '000000'] = fixed.split('.');
+  const trimmed = frac.replace(/0+$/, '');
+  const decimals = trimmed.length > 2 ? trimmed : frac.slice(0, 2);
+  const sign = cost < 0 ? '-' : '';
+  return `${sign}$${whole}.${decimals}`;
+};


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #138

Plane: [AICO-83](https://plane.panafor.com/panaforai/browse/AICO-83)

#### Description of Change

- Action bar shows cost as **icon only** (matches copy/edit)
- Hover popover: precise USD (up to 6 dp / micro-USD), not `toFixed(2)`
- Hover details: input/output/cache/reasoning/tool tokens + TPS/TTFT when present — not just total tokens

#### Test

- [x] Updated `formatMessageCostUsd` precision tests
- [ ] No tests needed

#### How to Test

1. After deploy, send a managed chat that stores `usage.cost`
2. Action bar shows `$` icon only (no inline amount)
3. Hover: precise cost + token breakdown rows

Made with [Cursor](https://cursor.com)