### PR TITLE
docs(skills): document moz tmpfs bind mount data recovery

### DIFF
--- a/.agents/skills/self-host-deploy/SKILL.md
+++ b/.agents/skills/self-host-deploy/SKILL.md
@@ -3,9 +3,11 @@ name: self-host-deploy
 description: >-
   Deploy Aico self-hosted with Docker Compose — zero to production.
   Covers setup.sh, custom domain, reverse proxy/CDN, build-from-source,
-  platform admin bootstrap, production hardening, and SPA chunk troubleshooting.
+  platform admin bootstrap, production hardening, SPA chunk troubleshooting,
+  and local moz deploy data persistence (PANACHAT_DATA_DIR / tmpfs bind bugs).
   Use when the user asks to deploy, self-host, docker compose, production setup,
-  domain config, platform admin, best practices, or errors like "Failed to fetch
+  domain config, platform admin, best practices, moz -u/-d/-i, missing users,
+  empty DB after redeploy, platform admins gone, or errors like "Failed to fetch
   dynamically imported module" on /_spa/assets.
 user-invocable: true
 ---

--- a/.agents/skills/self-host-deploy/reference.md
+++ b/.agents/skills/self-host-deploy/reference.md
@@ -117,13 +117,55 @@ FROM platform_admins pa
 JOIN users u ON u.id = pa.user_id;
 ```
 
-## Database reset (destructive)
+## Local moz data dir (PanaChat)
+
+Local builds via `moz` / `scripts/deploy-local.sh` persist Postgres/Redis/RustFS under:
+
+`PANACHAT_DATA_DIR` → default `~/.local/share/panachat-data/{postgres,redis,rustfs}`
+
+Compose binds that path via `docker-compose.aico.data.override.yml`. **`moz -u` / `moz -d` do not delete this directory** — they only recreate containers.
+
+### Symptom: users / platform admins “missing” after redeploy
+
+Often **not** a wipe. Docker Desktop + WSL2 sometimes reports a bind mount in `docker inspect` but the container filesystem is **tmpfs** (empty RAM disk). Postgres then initializes a fresh empty cluster while the real data remains on the host path.
+
+Diagnose:
 
 ```bash
-docker compose down
-sudo rm -rf ./data # Postgres volume
-docker compose up -d
+docker exec lobe-postgres df -T /var/lib/postgresql/data
+# Good: ext4 (or other real FS) under ~/.local/share/panachat-data/postgres
+# Bad:  tmpfs / none
+
+./scripts/deploy-local.sh -i # Users / Platform admins counts
 ```
+
+Recover (do **not** `rm -rf` the host postgres dir):
+
+```bash
+moz -k
+# Optional: confirm host cluster still has data
+docker run --rm -v "$HOME/.local/share/panachat-data/postgres:/d:ro" alpine \
+  sh -c 'test -f /d/PG_VERSION && du -sh /d && df -T /d'
+moz -d
+docker exec lobe-postgres df -T /var/lib/postgresql/data # must NOT be tmpfs
+moz -i
+```
+
+If it is **still tmpfs** after redeploy: restart Docker Desktop, then `moz -d` again.
+
+**Never** run `rm -rf ~/.local/share/panachat-data/postgres` unless the user explicitly wants a destructive reset — that is the good copy when the live container is on tmpfs.
+
+## Database reset (destructive)
+
+Only when the user explicitly wants to wipe data:
+
+```bash
+moz -k
+rm -rf "${PANACHAT_DATA_DIR:-$HOME/.local/share/panachat-data}/postgres"
+moz -d
+```
+
+Upstream-style `./data` wipe is obsolete for Aico local moz deploys (data lives under `PANACHAT_DATA_DIR`, not `docker-compose/deploy/data`).
 
 Migrations run automatically on container start (`docker.cjs`).
 


### PR DESCRIPTION
## Summary
- Document `PANACHAT_DATA_DIR` persistence for local `moz` deploys
- Diagnose/recover when Docker Desktop/WSL mounts Postgres as tmpfs (users appear missing; host data intact)
- Replace obsolete `./data` wipe instructions with the panachat-data path

## Test plan
- [ ] Skill text matches local recovery steps (`moz -k` → verify host → `moz -d` → `df -T` not tmpfs)


Made with [Cursor](https://cursor.com)