### PR TITLE
fix(auth): resolve react-router-dom import in auth SPA build

### DIFF
--- a/src/features/Auth/LegalDocument/index.tsx
+++ b/src/features/Auth/LegalDocument/index.tsx
@@ -5,7 +5,7 @@ import { Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   back: css`

--- a/src/features/AuthShell/AuthContainer.tsx
+++ b/src/features/AuthShell/AuthContainer.tsx
@@ -3,7 +3,7 @@ import { Center, Flexbox } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { cx } from 'antd-style';
 import { type FC, type PropsWithChildren } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { ProductLogo } from '@/components/Branding';
 import { useIsDark } from '@/hooks/useIsDark';


### PR DESCRIPTION
## Summary
- Replace stale `react-router-dom` imports with `react-router` in auth SPA entry graph
- Fixes `build:spa:auth` / `build:docker` Rolldown resolve failure

#### 🔗 Related Issue

Fixes #154

Plane: [AICO-90](https://plane.panafor.com/panaforai/browse/AICO-90)

## Test plan
- [x] `bun run build:spa:auth` succeeds
- [ ] `bun run build:docker` progresses past auth SPA step


Made with [Cursor](https://cursor.com)