### PR TITLE
🐛 fix(aico): pin RTL tab pills via indicator direction:ltr

### DIFF
--- a/src/styles/global.rtl.test.ts
+++ b/src/styles/global.rtl.test.ts
@@ -21,22 +21,13 @@ describe('global RTL control fixes', () => {
     expect(source).toContain('direction: ltr');
   });
 
-  it('maps Tabs selection indicators to physical left (incl. Settings animation)', () => {
-    // Ungated: physical left works in LTR and fixes RTL regardless of html.dir timing
+  it('forces LTR on Tabs/Segmented indicators so inset-inline-start matches physical left', () => {
     expect(source).toContain("[role='tablist'] > [role='presentation']");
-    expect(source).toContain('left: var(--active-tab-left) !important');
-    expect(source).toContain('inset-inline: auto !important');
-    expect(source).toContain(
-      'transition-property: left, top, inset-block-start, width, height, transform !important',
-    );
-    // Prior broken formula used containing-block % and --active-tab-right
+    expect(source).toContain("[data-orientation] > [aria-hidden='true']:first-of-type");
+    expect(source).toMatch(/\[role='tablist'\] > \[role='presentation'\][\s\S]*?direction:\s*ltr/);
+    // Prior broken approaches (inset-inline:auto wiped left under RTL)
+    expect(source).not.toContain('inset-inline: auto');
     expect(source).not.toContain('var(--active-tab-right)');
     expect(source).not.toContain('(var(--active-tab-width) - 100%)');
-  });
-
-  it('maps Segmented selection indicators to physical left', () => {
-    expect(source).toContain("[data-orientation] > [aria-hidden='true']:first-of-type");
-    expect(source).toContain('left: var(--active-item-left) !important');
-    expect(source).toContain('liberty/use-logical-spec');
   });
 });

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -84,10 +84,12 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
    * Tabs / Segmented indicators (Settings → Appearance animation, platform/org
    * admin tabs, etc.): JS writes physical offsetLeft into --active-tab-left /
    * --active-item-left, but component CSS binds logical inset-inline-start.
-   * Under RTL that mirrors the pill away from the active option. Always force
-   * physical \`left\` (safe in LTR too — left === inset-inline-start there).
-   * Do not gate on html[dir=rtl] only: antd direction=rtl can nest :dir(rtl)
-   * without html.dir matching yet.
+   * Under document RTL that places the pill from the wrong edge.
+   *
+   * Fix: force direction:ltr on the indicator so inset-inline-start resolves to
+   * physical left (matching the JS offset). Do not fight with left +
+   * inset-inline overrides — inset-inline:auto after left wipes the offset
+   * under RTL (inline-end maps to left), which left the pill on the wrong tab.
    */
   :dir(rtl) [role='switch'],
   html[dir='rtl'] [role='switch'] {
@@ -96,21 +98,10 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
     direction: ltr;
   }
 
-  /* stylelint-disable liberty/use-logical-spec -- indicator offsets are physical */
-  [role='tablist'] > [role='presentation'] {
-    right: auto !important;
-    left: var(--active-tab-left) !important;
-    inset-inline: auto !important;
-    transition-property: left, top, inset-block-start, width, height, transform !important;
-  }
-
+  [role='tablist'] > [role='presentation'],
   [data-orientation] > [aria-hidden='true']:first-of-type {
-    right: auto !important;
-    left: var(--active-item-left) !important;
-    inset-inline: auto !important;
-    transition-property: left, top, inset-block-start, width, height, transform !important;
+    direction: ltr;
   }
-  /* stylelint-enable liberty/use-logical-spec */
 `;
 
 export default genGlobalStyle;


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### How to Test

1. Set language to Persian (`fa-IR`).
2. Open `/platform` and `/org` — switch tabs; the grey pill must sit under the blue selected label.
3. Open **Settings → Appearance** animation tabs (خاموش / سریع / زیبا) — same check.
4. Confirm LTR English tabs still look correct.

#### 🔗 Related Issue

Fixes #144

Plane: [AICO-86](https://plane.panafor.com/panaforai/browse/AICO-86)

Related (prior incomplete fixes): #113 / #119 / PR #114 / PR #120

#### Description of Change

PR #120 set `left: var(--active-tab-left)` then `inset-inline: auto !important`. Under RTL, `inset-inline-end` maps to physical **left**, wiping the offset so the selection pill stayed on the wrong tab.

Replace that with `direction: ltr` on the indicator so the component’s existing `inset-inline-start: var(--active-tab-left)` resolves to physical left and tracks the selected option.

Made with [Cursor](https://cursor.com)