### PR TITLE
🙈 chore(aico): hide Downloads page and avatar menu entry

### DIFF
--- a/src/features/User/UserPanel/useMenu.tsx
+++ b/src/features/User/UserPanel/useMenu.tsx
@@ -53,7 +53,7 @@ export const useMenu = () => {
     authSelectors.isLogin(s),
     authSelectors.isLoginWithAuth(s),
   ]);
-  const { userPanel } = useNavLayout();
+  const { showDownloads, userPanel } = useNavLayout();
   const businessMenuItems = useBusinessMenuItems(isLogin);
   const hasActiveWorkspace = useHasActiveWorkspace();
 
@@ -137,7 +137,7 @@ export const useMenu = () => {
         ]
       : []),
     ...(!hideDocs ? helps : []),
-    ...(!isDesktop ? getApp : []),
+    ...(!isDesktop && showDownloads ? getApp : []),
   ]
     .filter(Boolean)
     // Remove consecutive dividers to prevent double divider lines

--- a/src/features/User/__tests__/useMenu.test.tsx
+++ b/src/features/User/__tests__/useMenu.test.tsx
@@ -58,6 +58,8 @@ describe('useMenu', () => {
       expect(mainItems?.some((item) => item?.key === 'setting')).toBe(true);
       // 'memory' is gated behind the showMemory nav-layout flag (defaults off)
       expect(mainItems?.some((item) => item?.key === 'memory')).toBe(false);
+      // Downloads / Get App is gated behind showDownloads (defaults off for Aico)
+      expect(mainItems?.some((item) => item?.key === 'get-app')).toBe(false);
       // 'logout' is shown when isLoginWithAuth is true
       expect(logoutItems.some((item) => item?.key === 'logout')).toBe(true);
     });

--- a/src/hooks/useNavLayout.test.tsx
+++ b/src/hooks/useNavLayout.test.tsx
@@ -62,4 +62,11 @@ describe('useNavLayout', () => {
 
     expect(memoryItem?.hidden).toBe(true);
   });
+
+  it('keeps Downloads / Get App hidden by default', async () => {
+    const { useNavLayout } = await import('./useNavLayout');
+    const { result } = renderHook(() => useNavLayout());
+
+    expect(result.current.showDownloads).toBe(false);
+  });
 });

--- a/src/hooks/useNavLayout.ts
+++ b/src/hooks/useNavLayout.ts
@@ -26,6 +26,11 @@ export interface NavLayout {
     showEvalEntry: boolean;
     showSettingsEntry: boolean;
   };
+  /**
+   * When false, hide Downloads / Get App entry points and treat `/downloads`
+   * as unavailable in product surfaces (route still redirects separately).
+   */
+  showDownloads: boolean;
   topNavItems: NavItem[];
   userPanel: {
     showDataImporter: boolean;
@@ -123,5 +128,12 @@ export const useNavLayout = (): NavLayout => {
     [],
   );
 
-  return { bottomMenuItems, footer, topNavItems, userPanel };
+  return {
+    bottomMenuItems,
+    footer,
+    // Temporarily hide Downloads / Get App for Aico until the surface is ready.
+    showDownloads: false,
+    topNavItems,
+    userPanel,
+  };
 };

