### PR TITLE
🐛 fix(aico): ModelSwitchPanel Footer imports + Resend env docs

### DIFF
--- a/.env.example.aico
+++ b/.env.example.aico
@@ -26,6 +26,13 @@ AUTH_EMAIL_VERIFICATION=0
 # AUTH_ALLOWED_EMAILS=admin@example.com
 # AUTH_DISABLE_EMAIL_PASSWORD=1
 
+# Email (Resend) — preferred for Aico
+# Without a verified domain, Resend only delivers to your Resend account email.
+# EMAIL_SERVICE_PROVIDER=resend
+# RESEND_API_KEY=re_xxxx
+# RESEND_FROM=Panachat <onboarding@resend.dev>
+# After domain verify, e.g. RESEND_FROM=Panachat <noreply@chat.panafor.com>
+
 # SSO (Better Auth) — order controls icon order on sign-in
 # AUTH_SSO_PROVIDERS=github,google
 # AUTH_GITHUB_ID=

--- a/src/features/ModelSwitchPanel/components/Footer.tsx
+++ b/src/features/ModelSwitchPanel/components/Footer.tsx
@@ -6,8 +6,8 @@ import { PlusIcon } from 'lucide-react';
 import { type FC, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { styles } from '../../styles';
-import { openEnableModelsModal } from '../EnableModelsModal';
+import { styles } from '../styles';
+import { openEnableModelsModal } from './EnableModelsModal';
 
 interface FooterProps {
   onOpenChange?: (open: boolean) => void;


### PR DESCRIPTION
<!-- Brief and heads-up -->

Leftover local canary commits: fix relative imports in `ModelSwitchPanel` Footer, and document Resend email vars in `.env.example.aico`.

| Before | After |
| ------ | ----- |
| Footer imported `../../styles` / `../EnableModelsModal` | `../styles` / `./EnableModelsModal` |
| No Resend docs in `.env.example.aico` | Commented Resend env block |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Fixes #183

Plane: [AICO-113](https://plane.panafor.com/panaforai/browse/AICO-113)


Made with [Cursor](https://cursor.com)