### PR TITLE
🐛 fix(auth): allow verification emails without Discord branding

### DIFF
--- a/packages/business/const/src/branding.test.ts
+++ b/packages/business/const/src/branding.test.ts
@@ -10,6 +10,7 @@ describe('branding env configuration', () => {
     const {
       BRANDING_NAME,
       BRANDING_NAME_FA,
+      BRANDING_EMOJI,
       ORG_NAME,
       BRANDING_CLOUD_NAME,
       BRANDING_CLOUD_NAME_FA,
@@ -20,6 +21,7 @@ describe('branding env configuration', () => {
 
     expect(BRANDING_NAME).toBe('Panachat');
     expect(BRANDING_NAME_FA).toBe('پاناچت');
+    expect(BRANDING_EMOJI).toBe('🐦‍🔥');
     expect(ORG_NAME).toBe('Panachat');
     expect(BRANDING_CLOUD_NAME).toBe('Panachat Cloud');
     expect(BRANDING_CLOUD_NAME_FA).toBe('ابر پاناچت');

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -18,6 +18,9 @@ export const BRANDING_NAME = readBrandingEnv('BRANDING_NAME', 'Panachat');
  */
 export const BRANDING_NAME_FA = readBrandingEnv('BRANDING_NAME_FA', 'پاناچت');
 
+/** Brand mark / emoji used in auth emails and similar surfaces. */
+export const BRANDING_EMOJI = readBrandingEnv('BRANDING_EMOJI', '🐦‍🔥');
+
 /** Organization / legal entity name used in copyright and structured data. */
 export const ORG_NAME = readBrandingEnv('ORG_NAME', BRANDING_NAME);
 

--- a/src/libs/better-auth/email-templates/branding.ts
+++ b/src/libs/better-auth/email-templates/branding.ts
@@ -1,0 +1,31 @@
+import {
+  BRANDING_EMOJI,
+  BRANDING_NAME,
+  BRANDING_NAME_FA,
+  COPYRIGHT_FULL,
+} from '@lobechat/business-const';
+
+/** Product name for English auth email copy / subjects. */
+export const emailBrandName = BRANDING_NAME;
+
+/** Logo row for HTML auth emails (emoji + EN name + FA name when distinct). */
+export const getEmailBrandLogoHtml = () => {
+  const showFa = Boolean(BRANDING_NAME_FA && BRANDING_NAME_FA !== BRANDING_NAME);
+  const faSuffix = showFa
+    ? `<span style="font-size: 14px; font-weight: 500; color: #6b7280; margin-left: 8px;">${BRANDING_NAME_FA}</span>`
+    : '';
+
+  return `<div style="text-align: center; margin-bottom: 32px;">
+      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
+        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">${BRANDING_EMOJI}</span>
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>${faSuffix}
+      </div>
+    </div>`;
+};
+
+/** Footer copyright line for HTML auth emails. */
+export const getEmailBrandCopyrightHtml = () => COPYRIGHT_FULL;
+
+/** Short automated-footer line, e.g. "This is an automated message from Panachat." */
+export const getEmailBrandAutomatedMessage = () =>
+  `This is an automated message from ${BRANDING_NAME}.`;

--- a/src/libs/better-auth/email-templates/change-email.ts
+++ b/src/libs/better-auth/email-templates/change-email.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Change email verification template
  * Sent to users when they request to change their email address
@@ -32,12 +34,7 @@ export const getChangeEmailVerificationTemplate = (params: {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -57,7 +54,7 @@ export const getChangeEmailVerificationTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          We received a request to change your LobeHub account email to this address. Please confirm by clicking the button below.
+          We received a request to change your ${emailBrandName} account email to this address. Please confirm by clicking the button below.
         </p>
 
         <!-- Button -->
@@ -100,14 +97,14 @@ export const getChangeEmailVerificationTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${getEmailBrandCopyrightHtml()}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Confirm Your New Email - LobeHub',
-    text: `You requested to change your LobeHub account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    subject: `Confirm Your New Email - ${emailBrandName}`,
+    text: `You requested to change your ${emailBrandName} account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/index.test.ts
+++ b/src/libs/better-auth/email-templates/index.test.ts
@@ -1,3 +1,9 @@
+import {
+  BRANDING_EMAIL,
+  BRANDING_EMOJI,
+  BRANDING_NAME,
+  SOCIAL_URL,
+} from '@lobechat/business-const';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -38,13 +44,31 @@ const templates = [
 ];
 
 describe('email templates', () => {
-  it.each(templates)(
-    'includes support email and Discord links in HTML and plain text',
-    (template) => {
-      expect(template.html).toContain('href="mailto:support@lobehub.com"');
-      expect(template.html).toContain('https://discord.gg/');
-      expect(template.text).toContain('support@lobehub.com');
-      expect(template.text).toContain('https://discord.gg/');
-    },
-  );
+  it.each(templates)('uses Panachat branding instead of LobeHub', (template) => {
+    expect(template.html).toContain(BRANDING_EMOJI);
+    expect(template.html).toContain(BRANDING_NAME);
+    expect(template.html).not.toContain('LobeHub');
+    expect(template.html).not.toContain('🤯');
+    expect(template.subject).not.toContain('LobeHub');
+  });
+
+  it.each(templates)('includes support links only when branding provides them', (template) => {
+    const supportEmail = BRANDING_EMAIL.support?.trim();
+    const discordUrl = SOCIAL_URL.discord?.trim();
+
+    if (supportEmail) {
+      expect(template.html).toContain(`mailto:${supportEmail}`);
+      expect(template.text).toContain(supportEmail);
+    } else {
+      expect(template.html).not.toContain('mailto:');
+    }
+
+    if (discordUrl) {
+      expect(template.html).toContain(discordUrl);
+      expect(template.text).toContain(discordUrl);
+    }
+
+    expect(template.html).not.toContain('undefined');
+    expect(template.text).not.toContain('undefined');
+  });
 });

--- a/src/libs/better-auth/email-templates/magic-link.ts
+++ b/src/libs/better-auth/email-templates/magic-link.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Magic link sign-in email template
  * Sent when user requests passwordless login
@@ -20,19 +22,14 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign in to LobeHub</title>
+  <title>Sign in to ${emailBrandName}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -40,7 +37,7 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Sign in to LobeHub
+          Sign in to ${emailBrandName}
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.5;">
           Click the link below to sign in to your account.
@@ -90,14 +87,14 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © ${new Date().getFullYear()} LobeHub. All rights reserved.
+        ${getEmailBrandCopyrightHtml()}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Your LobeHub sign-in link',
+    subject: `Your ${emailBrandName} sign-in link`,
     text: `Use this link to sign in: ${url}\n\nThis link expires in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/reset-password.ts
+++ b/src/libs/better-auth/email-templates/reset-password.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Password reset email template
  * Sent to users when they request a password reset
@@ -21,12 +23,7 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -44,7 +41,7 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
       <!-- Content -->
       <div style="color: #374151; font-size: 16px; line-height: 1.6;">
         <p style="margin: 0 0 24px 0; text-align: center;">
-          You recently requested to reset your password for your LobeHub account. Click the button below to proceed.
+          You recently requested to reset your password for your ${emailBrandName} account. Click the button below to proceed.
         </p>
 
         <!-- Button -->
@@ -83,14 +80,14 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © ${new Date().getFullYear()} LobeHub. All rights reserved.
+        ${getEmailBrandCopyrightHtml()}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Reset Your Password - LobeHub',
+    subject: `Reset Your Password - ${emailBrandName}`,
     text: `Reset your password by clicking this link: ${url}\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification-otp.ts
+++ b/src/libs/better-auth/email-templates/verification-otp.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Email OTP verification template for mobile
  * Sent to users when they need to verify their email using OTP code
@@ -32,12 +34,7 @@ export const getVerificationOTPEmailTemplate = (params: {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -57,7 +54,7 @@ export const getVerificationOTPEmailTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with LobeHub. To verify your email address, please use the verification code below:
+          Thanks for creating an account with ${emailBrandName}. To verify your email address, please use the verification code below:
         </p>
 
         <!-- OTP Code Box -->
@@ -98,14 +95,14 @@ export const getVerificationOTPEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${getEmailBrandCopyrightHtml()}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Verify Your Email - LobeHub',
+    subject: `Verify Your Email - ${emailBrandName}`,
     text: `Your verification code is: ${otp}\n\nThis code will expire in ${expirationText}.\n\nIf you didn't request this code, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification.ts
+++ b/src/libs/better-auth/email-templates/verification.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Email verification template
  * Sent to users when they sign up to verify their email address
@@ -32,12 +34,7 @@ export const getVerificationEmailTemplate = (params: {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -57,7 +54,7 @@ export const getVerificationEmailTemplate = (params: {
         ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
         
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with LobeHub. To access your account, please verify your email address by clicking the button below.
+          Thanks for creating an account with ${emailBrandName}. To access your account, please verify your email address by clicking the button below.
         </p>
 
         <!-- Button -->
@@ -100,14 +97,14 @@ export const getVerificationEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        © 2026 LobeHub. All rights reserved.
+        ${getEmailBrandCopyrightHtml()}
       </p>
     </div>
   </div>
 </body>
 </html>
     `,
-    subject: 'Verify Your Email - LobeHub',
+    subject: `Verify Your Email - ${emailBrandName}`,
     text: `Please verify your email by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-invite.ts
+++ b/src/libs/better-auth/email-templates/workspace-invite.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandLogoHtml } from './branding';
+
 /**
  * Workspace invitation email template
  * Sent when a workspace owner invites someone (by email) to join their workspace.
@@ -17,7 +19,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
   const inviterLabel = inviterName || inviterEmail || 'A teammate';
   const inviterByline =
     inviterEmail && inviterName ? `${inviterName} (${inviterEmail})` : inviterLabel;
-  const subject = `${inviterLabel} invited you to join ${workspaceName} on LobeHub`;
+  const subject = `${inviterLabel} invited you to join ${workspaceName} on ${emailBrandName}`;
   const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
 
   return {
@@ -33,12 +35,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -46,7 +43,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Join <strong>${workspaceName}</strong> on LobeHub
+          Join <strong>${workspaceName}</strong> on ${emailBrandName}
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
           You've been invited as a <strong>${roleLabel}</strong>.
@@ -57,7 +54,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <div style="color: #374151; font-size: 16px; line-height: 1.6;">
         <p style="margin: 0 0 24px 0;">
           <strong>${inviterByline}</strong> has invited you to collaborate inside the
-          <strong>${workspaceName}</strong> workspace on LobeHub.
+          <strong>${workspaceName}</strong> workspace on ${emailBrandName}.
         </p>
 
         <!-- Button -->
@@ -76,7 +73,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
         </div>
 
         <p style="color: #6b7280; font-size: 15px; margin: 0;">
-          If you don't have a LobeHub account yet, you'll be guided through a quick signup before joining the workspace.
+          If you don't have a ${emailBrandName} account yet, you'll be guided through a quick signup before joining the workspace.
         </p>
       </div>
 
@@ -108,6 +105,6 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 </html>
     `,
     subject,
-    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on LobeHub as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on ${emailBrandName} as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-member-removed.ts
+++ b/src/libs/better-auth/email-templates/workspace-member-removed.ts
@@ -1,5 +1,7 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
+import { emailBrandName, getEmailBrandAutomatedMessage, getEmailBrandLogoHtml } from './branding';
+
 export const getWorkspaceMemberRemovedEmailTemplate = (params: {
   reason: 'downgrade' | 'removed_by_owner';
   workspaceName: string;
@@ -8,13 +10,9 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
 
   const isDowngrade = reason === 'downgrade';
 
-  const subject = isDowngrade
-    ? `You have been removed from ${workspaceName} on LobeHub`
-    : `You have been removed from ${workspaceName} on LobeHub`;
+  const subject = `You have been removed from ${workspaceName} on ${emailBrandName}`;
 
-  const heading = isDowngrade
-    ? `Removed from <strong>${workspaceName}</strong>`
-    : `Removed from <strong>${workspaceName}</strong>`;
+  const heading = `Removed from <strong>${workspaceName}</strong>`;
 
   const body = isDowngrade
     ? `The workspace <strong>${workspaceName}</strong> has been downgraded, and all team members have been removed as a result. Your personal data and workspaces are not affected.`
@@ -33,12 +31,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <span style="font-size: 24px; line-height: 1; margin-right: 10px;">🤯</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">LobeHub</span>
-      </div>
-    </div>
+    ${getEmailBrandLogoHtml()}
 
     <!-- Card -->
     <div style="background: #ffffff; border-radius: 20px; padding: 40px; box-shadow: 0 8px 30px rgba(0,0,0,0.04); border: 1px solid rgba(0,0,0,0.02);">
@@ -70,7 +63,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
       <!-- Footer note -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0;">
-          You can continue using LobeHub with your personal workspace.
+          You can continue using ${emailBrandName} with your personal workspace.
         </p>
       </div>
     </div>
@@ -81,7 +74,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        This is an automated message from LobeHub.
+        ${getEmailBrandAutomatedMessage()}
       </p>
     </div>
   </div>

--- a/src/libs/email/support.test.ts
+++ b/src/libs/email/support.test.ts
@@ -3,18 +3,35 @@ import { describe, expect, it } from 'vitest';
 import { EMAIL_SUPPORT_ADDRESS, getEmailSupportHtml, getEmailSupportText } from './support';
 
 describe('email support helpers', () => {
-  it('renders actionable support links for HTML and plain-text emails', () => {
+  it('omits missing support/discord branding instead of crashing', () => {
+    // Aico self-host branding leaves SOCIAL_URL.discord undefined and may leave
+    // BRANDING_SUPPORT_EMAIL empty — verification emails must still render.
+    expect(() => getEmailSupportHtml()).not.toThrow();
+    expect(() => getEmailSupportText()).not.toThrow();
+
     const html = getEmailSupportHtml();
     const text = getEmailSupportText();
 
-    expect(EMAIL_SUPPORT_ADDRESS).toBe('support@lobehub.com');
-    expect(html).toContain('href="mailto:support@lobehub.com"');
-    expect(html).toContain('https://discord.gg/');
-    expect(text).toContain('support@lobehub.com');
-    expect(text).toContain('https://discord.gg/');
+    if (EMAIL_SUPPORT_ADDRESS?.trim()) {
+      expect(html).toContain(`mailto:${EMAIL_SUPPORT_ADDRESS.trim()}`);
+      expect(text).toContain(EMAIL_SUPPORT_ADDRESS.trim());
+    } else {
+      expect(html).not.toContain('mailto:');
+      expect(text).toBe('');
+    }
+
+    expect(html).not.toContain('undefined');
+    expect(text).not.toContain('undefined');
   });
 
-  it('escapes localized labels before rendering HTML', () => {
+  it('escapes localized labels before rendering HTML when support email is set', () => {
+    if (!EMAIL_SUPPORT_ADDRESS?.trim()) {
+      // Without a support address the HTML footer is empty; escaping is still
+      // covered for contact labels when an address exists.
+      expect(getEmailSupportHtml({ contactSupport: '<script>' })).toBe('');
+      return;
+    }
+
     const html = getEmailSupportHtml({
       contactSupport: '<script>alert("support")</script>',
       joinDiscord: '<strong>Discord</strong>',
@@ -23,6 +40,5 @@ describe('email support helpers', () => {
     expect(html).not.toContain('<script>');
     expect(html).not.toContain('<strong>');
     expect(html).toContain('&lt;script&gt;');
-    expect(html).toContain('&lt;strong&gt;');
   });
 });

--- a/src/libs/email/support.ts
+++ b/src/libs/email/support.ts
@@ -25,14 +25,40 @@ export const getEmailSupportHtml = ({
   contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
   joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
 }: EmailSupportCopy = {}) => {
-  const supportEmail = escapeHtml(EMAIL_SUPPORT_ADDRESS);
-  const discordUrl = escapeHtml(SOCIAL_URL.discord);
+  const supportEmail = EMAIL_SUPPORT_ADDRESS?.trim();
+  const discordUrl = SOCIAL_URL.discord?.trim();
+  const parts: string[] = [];
 
-  return `<a href="mailto:${supportEmail}" style="color: #6b7280; text-decoration: underline;">${escapeHtml(contactSupport)}</a><span style="color: #a1a1aa;"> · </span><a href="${discordUrl}" target="_blank" rel="noopener noreferrer" style="color: #6b7280; text-decoration: underline;">${escapeHtml(joinDiscord)}</a>`;
+  if (supportEmail) {
+    parts.push(
+      `<a href="mailto:${escapeHtml(supportEmail)}" style="color: #6b7280; text-decoration: underline;">${escapeHtml(contactSupport)}</a>`,
+    );
+  }
+
+  if (discordUrl) {
+    parts.push(
+      `<a href="${escapeHtml(discordUrl)}" target="_blank" rel="noopener noreferrer" style="color: #6b7280; text-decoration: underline;">${escapeHtml(joinDiscord)}</a>`,
+    );
+  }
+
+  return parts.join('<span style="color: #a1a1aa;"> · </span>');
 };
 
 export const getEmailSupportText = ({
   contactSupport = DEFAULT_SUPPORT_COPY.contactSupport,
   joinDiscord = DEFAULT_SUPPORT_COPY.joinDiscord,
-}: EmailSupportCopy = {}) =>
-  `${contactSupport}: ${EMAIL_SUPPORT_ADDRESS} | ${joinDiscord}: ${SOCIAL_URL.discord}`;
+}: EmailSupportCopy = {}) => {
+  const supportEmail = EMAIL_SUPPORT_ADDRESS?.trim();
+  const discordUrl = SOCIAL_URL.discord?.trim();
+  const parts: string[] = [];
+
+  if (supportEmail) {
+    parts.push(`${contactSupport}: ${supportEmail}`);
+  }
+
+  if (discordUrl) {
+    parts.push(`${joinDiscord}: ${discordUrl}`);
+  }
+
+  return parts.join(' | ');
+};


### PR DESCRIPTION
#### 💥 Change Type
- [x] 🐛 `Bug Fixes`

#### 🔗 Related Issue
Fixes #188

Plane: [AICO-116](https://plane.panafor.com/panaforai/browse/AICO-116)

#### 📝 Description of Change
Signup verification emails crashed in the Better Auth background task when Aico branding left `SOCIAL_URL.discord` undefined (`escapeHtml` → `replaceAll`). Footer helpers now skip missing support/Discord links so Resend can deliver verification mail.

#### 🧪 How to Test
- [x] Unit tests: `src/libs/email/support.test.ts`
- [x] Redeployed local image; `send-verification-email` delivered `Verify Your Email` via Resend


Made with [Cursor](https://cursor.com)