### PR TITLE
🐛 fix(aico): hide free chat models and improve input RTL/LTR

### DIFF
--- a/packages/database/src/repositories/aiInfra/__tests__/getEnabledModels.test.ts
+++ b/packages/database/src/repositories/aiInfra/__tests__/getEnabledModels.test.ts
@@ -1088,5 +1088,44 @@ describe('AiInfraRepos', () => {
         units: [{ name: 'textInput', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' }],
       });
     });
+
+    it('should exclude free models marked by :free id or (free) display name', async () => {
+      const mockProviders = [
+        {
+          enabled: true,
+          id: 'openrouter',
+          name: 'OpenRouter',
+          sort: 1,
+          source: 'builtin' as const,
+        },
+      ];
+
+      vi.spyOn(repo, 'getAiProviderList').mockResolvedValue(mockProviders);
+      vi.spyOn(repo.aiModelModel, 'getAllModels').mockResolvedValue([]);
+      vi.spyOn(repo as any, 'fetchBuiltinModels').mockResolvedValue([
+        {
+          displayName: 'Llama 3.3 70B Instruct',
+          enabled: true,
+          id: 'meta-llama/llama-3.3-70b-instruct:free',
+          type: 'chat' as const,
+        },
+        {
+          displayName: 'Gemma 2 9B (free)',
+          enabled: true,
+          id: 'google/gemma-2-9b-it',
+          type: 'chat' as const,
+        },
+        {
+          displayName: 'GPT-4o',
+          enabled: true,
+          id: 'openai/gpt-4o',
+          type: 'chat' as const,
+        },
+      ]);
+
+      const result = await repo.getEnabledModels();
+
+      expect(result.map((m) => m.id)).toEqual(['openai/gpt-4o']);
+    });
   });
 });

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -206,9 +206,9 @@ export class AiInfraRepos {
         injectSearchSettings(item.providerId, { ...item, type: normalizeAiModelType(item.type) }),
       );
 
-    return [...builtinModels, ...appendedUserModels].sort(
-      (a, b) => (a?.sort ?? Infinity) - (b?.sort ?? Infinity),
-    ) as EnabledAiModel[];
+    return [...builtinModels, ...appendedUserModels]
+      .filter((model) => isAiModelVisible(model) && !isFreeAiModel(model))
+      .sort((a, b) => (a?.sort ?? Infinity) - (b?.sort ?? Infinity)) as EnabledAiModel[];
   };
 
   getAiProviderRuntimeState = async (

--- a/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
+++ b/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
@@ -1,0 +1,70 @@
+import { useLexicalComposerContext } from '@lobehub/editor';
+import { $getRoot, $isElementNode } from 'lexical';
+import { type FC, useEffect } from 'react';
+
+import { getTextDirectionFromFirstStrong } from './getTextDirectionFromFirstStrong';
+
+const AUTO_DIR_TAG = 'chat-input-auto-direction';
+
+/**
+ * Sets each top-level block's Lexical direction from the first strong character.
+ * Also clears a forced root `ltr` (from @lobehub/editor inode defaults) so
+ * paragraphs can use auto / explicit rtl without inheriting LTR.
+ */
+const ReactAutoDirectionPlugin: FC = () => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const lexicalEditor = editor.getLexicalEditor();
+    if (!lexicalEditor) return;
+
+    return lexicalEditor.registerUpdateListener(({ editorState, tags }) => {
+      if (tags.has(AUTO_DIR_TAG)) return;
+
+      let needsUpdate = false;
+
+      editorState.read(() => {
+        const root = $getRoot();
+        if (root.getDirection() !== null) {
+          needsUpdate = true;
+          return;
+        }
+
+        for (const child of root.getChildren()) {
+          if (!$isElementNode(child) || child.isInline()) continue;
+          const next = getTextDirectionFromFirstStrong(child.getTextContent());
+          if (child.getDirection() !== next) {
+            needsUpdate = true;
+            return;
+          }
+        }
+      });
+
+      if (!needsUpdate) return;
+
+      lexicalEditor.update(
+        () => {
+          const root = $getRoot();
+          if (root.getDirection() !== null) {
+            root.setDirection(null);
+          }
+
+          for (const child of root.getChildren()) {
+            if (!$isElementNode(child) || child.isInline()) continue;
+            const next = getTextDirectionFromFirstStrong(child.getTextContent());
+            if (child.getDirection() !== next) {
+              child.setDirection(next);
+            }
+          }
+        },
+        { tag: AUTO_DIR_TAG },
+      );
+    });
+  }, [editor]);
+
+  return null;
+};
+
+ReactAutoDirectionPlugin.displayName = 'ReactAutoDirectionPlugin';
+
+export default ReactAutoDirectionPlugin;

