### PR TITLE
🙈 fix(aico): hide profile change-email control for Panachat

### DIFF
--- a/src/features/SettingsSearch/items.ts
+++ b/src/features/SettingsSearch/items.ts
@@ -204,7 +204,9 @@ export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
   },
   {
     anchor: 'profile-email',
-    keywords: ['email', 'email address', 'update email', 'change email'],
+    // Change-email UI is hidden for Aico/Panachat (`isCustomBranding`); keep
+    // discoverability for the read-only email row only.
+    keywords: ['email', 'email address'],
     labelKey: 'profile.email',
     ns: 'auth',
     tab: SettingsTabs.Profile,

--- a/src/routes/(main)/settings/profile/features/EmailRow.tsx
+++ b/src/routes/(main)/settings/profile/features/EmailRow.tsx
@@ -10,12 +10,14 @@ import { changeEmail } from '@/libs/better-auth/auth-client';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
+import { isProfileChangeEmailEnabled } from './isProfileChangeEmailEnabled';
 import ProfileRow from './ProfileRow';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 const EmailRow = () => {
   const { t } = useTranslation('auth');
+  const allowChangeEmail = isProfileChangeEmailEnabled();
   const email = useUserStore(userProfileSelectors.email);
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
@@ -118,6 +120,7 @@ const EmailRow = () => {
       anchor={'profile-email'}
       label={t('profile.email')}
       action={
+        allowChangeEmail &&
         !isEditing && (
           <Text style={{ cursor: 'pointer', fontSize: 13 }} onClick={handleStartEdit}>
             {t('profile.updateEmail')}
@@ -125,7 +128,9 @@ const EmailRow = () => {
         )
       }
     >
-      <AnimatePresence mode="wait">{isEditing ? editingContent : displayContent}</AnimatePresence>
+      <AnimatePresence mode="wait">
+        {allowChangeEmail && isEditing ? editingContent : displayContent}
+      </AnimatePresence>
     </ProfileRow>
   );
 };

--- a/src/routes/(main)/settings/profile/features/isProfileChangeEmailEnabled.test.ts
+++ b/src/routes/(main)/settings/profile/features/isProfileChangeEmailEnabled.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isCustomBranding: true,
+}));
+
+vi.mock('@/const/version', () => ({
+  get isCustomBranding() {
+    return mocks.isCustomBranding;
+  },
+}));
+
+describe('isProfileChangeEmailEnabled', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns false for custom branding (Aico/Panachat)', async () => {
+    mocks.isCustomBranding = true;
+    const { isProfileChangeEmailEnabled } = await import('./isProfileChangeEmailEnabled');
+    expect(isProfileChangeEmailEnabled()).toBe(false);
+  });
+
+  it('returns true when branding is not customized', async () => {
+    mocks.isCustomBranding = false;
+    const { isProfileChangeEmailEnabled } = await import('./isProfileChangeEmailEnabled');
+    expect(isProfileChangeEmailEnabled()).toBe(true);
+  });
+});

--- a/src/routes/(main)/settings/profile/features/isProfileChangeEmailEnabled.ts
+++ b/src/routes/(main)/settings/profile/features/isProfileChangeEmailEnabled.ts
@@ -1,0 +1,7 @@
+import { isCustomBranding } from '@/const/version';
+
+/**
+ * Whether Settings → Profile may expose the change-email entry point.
+ * Hidden for Aico/Panachat custom branding for now; kept for upstream LobeHub.
+ */
+export const isProfileChangeEmailEnabled = (): boolean => !isCustomBranding;


### PR DESCRIPTION
#### 💥 Change Type
- [x] 🐛 `Bug Fixes`

#### 🔗 Related Issue

Fixes #192

Plane: [AICO-118](https://plane.panafor.com/panaforai/browse/AICO-118)

#### 📝 Description of Change

Temporarily hide the Settings → Profile **Update Email** entry point for Aico/Panachat (`isCustomBranding`). The email address remains visible as read-only; Better Auth `changeEmail` backend stays unchanged. Settings search keywords no longer advertise change/update email.

#### 🧪 How to Test
- [x] Unit: `isProfileChangeEmailEnabled.test.ts`
- [ ] UI: Settings → Profile — email shows, no Update Email control
- [ ] Confirm sign-in “use a different email” flow is unaffected


Made with [Cursor](https://cursor.com)