### PR TITLE
🐛 fix(message): keep ChatMessageError.type through superjson

### DIFF
--- a/src/services/message/__tests__/updateMessageError.superjson.test.ts
+++ b/src/services/message/__tests__/updateMessageError.superjson.test.ts
@@ -1,0 +1,97 @@
+import superjson from 'superjson';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { lambdaClient } from '@/libs/trpc/client';
+
+import { MessageService, toPlainChatMessageError } from '../index';
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    message: {
+      update: { mutate: vi.fn().mockResolvedValue({ messages: [], success: true }) },
+    },
+  },
+}));
+
+describe('toPlainChatMessageError', () => {
+  it('preserves type from an Error that had ChatMessageError fields assigned', () => {
+    const streamError = new Error('Invalid API Key');
+    Object.assign(streamError, {
+      body: { provider: 'openai' },
+      type: 'InvalidProviderAPIKey',
+    });
+
+    expect(toPlainChatMessageError(streamError as any)).toEqual({
+      body: { provider: 'openai' },
+      message: 'Invalid API Key',
+      type: 'InvalidProviderAPIKey',
+    });
+  });
+
+  it('maps errorType when type is absent', () => {
+    expect(
+      toPlainChatMessageError({ error: undefined, errorType: 'InvalidProviderAPIKey' } as any),
+    ).toEqual({
+      body: undefined,
+      message: undefined,
+      type: 'InvalidProviderAPIKey',
+    });
+  });
+});
+
+describe('MessageService.updateMessageError + superjson', () => {
+  const service = new MessageService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends a plain ChatMessageError that survives superjson (Error custom fields do not)', async () => {
+    const streamError = new Error('Invalid API Key');
+    Object.assign(streamError, {
+      body: { provider: 'openai' },
+      errorType: 'InvalidProviderAPIKey',
+      type: 'InvalidProviderAPIKey',
+    });
+
+    // Superjson drops custom fields on Error — this is why we must plain-clone.
+    const stripped = superjson.deserialize(superjson.serialize(streamError)) as Error;
+    expect((stripped as any).type).toBeUndefined();
+
+    await service.updateMessageError('msg-1', streamError as any, { topicId: 'topic-1' });
+
+    expect(lambdaClient.message.update.mutate).toHaveBeenCalledWith({
+      id: 'msg-1',
+      topicId: 'topic-1',
+      value: {
+        error: {
+          body: { provider: 'openai' },
+          message: 'Invalid API Key',
+          type: 'InvalidProviderAPIKey',
+        },
+      },
+    });
+
+    const payload = vi.mocked(lambdaClient.message.update.mutate).mock.calls[0][0];
+    const roundTripped = superjson.deserialize(superjson.serialize(payload)) as typeof payload;
+    expect(roundTripped.value.error.type).toBe('InvalidProviderAPIKey');
+  });
+
+  it('normalizes error on updateMessage so optimistic paths stay safe', async () => {
+    const streamError = new Error('boom');
+    Object.assign(streamError, { type: 'InvalidProviderAPIKey' });
+
+    await service.updateMessage('msg-3', { error: streamError as any });
+
+    expect(lambdaClient.message.update.mutate).toHaveBeenCalledWith({
+      id: 'msg-3',
+      value: {
+        error: {
+          body: { message: 'boom', name: 'Error' },
+          message: 'boom',
+          type: 'InvalidProviderAPIKey',
+        },
+      },
+    });
+  });
+});

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -21,6 +21,54 @@ import { lambdaClient } from '@/libs/trpc/client';
 import { abortableRequest } from '../utils/abortableRequest';
 
 /**
+ * Always return a plain object for tRPC + superjson.
+ *
+ * Stream / runtime paths often Object.assign ChatMessageError fields onto an
+ * `Error` instance. Superjson's Error serializer only keeps `name`/`message`,
+ * so `type` (and body/classification) would otherwise arrive as `undefined`
+ * and fail `ChatMessageErrorSchema` on `message.update`.
+ */
+export const toPlainChatMessageError = (
+  value: ChatMessageError | null | undefined,
+): ChatMessageError | null | undefined => {
+  if (value == null) return value;
+
+  const raw = value as ChatMessageError & { errorType?: unknown };
+  const type =
+    (typeof raw.type === 'string' || typeof raw.type === 'number' ? raw.type : undefined) ??
+    (typeof raw.errorType === 'string' || typeof raw.errorType === 'number'
+      ? (raw.errorType as ChatMessageError['type'])
+      : undefined);
+
+  if (!type) {
+    return {
+      body: value instanceof Error ? { message: value.message, name: value.name } : value,
+      message: typeof raw.message === 'string' ? raw.message : undefined,
+      type: 'ApplicationRuntimeError',
+    };
+  }
+
+  return {
+    attribution: raw.attribution,
+    body:
+      raw.body !== undefined
+        ? raw.body
+        : value instanceof Error
+          ? { message: value.message, name: value.name }
+          : undefined,
+    category: raw.category,
+    countAsFailure: raw.countAsFailure,
+    httpStatus: raw.httpStatus,
+    isFallback: raw.isFallback,
+    message: typeof raw.message === 'string' ? raw.message : undefined,
+    numericId: raw.numericId,
+    retryable: raw.retryable,
+    severity: raw.severity,
+    type,
+  };
+};
+
+/**
  * Query context for message operations
  * Contains identifiers needed for querying/filtering messages after mutations
  */
@@ -195,14 +243,10 @@ export class MessageService {
   };
 
   updateMessageError = async (id: string, value: ChatMessageError, ctx?: MessageQueryContext) => {
-    const error = value.type
-      ? value
-      : { body: value, message: value.message, type: 'ApplicationRuntimeError' };
-
     return lambdaClient.message.update.mutate({
       ...ctx,
       id,
-      value: { error },
+      value: { error: toPlainChatMessageError(value) },
     });
   };
 
@@ -232,10 +276,13 @@ export class MessageService {
     value: Partial<UpdateMessageParams>,
     ctx?: MessageQueryContext,
   ): Promise<UpdateMessageResult> => {
+    const nextValue =
+      'error' in value ? { ...value, error: toPlainChatMessageError(value.error) } : value;
+
     return lambdaClient.message.update.mutate({
       ...ctx,
       id,
-      value,
+      value: nextValue,
     });
   };
 


### PR DESCRIPTION
<!-- Brief and heads-up -->

When stream failures persist via `message.update`, the client often passes an `Error` with `ChatMessageError` fields assigned on it. Superjson strips those custom fields, so Zod rejects `error.type` as undefined.

| Before | After |
| ------ | ----- |
| `message.update` BAD_REQUEST on invalid API key / stream errors | Plain `ChatMessageError` survives superjson; inline error persists |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression: `src/services/message/__tests__/updateMessageError.superjson.test.ts` (Error → plain object round-trip).

#### 🔗 Related Issue

Fixes #179

Plane: [AICO-111](https://plane.panafor.com/panaforai/browse/AICO-111)


Made with [Cursor](https://cursor.com)