--- a/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.test.ts
+++ b/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTextDirectionFromFirstStrong } from './getTextDirectionFromFirstStrong';
+
+describe('getTextDirectionFromFirstStrong', () => {
+  it('returns rtl when the first strong character is Persian/Arabic', () => {
+    expect(getTextDirectionFromFirstStrong('سلام world')).toBe('rtl');
+    expect(getTextDirectionFromFirstStrong('  سلام')).toBe('rtl');
+  });
+
+  it('returns ltr when the first strong character is Latin', () => {
+    expect(getTextDirectionFromFirstStrong('hello سلام')).toBe('ltr');
+    expect(getTextDirectionFromFirstStrong('  hello')).toBe('ltr');
+  });
+
+  it('keeps rtl when English appears mid Persian sentence', () => {
+    expect(getTextDirectionFromFirstStrong('من از GPT استفاده می‌کنم')).toBe('rtl');
+  });
+
+  it('ignores leading digits and punctuation', () => {
+    expect(getTextDirectionFromFirstStrong('123 سلام')).toBe('rtl');
+    expect(getTextDirectionFromFirstStrong('...hello')).toBe('ltr');
+  });
+
+  it('returns null for empty or neutral-only text', () => {
+    expect(getTextDirectionFromFirstStrong('')).toBeNull();
+    expect(getTextDirectionFromFirstStrong('   ')).toBeNull();
+    expect(getTextDirectionFromFirstStrong('123')).toBeNull();
+  });
+});

--- a/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.ts
+++ b/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.ts
@@ -1,0 +1,18 @@
+export type TextDirection = 'ltr' | 'rtl' | null;
+
+/**
+ * First-strong character direction (Unicode bidi base direction).
+ * Skips neutrals; returns rtl for Arabic/Persian/Hebrew strong chars,
+ * ltr for Latin (and other LTR) letters. Digits alone do not set direction.
+ */
+const RTL_STRONG =
+  /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
+const LTR_STRONG = /[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0400-\u04FF]/u;
+
+export const getTextDirectionFromFirstStrong = (text: string): TextDirection => {
+  for (const char of text) {
+    if (RTL_STRONG.test(char)) return 'rtl';
+    if (LTR_STRONG.test(char)) return 'ltr';
+  }
+  return null;
+};

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -58,7 +58,11 @@ import { useMentionCategories } from './useMentionCategories';
 
 const className = cx(
   css`
+    /* Per-line first-strong direction for soft breaks; Lexical sets dir per paragraph. */
+    unicode-bidi: plaintext;
+
     p {
+      unicode-bidi: plaintext;
       margin-block-end: 0;
     }
   `,

--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -12,6 +12,7 @@ import { type Editor } from '@lobehub/editor/react';
 
 import { ReactActionTagPlugin } from './ActionTag';
 import { ReactLocalFileTagPlugin } from './LocalFileTag';
+import ReactAutoDirectionPlugin from './ReactAutoDirectionPlugin';
 import { ReactReferTopicPlugin } from './ReferTopic';
 
 type EditorPlugins = NonNullable<Parameters<typeof Editor>[0]['plugins']>;
@@ -22,6 +23,7 @@ interface CreateChatInputRichPluginsOptions {
 }
 
 export const CHAT_INPUT_EMBED_PLUGINS: EditorPlugins = [
+  ReactAutoDirectionPlugin,
   ReactActionTagPlugin,
   ReactReferTopicPlugin,
   ReactLocalFileTagPlugin,

--- a/src/features/Home/InputArea/InputFallback.tsx
+++ b/src/features/Home/InputArea/InputFallback.tsx
@@ -45,6 +45,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   textarea: css`
     resize: none;
 
+    unicode-bidi: plaintext;
     display: block;
     flex: 1;
 
@@ -105,6 +106,7 @@ const InputFallback = memo<InputFallbackProps>(
             autoFocus
             aria-label={placeholder}
             className={styles.textarea}
+            dir="auto"
             placeholder={placeholder}
             value={value}
             onChange={handleChange}

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -11,7 +11,7 @@ import type {
   ModelParamsSchema,
   Pricing,
 } from 'model-bank';
-import { isAiModelVisible } from 'model-bank/aiModel';
+import { isAiModelVisible, isFreeAiModel } from 'model-bank/aiModel';
 import { type SWRResponse } from 'swr';
 
 import { mutate, useClientDataSWR } from '@/libs/swr';
@@ -124,7 +124,11 @@ const createProviderModelCollector = (
 ) => {
   return async (enabledAiModels: EnabledAiModel[], providerId: string) => {
     const filteredModels = enabledAiModels.filter(
-      (model) => model.providerId === providerId && model.type === type && isAiModelVisible(model),
+      (model) =>
+        model.providerId === providerId &&
+        model.type === type &&
+        isAiModelVisible(model) &&
+        !isFreeAiModel(model),
     );
 
     if (!filteredModels.length) return [];


### PR DESCRIPTION
## Summary
- Hide OpenRouter-style free models (`:free` / `(free)`) from the chat model selector by filtering them in `getEnabledModels` and the chat provider model collector.
- Improve chat input RTL/LTR: each paragraph uses first-strong character direction, clears forced Lexical root `ltr`, and applies `unicode-bidi: plaintext` so mixed Persian/English no longer breaks layout.

## Test plan
- [ ] Open chat model selector — free models (`…:free` / `(free)`) are not listed
- [ ] Type a Persian sentence starting with فارسی — input aligns RTL
- [ ] Insert English in the middle of a Persian sentence — paragraph stays RTL
- [ ] Type an English-first line — input aligns LTR
- [ ] Soft line break (Shift+Enter) with different scripts — each line follows first strong char

Fixes #143
Plane: AICO-85 — https://plane.panafor.com/panaforai/browse/AICO-85


Made with [Cursor](https://cursor.com)