### PR TITLE
🐛 fix(auth): import APIError from better-auth/api

### DIFF
--- a/src/libs/better-auth/plugins/aico-ban-message.ts
+++ b/src/libs/better-auth/plugins/aico-ban-message.ts
@@ -1,4 +1,4 @@
-import { APIError } from '@better-auth/core/error';
+import { APIError } from 'better-auth/api';
 import { type BetterAuthPlugin } from 'better-auth/types';
 
 /**


### PR DESCRIPTION
<!-- Brief and heads-up -->

Turbopack/`build:docker` could not resolve `@better-auth/core/error` from `aico-ban-message.ts`. Import `APIError` from the public `better-auth/api` entry (same as sibling auth plugins).

| Before | After |
| ------ | ----- |
| Module not found `@better-auth/core/error` | Resolves via `better-auth/api` |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified `import { APIError } from 'better-auth/api'` and plugin module load.

#### 🔗 Related Issue

Fixes #181

Plane: [AICO-112](https://plane.panafor.com/panaforai/browse/AICO-112)


Made with [Cursor](https://cursor.com)