### PR TITLE
fix: invite link recovery + billing switcher/Home funds UX

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
@@ -350,6 +350,52 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     expect(listed.invites.every((i: any) => !('token' in i))).toBe(true);
   });
 
+  it('AICO-92: getInviteLink reveals URL to managers; denies members/strangers; rejects revoked', async () => {
+    const ownerCaller = organizationRouter.createCaller(createTestContext(ownerId));
+    const created = await ownerCaller.create({ name: 'Reveal Link Org' });
+    const invite = await ownerCaller.inviteMember({
+      identifierType: 'email',
+      identifierValue: 'reveal@rbac.test',
+      orgId: created.id,
+    });
+
+    const revealed = await ownerCaller.getInviteLink({
+      inviteId: invite.id,
+      orgId: created.id,
+    });
+    expect(revealed.inviteUrl).toBe(invite.inviteUrl);
+    expect(revealed.id).toBe(invite.id);
+    expect((revealed as { token?: string }).token).toBeUndefined();
+
+    // Accept as member so they become an org member without manager rights.
+    const memberInvite = await ownerCaller.inviteMember({
+      identifierType: 'email',
+      identifierValue: 'member@rbac.test',
+      orgId: created.id,
+    });
+    const memberCaller = organizationRouter.createCaller(createTestContext(memberId));
+    await memberCaller.acceptInvite({
+      token: memberInvite.inviteUrl.split('/invite/').at(-1)!,
+    });
+    await expect(
+      memberCaller.getInviteLink({ inviteId: invite.id, orgId: created.id }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const strangerCaller = organizationRouter.createCaller(createTestContext(strangerId));
+    await expect(
+      strangerCaller.getInviteLink({ inviteId: invite.id, orgId: created.id }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+
+    const revoked = await ownerCaller.revokeInvite({
+      inviteId: invite.id,
+      orgId: created.id,
+    });
+    expect((revoked as { token?: string }).token).toBeUndefined();
+    await expect(
+      ownerCaller.getInviteLink({ inviteId: invite.id, orgId: created.id }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'Invite is not pending' });
+  });
+
   it('AICO-P1-018: getMyWallet returns string balances (micro-USD serialization)', async () => {
     const caller = aicoBillingRouter.createCaller(createTestContext(strangerId));
     const wallet = await caller.getMyWallet();

--- a/apps/server/src/routers/lambda/organization.ts
+++ b/apps/server/src/routers/lambda/organization.ts
@@ -376,7 +376,39 @@ export const organizationRouter = router({
       await requireOrgManager(ctx.organizationModel, ctx.userId, input.orgId);
       const revoked = await ctx.organizationModel.revokeInvite(input);
       if (!revoked) throw new TRPCError({ code: 'NOT_FOUND', message: 'Invite not found' });
-      return revoked;
+      // Never return the raw token — managers already have getInviteLink for URL recovery.
+      return {
+        expiresAt: revoked.expiresAt.toISOString(),
+        id: revoked.id,
+        identifierType: revoked.identifierType,
+        identifierValue: revoked.identifierValue,
+        role: revoked.role,
+        status: revoked.status,
+      };
+    }),
+
+  /**
+   * On-demand invite URL for org managers (AICO-92).
+   * Keeps listMembers token-free (AICO-P1-026) while allowing recovery after the
+   * one-shot post-invite modal is closed.
+   */
+  getInviteLink: orgProcedure
+    .input(z.object({ inviteId: z.string().min(1), orgId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      await requireOrgManager(ctx.organizationModel, ctx.userId, input.orgId);
+      const invite = await ctx.organizationModel.getInviteById(input);
+      if (!invite) throw new TRPCError({ code: 'NOT_FOUND', message: 'Invite not found' });
+      if (invite.status !== 'pending') {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invite is not pending' });
+      }
+      if (invite.expiresAt.getTime() < Date.now()) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invite expired' });
+      }
+      return {
+        expiresAt: invite.expiresAt.toISOString(),
+        id: invite.id,
+        inviteUrl: `${appEnv.APP_URL}/invite/${invite.token}`,
+      };
     }),
 
   getInvitePreview: orgProcedure

--- a/locales/en-US/aico.json
+++ b/locales/en-US/aico.json
@@ -98,6 +98,8 @@
   "org.invite.role": "Role",
   "org.invite.sent": "Invite created — share this link",
   "org.invite.shareLink": "Invitation created. Copy this link to share manually (Telegram, WhatsApp, etc.). Delivery by email/SMS may also have been attempted.",
+  "org.invite.showLink": "Show link",
+  "org.invite.showLinkFailed": "Failed to load invite link",
   "org.invite.submit": "Send invite",
   "org.invite.title": "Invite member",
   "org.invite.type": "Invite by",

--- a/locales/fa-IR/aico.json
+++ b/locales/fa-IR/aico.json
@@ -98,6 +98,8 @@
   "org.invite.role": "نقش",
   "org.invite.sent": "دعوت ایجاد شد — این لینک را به اشتراک بگذارید",
   "org.invite.shareLink": "دعوت ایجاد شد. این لینک را کپی کنید تا دستی ارسال کنید (تلگرام، واتساپ و …). ممکن است ایمیل/پیامک هم ارسال شده باشد.",
+  "org.invite.showLink": "نمایش لینک",
+  "org.invite.showLinkFailed": "بارگذاری لینک دعوت ناموفق بود",
   "org.invite.submit": "ارسال دعوت‌نامه",
   "org.invite.title": "دعوت عضو",
   "org.invite.type": "دعوت از طریق",

--- a/locales/fr-FR/aico.json
+++ b/locales/fr-FR/aico.json
@@ -98,6 +98,8 @@
   "org.invite.role": "Rôle",
   "org.invite.sent": "Invitation créée — partagez ce lien",
   "org.invite.shareLink": "Invitation créée. Copiez ce lien pour le partager manuellement (Telegram, WhatsApp, etc.). Un envoi par e-mail/SMS a peut-être aussi été tenté.",
+  "org.invite.showLink": "Afficher le lien",
+  "org.invite.showLinkFailed": "Échec du chargement du lien d'invitation",
   "org.invite.submit": "Envoyer l'invitation",
   "org.invite.title": "Inviter un membre",
   "org.invite.type": "Inviter par",

--- a/locales/zh-CN/aico.json
+++ b/locales/zh-CN/aico.json
@@ -98,6 +98,8 @@
   "org.invite.role": "角色",
   "org.invite.sent": "邀请已创建 — 请分享此链接",
   "org.invite.shareLink": "邀请已创建。可复制此链接手动分享（Telegram、WhatsApp 等）。系统也可能已尝试通过邮件/短信发送。",
+  "org.invite.showLink": "显示链接",
+  "org.invite.showLinkFailed": "加载邀请链接失败",
   "org.invite.submit": "发送邀请",
   "org.invite.title": "邀请成员",
   "org.invite.type": "邀请方式",

--- a/packages/database/src/models/organization.ts
+++ b/packages/database/src/models/organization.ts
@@ -586,6 +586,15 @@ export class OrganizationModel {
     });
   };
 
+  getInviteById = async (params: { inviteId: string; orgId: string }) => {
+    return this.db.query.organizationInvites.findFirst({
+      where: and(
+        eq(organizationInvites.id, params.inviteId),
+        eq(organizationInvites.orgId, params.orgId),
+      ),
+    });
+  };
+
   listPendingInvites = async (orgId: string) => {
     return this.db.query.organizationInvites.findMany({
       where: and(eq(organizationInvites.orgId, orgId), eq(organizationInvites.status, 'pending')),

--- a/packages/locales/src/default/aico.ts
+++ b/packages/locales/src/default/aico.ts
@@ -93,6 +93,8 @@ export default {
   'org.invite.sent': 'Invite created — share this link',
   'org.invite.shareLink':
     'Invitation created. Copy this link to share manually (Telegram, WhatsApp, etc.). Delivery by email/SMS may also have been attempted.',
+  'org.invite.showLink': 'Show link',
+  'org.invite.showLinkFailed': 'Failed to load invite link',
   'org.invite.submit': 'Send invite',
   'org.invite.title': 'Invite member',
   'org.invite.type': 'Invite by',

--- a/src/features/AicoBilling/BillingSourceSwitcher.tsx
+++ b/src/features/AicoBilling/BillingSourceSwitcher.tsx
@@ -89,7 +89,7 @@ const BillingSourceSwitcher = memo(() => {
       const remaining = formatRemainingUsd(source.remainingUsd);
 
       return {
-        icon: selected ? CheckIcon : WalletIcon,
+        icon: WalletIcon,
         key: source.source === 'personal' ? 'personal' : `org:${source.organizationId}`,
         label: (
           <div className={styles.row}>

--- a/src/features/Home/InputArea/EditorInput.test.tsx
+++ b/src/features/Home/InputArea/EditorInput.test.tsx
@@ -4,10 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import HomeEditorInput from './EditorInput';
 
 const getBusinessChatInputSendAreaPrefix = vi.fn(() => <div data-testid="aico-billing-switcher" />);
+const useBusinessChatInputAlerts = vi.fn(() => <div data-testid="aico-funds-blocked-alert" />);
 
 vi.mock('@/business/client/hooks/useBusinessChatInputSendAreaPrefix', () => ({
   getBusinessChatInputSendAreaPrefix: (...args: unknown[]) =>
     getBusinessChatInputSendAreaPrefix(...args),
+  useBusinessChatInputAlerts: () => useBusinessChatInputAlerts(),
   useBusinessChatInputSendDisabled: () => false,
 }));
 
@@ -40,6 +42,7 @@ vi.mock('@/store/chat', () => ({
 describe('HomeEditorInput billing switcher', () => {
   beforeEach(() => {
     getBusinessChatInputSendAreaPrefix.mockClear();
+    useBusinessChatInputAlerts.mockClear();
   });
 
   it('exposes the billing source switcher before the first message', () => {
@@ -57,5 +60,22 @@ describe('HomeEditorInput billing switcher', () => {
 
     expect(getBusinessChatInputSendAreaPrefix).toHaveBeenCalled();
     expect(screen.getByTestId('aico-billing-switcher')).toBeInTheDocument();
+  });
+
+  it('mounts funds-blocked alerts above the composer (Conversation parity)', () => {
+    render(
+      <HomeEditorInput
+        initialValue=""
+        isAgentConfigLoading={false}
+        loading={false}
+        mode="chat"
+        send={async () => {}}
+        onModeChange={() => {}}
+        onValueChange={() => {}}
+      />,
+    );
+
+    expect(useBusinessChatInputAlerts).toHaveBeenCalled();
+    expect(screen.getByTestId('aico-funds-blocked-alert')).toBeInTheDocument();
   });
 });

--- a/src/features/Home/InputArea/EditorInput.tsx
+++ b/src/features/Home/InputArea/EditorInput.tsx
@@ -4,6 +4,7 @@ import { memo, type ReactNode, useMemo } from 'react';
 
 import {
   getBusinessChatInputSendAreaPrefix,
+  useBusinessChatInputAlerts,
   useBusinessChatInputSendDisabled,
 } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
 import { useFundsBlockedComposerCue } from '@/features/AicoBilling';
@@ -52,6 +53,7 @@ const HomeEditorInput = memo<HomeEditorInputProps>(
     send,
   }) => {
     const billingSendDisabled = useBusinessChatInputSendDisabled();
+    const businessAlerts = useBusinessChatInputAlerts();
     const { onMarkdownContentChange: withFundsBlockedCue } = useFundsBlockedComposerCue();
     const handleMarkdownContentChange = useMemo(
       () => withFundsBlockedCue(onValueChange),
@@ -97,25 +99,28 @@ const HomeEditorInput = memo<HomeEditorInputProps>(
         onMarkdownContentChange={handleMarkdownContentChange}
         onSend={send}
       >
-        <DesktopChatInput
-          actionBarStyle={actionBarStyle}
-          dropdownPlacement="bottomLeft"
-          initialContent={initialValue}
-          inputContainerProps={inputContainerProps}
-          placeholder={placeholder}
-          sendAreaPrefix={getBusinessChatInputSendAreaPrefix()}
-          showControlBar={false}
-          leftContent={
-            <Flexbox horizontal align={'center'} gap={2}>
-              <ModeSelect value={mode} onChange={onModeChange} />
-              {mode !== 'chat' ? null : isAgentConfigLoading ? (
-                <ActionIcon disabled icon={PlusIcon} size={'small'} />
-              ) : (
-                <ActionBar disableCollapse dropdownPlacement="bottomLeft" />
-              )}
-            </Flexbox>
-          }
-        />
+        <Flexbox gap={0}>
+          {businessAlerts}
+          <DesktopChatInput
+            actionBarStyle={actionBarStyle}
+            dropdownPlacement="bottomLeft"
+            initialContent={initialValue}
+            inputContainerProps={inputContainerProps}
+            placeholder={placeholder}
+            sendAreaPrefix={getBusinessChatInputSendAreaPrefix()}
+            showControlBar={false}
+            leftContent={
+              <Flexbox horizontal align={'center'} gap={2}>
+                <ModeSelect value={mode} onChange={onModeChange} />
+                {mode !== 'chat' ? null : isAgentConfigLoading ? (
+                  <ActionIcon disabled icon={PlusIcon} size={'small'} />
+                ) : (
+                  <ActionBar disableCollapse dropdownPlacement="bottomLeft" />
+                )}
+              </Flexbox>
+            }
+          />
+        </Flexbox>
       </ChatInputProvider>
     );
   },

--- a/src/features/OrgAdmin/OrgAdminMembers.tsx
+++ b/src/features/OrgAdmin/OrgAdminMembers.tsx
@@ -684,23 +684,43 @@ export const OrgAdminMembers = () => {
                   { dataIndex: 'identifierValue', title: t('org.columns.value') },
                   { dataIndex: 'role', title: t('org.columns.role') },
                   {
-                    key: 'revoke',
+                    key: 'actions',
                     title: t('org.columns.actions'),
                     render: (_, row) => (
-                      <Button
-                        size="small"
-                        type="text"
-                        onClick={async () => {
-                          if (!selectedOrgId) return;
-                          await lambdaClient.organization.revokeInvite.mutate({
-                            inviteId: row.id,
-                            orgId: selectedOrgId,
-                          });
-                          await mutate();
-                        }}
-                      >
-                        {t('org.revoke')}
-                      </Button>
+                      <Flexbox horizontal gap={4}>
+                        <Button
+                          size="small"
+                          type="text"
+                          onClick={async () => {
+                            if (!selectedOrgId) return;
+                            try {
+                              const result = await lambdaClient.organization.getInviteLink.query({
+                                inviteId: row.id,
+                                orgId: selectedOrgId,
+                              });
+                              presentInviteLink(result.inviteUrl);
+                            } catch (error) {
+                              toastAicoError(error, t, 'org.invite.showLinkFailed');
+                            }
+                          }}
+                        >
+                          {t('org.invite.showLink')}
+                        </Button>
+                        <Button
+                          size="small"
+                          type="text"
+                          onClick={async () => {
+                            if (!selectedOrgId) return;
+                            await lambdaClient.organization.revokeInvite.mutate({
+                              inviteId: row.id,
+                              orgId: selectedOrgId,
+                            });
+                            await mutate();
+                          }}
+                        >
+                          {t('org.revoke')}
+                        </Button>
+                      </Flexbox>
                     ),
                   },
                 ]}


### PR DESCRIPTION
## Summary
- **AICO-92 / #162**: Add manager-gated `getInviteLink` and a Show link action on pending invites; keep `listMembers` token-free (AICO-P1-026). Strip token from `revokeInvite` response.
- **AICO-93 / #163**: Use a single check in `BillingSourceSwitcher`; wire `FundsBlockedAlert` on Home `EditorInput` (Conversation parity).

#### Related Issue

Fixes #162
Fixes #163

Plane: [AICO-92](https://plane.panafor.com/panaforai/browse/AICO-92)
Plane: [AICO-93](https://plane.panafor.com/panaforai/browse/AICO-93)

## Test plan
- [ ] Org admin: invite member, close modal, open pending table → Show link reopens invite URL modal; revoke still works
- [ ] Confirm `listMembers` payload has no `token` field
- [ ] Member/stranger cannot call `getInviteLink`
- [ ] Home: select `$0` wallet source → funds-blocked Alert appears above composer; send stays disabled
- [ ] Billing source dropdown shows one check on the selected row only
- [ ] Locale check: fa-IR / en-US / fr-FR for Show link + funds copy