--- a/src/routes/(main)/home/_layout/Footer/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.test.tsx
@@ -67,6 +67,7 @@ const renderFooter = async ({
   hideGitHub = true,
   serverConfigInit = true,
 }: RenderFooterOptions = {}) => {
+  cleanup();
   vi.resetModules();
   analyticsTrack.mockReset();
   vi.stubGlobal('localStorage', {
@@ -166,6 +167,7 @@ const renderFooter = async ({
         showEvalEntry: false,
         showSettingsEntry: true,
       },
+      showDownloads: false,
       topNavItems: [],
       userPanel: {
         showDataImporter: false,
@@ -231,17 +233,14 @@ afterEach(() => {
 });
 
 describe('Footer help menu tracking', () => {
-  it('shows Get App immediately before GitHub on web', async () => {
+  it('does not show Get App when downloads are hidden', async () => {
     const user = userEvent.setup();
     await renderFooter({ hideGitHub: false });
 
     await user.click(screen.getByRole('button', { name: 'Help' }));
 
-    const getApp = await screen.findByRole('link', { name: 'Get App' });
-    const github = screen.getByRole('link', { name: 'GitHub' });
-
-    expect(getApp).toHaveAttribute('href', '/downloads');
-    expect(getApp.compareDocumentPosition(github) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByRole('link', { name: 'Get App' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
   }, 20000);
 
   it('does not show Get App in desktop builds', async () => {

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -103,7 +103,7 @@ const collectMenuKeys = (items: FooterMenuItems): string[] =>
 const Footer = memo(() => {
   const { t } = useTranslation('common');
   const { analytics } = useAnalytics();
-  const { footer } = useNavLayout();
+  const { footer, showDownloads } = useNavLayout();
   const hasActiveWorkspace = useHasActiveWorkspace();
   const settingLabelKey = hasActiveWorkspace ? 'userPanel.workspaceSetting' : 'userPanel.setting';
   const activeNavKey = useActiveNavKey();
@@ -287,7 +287,7 @@ const Footer = memo(() => {
         label: t('changelog'),
         onClick: handleOpenChangelogModal,
       },
-      ...(!isDesktop && footer.layout === 'compact'
+      ...(!isDesktop && showDownloads && footer.layout === 'compact'
         ? [
             {
               icon: <Icon icon={Download} />,
@@ -349,6 +349,7 @@ const Footer = memo(() => {
     footer.layout,
     footer.hideGitHub,
     footer.showEvalEntry,
+    showDownloads,
     enableBusinessFeatures,
     handleOpenChangelogModal,
     handleOpenFeedbackModal,

--- a/src/spa/router/desktopRouter.shared.tsx
+++ b/src/spa/router/desktopRouter.shared.tsx
@@ -2,7 +2,6 @@
 
 import {
   BrainCircuit,
-  Download,
   FilePenIcon,
   Image,
   LibraryBigIcon,
@@ -793,11 +792,9 @@ export const sharedMainAreaChildren: RouteObject[] = [
 const createMainAreaChildrenDefinition = (options: MainAreaRouteOptions = {}): RouteObject[] => [
   ...sharedMainAreaChildren,
 
-  // Downloads page (personal-only — never mirrored under /:workspaceSlug)
+  // Downloads page temporarily redirected (Aico hides this surface for now)
   {
-    element: dynamicElement(() => import('@/routes/(main)/downloads'), 'Desktop > Downloads'),
-    errorElement: <ErrorBoundary />,
-    handle: { meta: routeMeta({ icon: Download, titleKey: 'navigation.downloads' }) },
+    element: redirectElement('/'),
     path: 'downloads',
   },
 

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -294,10 +294,9 @@ export const mobileRoutes: RouteObject[] = [
     children: [
       ...sharedMainAreaChildren,
 
-      // Downloads page (personal-only — never mirrored under /:workspaceSlug)
+      // Downloads page temporarily redirected (Aico hides this surface for now)
       {
-        element: dynamicElement(() => import('@/routes/(main)/downloads'), 'Mobile > Downloads'),
-        errorElement: <ErrorBoundary />,
+        element: redirectElement('/'),
         path: 'downloads',
       },
 


### PR DESCRIPTION
#### 🙈 Change Type

- [x] chore — hide unfinished Downloads surface for Panachat

#### 🔗 Related Issue

Fixes #191

Plane: [AICO-117](https://plane.panafor.com/panaforai/browse/AICO-117)

#### 📝 Description of Change

Temporarily hide Downloads / Get App on Aico (Panachat):

- Gate avatar menu + home footer Get App behind `useNavLayout.showDownloads` (default `false`)
- Redirect SPA `/downloads` to `/` on desktop and mobile routers so direct URLs cannot open the page
- Other avatar menu items unchanged

#### 🧪 How to Test

- [x] Unit tests for `useNavLayout`, `useMenu`, Footer
- [ ] Manual: avatar menu has no Downloads / Get App entry
- [ ] Manual: open `/downloads` → redirects to home
- [ ] Manual: Settings / logout / other avatar items still work

#### 📋 Checklist

- [x] Tested locally
- [ ] Docs updated (N/A)
- [x] AI-generated; human review welcome

Made with [Cursor](https://cursor.com)