### PR TITLE
✨ feat(auth): localize Better Auth emails to Persian RTL

### DIFF
--- a/src/libs/better-auth/email-templates/branding.ts
+++ b/src/libs/better-auth/email-templates/branding.ts
@@ -2,30 +2,63 @@ import {
   BRANDING_EMOJI,
   BRANDING_NAME,
   BRANDING_NAME_FA,
-  COPYRIGHT_FULL,
+  ORG_NAME_FA,
 } from '@lobechat/business-const';
 
-/** Product name for English auth email copy / subjects. */
-export const emailBrandName = BRANDING_NAME;
+/** Product name for Persian auth email copy / subjects. */
+export const emailBrandName = BRANDING_NAME_FA || BRANDING_NAME;
 
-/** Logo row for HTML auth emails (emoji + EN name + FA name when distinct). */
+/** Logo row for HTML auth emails (emoji + FA name + EN name when distinct). */
 export const getEmailBrandLogoHtml = () => {
-  const showFa = Boolean(BRANDING_NAME_FA && BRANDING_NAME_FA !== BRANDING_NAME);
-  const faSuffix = showFa
-    ? `<span style="font-size: 14px; font-weight: 500; color: #6b7280; margin-left: 8px;">${BRANDING_NAME_FA}</span>`
+  const showEn = Boolean(BRANDING_NAME && BRANDING_NAME !== emailBrandName);
+  const enSuffix = showEn
+    ? `<span style="font-size: 14px; font-weight: 500; color: #6b7280; margin-left: 8px;">${BRANDING_NAME}</span>`
     : '';
 
   return `<div style="text-align: center; margin-bottom: 32px;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
+      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: #ffffff; border-radius: 12px; padding: 8px 16px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); direction: ltr;">
         <span style="font-size: 24px; line-height: 1; margin-right: 10px;">${BRANDING_EMOJI}</span>
-        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${BRANDING_NAME}</span>${faSuffix}
+        <span style="font-size: 18px; font-weight: 700; color: #000000; letter-spacing: -0.5px;">${emailBrandName}</span>${enSuffix}
       </div>
     </div>`;
 };
 
-/** Footer copyright line for HTML auth emails. */
-export const getEmailBrandCopyrightHtml = () => COPYRIGHT_FULL;
+/** Footer copyright line for HTML auth emails (Persian). */
+export const getEmailBrandCopyrightHtml = () =>
+  `© ${new Date().getFullYear()} ${ORG_NAME_FA}. تمامی حقوق محفوظ است.`;
 
-/** Short automated-footer line, e.g. "This is an automated message from Panachat." */
-export const getEmailBrandAutomatedMessage = () =>
-  `This is an automated message from ${BRANDING_NAME}.`;
+/** Short automated-footer line, e.g. "این یک پیام خودکار از پاناچت است." */
+export const getEmailBrandAutomatedMessage = () => `این یک پیام خودکار از ${emailBrandName} است.`;
+
+/** Shared email body font stack with Persian-capable fallbacks. */
+export const EMAIL_FONT_STACK = "Tahoma, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif";
+
+/**
+ * Format a duration in Persian for expiration notes.
+ * Prefers hours when `seconds >= 3600`, otherwise minutes (or seconds if under a minute).
+ */
+export const formatEmailExpirationFa = (seconds: number) => {
+  if (seconds >= 3600) {
+    const hours = seconds / 3600;
+    return hours === 1 ? '۱ ساعت' : `${hours} ساعت`;
+  }
+
+  if (seconds >= 60) {
+    const minutes = Math.round(seconds / 60);
+    return minutes === 1 ? '۱ دقیقه' : `${minutes} دقیقه`;
+  }
+
+  return seconds === 1 ? '۱ ثانیه' : `${seconds} ثانیه`;
+};
+
+/** Map workspace role keys to Persian labels for invite emails. */
+export const formatWorkspaceRoleFa = (role: string) => {
+  const normalized = role.trim().toLowerCase();
+  const labels: Record<string, string> = {
+    admin: 'مدیر',
+    member: 'عضو',
+    owner: 'مالک',
+  };
+
+  return labels[normalized] ?? role;
+};

--- a/src/libs/better-auth/email-templates/change-email.ts
+++ b/src/libs/better-auth/email-templates/change-email.ts
@@ -1,9 +1,15 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  formatEmailExpirationFa,
+  getEmailBrandCopyrightHtml,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Change email verification template
+ * Change email verification template (Persian)
  * Sent to users when they request to change their email address
  */
 export const getChangeEmailVerificationTemplate = (params: {
@@ -12,24 +18,18 @@ export const getChangeEmailVerificationTemplate = (params: {
   userName?: string | null;
 }) => {
   const { url, userName, expiresInSeconds } = params;
-
-  // Format expiration time in a human-readable way
-  const expiresInHours = expiresInSeconds / 3600;
-  const expirationText =
-    expiresInHours >= 1
-      ? `${expiresInHours} hour${expiresInHours > 1 ? 's' : ''}`
-      : `${expiresInSeconds / 60} minutes`;
+  const expirationText = formatEmailExpirationFa(expiresInSeconds);
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Confirm your new email</title>
+  <title>تأیید ایمیل جدید</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
@@ -42,38 +42,38 @@ export const getChangeEmailVerificationTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Confirm your new email address
+          تأیید آدرس ایمیل جدید
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
-          You requested to change your email.
+          درخواست تغییر ایمیل دریافت شد.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
-        ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
+        ${userName ? `<p style="margin: 0 0 16px 0;">سلام <strong>${userName}</strong>،</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          We received a request to change your ${emailBrandName} account email to this address. Please confirm by clicking the button below.
+          درخواستی برای تغییر ایمیل حساب ${emailBrandName} شما به این آدرس دریافت کردیم. لطفاً با کلیک روی دکمه زیر آن را تأیید کنید.
         </p>
 
         <!-- Button -->
         <div style="text-align: center; margin: 36px 0;">
           <a href="${url}" target="_blank"
              style="display: inline-block; background-color: #000000; color: #ffffff; text-decoration: none; padding: 16px 36px; border-radius: 14px; font-weight: 600; font-size: 16px; transition: transform 0.1s ease; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            Confirm New Email
+            تأیید ایمیل جدید
           </a>
         </div>
 
         <!-- Expiration Note -->
         <div style="background-color: #f9fafb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #f3f4f6;">
           <p style="color: #6b7280; font-size: 14px; margin: 0; text-align: center;">
-            ⏰ This link will expire in <strong>${expirationText}</strong>.
+            ⏰ این لینک تا <strong>${expirationText}</strong> دیگر منقضی می‌شود.
           </p>
         </div>
 
         <p style="color: #6b7280; font-size: 15px; margin: 0 0 8px 0;">
-          If you didn't request this change, you can safely ignore this email. Your current email will remain unchanged.
+          اگر این تغییر را درخواست نکرده‌اید، این ایمیل را نادیده بگیرید. ایمیل فعلی شما بدون تغییر می‌ماند.
         </p>
       </div>
 
@@ -83,9 +83,9 @@ export const getChangeEmailVerificationTemplate = (params: {
       <!-- Fallback Link -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          Button not working? Copy and paste this link into your browser:
+          دکمه کار نمی‌کند؟ این لینک را در مرورگر کپی کنید:
         </p>
-        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4;">
+        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4; direction: ltr;">
           ${url}
         </a>
       </div>
@@ -104,7 +104,7 @@ export const getChangeEmailVerificationTemplate = (params: {
 </body>
 </html>
     `,
-    subject: `Confirm Your New Email - ${emailBrandName}`,
-    text: `You requested to change your ${emailBrandName} account email. Please confirm by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\nIf you didn't request this change, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    subject: `تأیید ایمیل جدید — ${emailBrandName}`,
+    text: `درخواست تغییر ایمیل حساب ${emailBrandName} شما ثبت شد. لطفاً با کلیک روی این لینک تأیید کنید: ${url}\n\nاین لینک تا ${expirationText} دیگر منقضی می‌شود.\n\nاگر این تغییر را درخواست نکرده‌اید، این ایمیل را نادیده بگیرید.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/index.test.ts
+++ b/src/libs/better-auth/email-templates/index.test.ts
@@ -2,6 +2,7 @@ import {
   BRANDING_EMAIL,
   BRANDING_EMOJI,
   BRANDING_NAME,
+  BRANDING_NAME_FA,
   SOCIAL_URL,
 } from '@lobechat/business-const';
 import { describe, expect, it } from 'vitest';
@@ -44,11 +45,15 @@ const templates = [
 ];
 
 describe('email templates', () => {
-  it.each(templates)('uses Panachat branding instead of LobeHub', (template) => {
+  it.each(templates)('uses Persian Panachat branding instead of LobeHub', (template) => {
+    expect(template.html).toContain('lang="fa"');
+    expect(template.html).toContain('dir="rtl"');
     expect(template.html).toContain(BRANDING_EMOJI);
+    expect(template.html).toContain(BRANDING_NAME_FA);
     expect(template.html).toContain(BRANDING_NAME);
     expect(template.html).not.toContain('LobeHub');
     expect(template.html).not.toContain('🤯');
+    expect(template.subject).toContain(BRANDING_NAME_FA);
     expect(template.subject).not.toContain('LobeHub');
   });
 
@@ -70,5 +75,17 @@ describe('email templates', () => {
 
     expect(template.html).not.toContain('undefined');
     expect(template.text).not.toContain('undefined');
+  });
+
+  it('renders Persian invite role labels', () => {
+    const template = getWorkspaceInviteEmailTemplate({
+      expiresInDays: 7,
+      role: 'member',
+      url: 'https://example.com/invite',
+      workspaceName: 'تیم نمونه',
+    });
+
+    expect(template.html).toContain('عضو');
+    expect(template.subject).toContain(BRANDING_NAME_FA);
   });
 });

--- a/src/libs/better-auth/email-templates/magic-link.ts
+++ b/src/libs/better-auth/email-templates/magic-link.ts
@@ -1,30 +1,31 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  formatEmailExpirationFa,
+  getEmailBrandCopyrightHtml,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Magic link sign-in email template
+ * Magic link sign-in email template (Persian)
  * Sent when user requests passwordless login
  */
 export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; url: string }) => {
   const { url, expiresInSeconds } = params;
-
-  const expiresInMinutes = Math.round(expiresInSeconds / 60);
-  const expirationText =
-    expiresInMinutes >= 1
-      ? `${expiresInMinutes} minute${expiresInMinutes > 1 ? 's' : ''}`
-      : `${expiresInSeconds} seconds`;
+  const expirationText = formatEmailExpirationFa(expiresInSeconds);
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign in to ${emailBrandName}</title>
+  <title>ورود به ${emailBrandName}</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
@@ -37,33 +38,33 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Sign in to ${emailBrandName}
+          ورود به ${emailBrandName}
         </h1>
-        <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.5;">
-          Click the link below to sign in to your account.
+        <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.8;">
+          برای ورود به حساب، روی لینک زیر کلیک کنید.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
         
         <!-- Button -->
         <div style="text-align: center; margin: 32px 0;">
           <a href="${url}" target="_blank"
              style="display: inline-block; background-color: #000000; color: #ffffff; text-decoration: none; padding: 16px 36px; border-radius: 14px; font-weight: 600; font-size: 16px; transition: all 0.2s ease; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            Sign In
+            ورود
           </a>
         </div>
 
         <!-- Expiration Note -->
         <div style="background-color: #f9fafb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #f3f4f6;">
-          <p style="color: #6b7280; font-size: 13px; margin: 0; text-align: center; line-height: 1.5;">
-            ⏰ This link will expire in <strong>${expirationText}</strong>.
+          <p style="color: #6b7280; font-size: 13px; margin: 0; text-align: center; line-height: 1.8;">
+            ⏰ این لینک تا <strong>${expirationText}</strong> دیگر منقضی می‌شود.
           </p>
         </div>
 
         <p style="color: #6b7280; font-size: 14px; margin: 0 0 8px 0; text-align: center;">
-          If you didn't request this email, you can safely ignore it.
+          اگر این ایمیل را درخواست نکرده‌اید، می‌توانید آن را نادیده بگیرید.
         </p>
       </div>
 
@@ -73,9 +74,9 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
       <!-- Fallback Link -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          Button not working? Copy and paste this link into your browser:
+          دکمه کار نمی‌کند؟ این لینک را در مرورگر کپی کنید:
         </p>
-        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4;">
+        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4; direction: ltr;">
           ${url}
         </a>
       </div>
@@ -94,7 +95,7 @@ export const getMagicLinkEmailTemplate = (params: { expiresInSeconds: number; ur
 </body>
 </html>
     `,
-    subject: `Your ${emailBrandName} sign-in link`,
-    text: `Use this link to sign in: ${url}\n\nThis link expires in ${expirationText}.\n\n${getEmailSupportText()}`,
+    subject: `لینک ورود به ${emailBrandName}`,
+    text: `برای ورود از این لینک استفاده کنید: ${url}\n\nاین لینک تا ${expirationText} دیگر منقضی می‌شود.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/reset-password.ts
+++ b/src/libs/better-auth/email-templates/reset-password.ts
@@ -1,9 +1,14 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  getEmailBrandCopyrightHtml,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Password reset email template
+ * Password reset email template (Persian)
  * Sent to users when they request a password reset
  */
 export const getResetPasswordEmailTemplate = (params: { url: string }) => {
@@ -12,13 +17,13 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reset your password</title>
+  <title>بازنشانی رمز عبور</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
@@ -31,31 +36,31 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Reset Your Password
+          بازنشانی رمز عبور
         </h1>
-        <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.5;">
-          No worries, we'll help you get back on track.
+        <p style="color: #6b7280; font-size: 16px; margin: 0; line-height: 1.8;">
+          نگران نباشید؛ کمکتان می‌کنیم دوباره وارد شوید.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
         <p style="margin: 0 0 24px 0; text-align: center;">
-          You recently requested to reset your password for your ${emailBrandName} account. Click the button below to proceed.
+          اخیراً درخواست بازنشانی رمز عبور حساب ${emailBrandName} خود را ثبت کرده‌اید. برای ادامه روی دکمه زیر کلیک کنید.
         </p>
 
         <!-- Button -->
         <div style="text-align: center; margin: 32px 0;">
           <a href="${url}" target="_blank"
              style="display: inline-block; background-color: #000000; color: #ffffff; text-decoration: none; padding: 16px 36px; border-radius: 14px; font-weight: 600; font-size: 16px; transition: all 0.2s ease; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            Reset Password
+            بازنشانی رمز عبور
           </a>
         </div>
 
         <!-- Security Note -->
         <div style="background-color: #f9fafb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #f3f4f6;">
-          <p style="color: #6b7280; font-size: 13px; margin: 0; text-align: center; line-height: 1.5;">
-            🔒 If you did not request a password reset, please ignore this email or contact support if you have concerns.
+          <p style="color: #6b7280; font-size: 13px; margin: 0; text-align: center; line-height: 1.8;">
+            🔒 اگر این درخواست را نداده‌اید، این ایمیل را نادیده بگیرید یا در صورت نگرانی با پشتیبانی تماس بگیرید.
           </p>
         </div>
       </div>
@@ -66,9 +71,9 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
       <!-- Fallback Link -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          Trouble clicking the button? Copy and paste the URL below:
+          دکمه کار نمی‌کند؟ این آدرس را در مرورگر کپی کنید:
         </p>
-        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4;">
+        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4; direction: ltr;">
           ${url}
         </a>
       </div>
@@ -87,7 +92,7 @@ export const getResetPasswordEmailTemplate = (params: { url: string }) => {
 </body>
 </html>
     `,
-    subject: `Reset Your Password - ${emailBrandName}`,
-    text: `Reset your password by clicking this link: ${url}\n\n${getEmailSupportText()}`,
+    subject: `بازنشانی رمز عبور — ${emailBrandName}`,
+    text: `برای بازنشانی رمز عبور روی این لینک کلیک کنید: ${url}\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification-otp.ts
+++ b/src/libs/better-auth/email-templates/verification-otp.ts
@@ -1,9 +1,15 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  formatEmailExpirationFa,
+  getEmailBrandCopyrightHtml,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Email OTP verification template for mobile
+ * Email OTP verification template for mobile (Persian)
  * Sent to users when they need to verify their email using OTP code
  */
 export const getVerificationOTPEmailTemplate = (params: {
@@ -12,24 +18,18 @@ export const getVerificationOTPEmailTemplate = (params: {
   userName?: string | null;
 }) => {
   const { otp, userName, expiresInSeconds } = params;
-
-  // Format expiration time in a human-readable way
-  const expiresInMinutes = expiresInSeconds / 60;
-  const expirationText =
-    expiresInMinutes >= 1
-      ? `${expiresInMinutes} minute${expiresInMinutes > 1 ? 's' : ''}`
-      : `${expiresInSeconds} seconds`;
+  const expirationText = formatEmailExpirationFa(expiresInSeconds);
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Verify your email</title>
+  <title>تأیید ایمیل</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
@@ -42,25 +42,25 @@ export const getVerificationOTPEmailTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Verify your email address
+          تأیید آدرس ایمیل
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
-          Enter this code in the app to complete verification.
+          این کد را در اپلیکیشن وارد کنید تا تأیید کامل شود.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
-        ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
+        ${userName ? `<p style="margin: 0 0 16px 0;">سلام <strong>${userName}</strong>،</p>` : ''}
 
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with ${emailBrandName}. To verify your email address, please use the verification code below:
+          از ثبت‌نام در ${emailBrandName} سپاسگزاریم. برای تأیید ایمیل، از کد زیر استفاده کنید:
         </p>
 
         <!-- OTP Code Box -->
         <div style="text-align: center; margin: 36px 0;">
           <div style="display: inline-block; background-color: #000000; padding: 24px 48px; border-radius: 14px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            <div style="font-size: 36px; font-weight: 700; letter-spacing: 12px; color: #ffffff; font-family: 'Courier New', Courier, monospace;">
+            <div style="font-size: 36px; font-weight: 700; letter-spacing: 12px; color: #ffffff; font-family: 'Courier New', Courier, monospace; direction: ltr;">
               ${otp}
             </div>
           </div>
@@ -69,12 +69,12 @@ export const getVerificationOTPEmailTemplate = (params: {
         <!-- Expiration Note -->
         <div style="background-color: #f9fafb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #f3f4f6;">
           <p style="color: #6b7280; font-size: 14px; margin: 0; text-align: center;">
-            ⏰ This code will expire in <strong>${expirationText}</strong>.
+            ⏰ این کد تا <strong>${expirationText}</strong> دیگر منقضی می‌شود.
           </p>
         </div>
 
         <p style="color: #6b7280; font-size: 15px; margin: 0 0 8px 0;">
-          If you didn't request this code, you can safely ignore this email.
+          اگر این کد را درخواست نکرده‌اید، می‌توانید این ایمیل را نادیده بگیرید.
         </p>
       </div>
 
@@ -84,7 +84,7 @@ export const getVerificationOTPEmailTemplate = (params: {
       <!-- Security Note -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          🔒 For security reasons, never share this code with anyone.
+          🔒 به‌خاطر امنیت، این کد را با کسی به اشتراک نگذارید.
         </p>
       </div>
     </div>
@@ -102,7 +102,7 @@ export const getVerificationOTPEmailTemplate = (params: {
 </body>
 </html>
     `,
-    subject: `Verify Your Email - ${emailBrandName}`,
-    text: `Your verification code is: ${otp}\n\nThis code will expire in ${expirationText}.\n\nIf you didn't request this code, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    subject: `تأیید ایمیل — ${emailBrandName}`,
+    text: `کد تأیید شما: ${otp}\n\nاین کد تا ${expirationText} دیگر منقضی می‌شود.\n\nاگر این کد را درخواست نکرده‌اید، می‌توانید این ایمیل را نادیده بگیرید.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/verification.ts
+++ b/src/libs/better-auth/email-templates/verification.ts
@@ -1,9 +1,15 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandCopyrightHtml, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  formatEmailExpirationFa,
+  getEmailBrandCopyrightHtml,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Email verification template
+ * Email verification template (Persian)
  * Sent to users when they sign up to verify their email address
  */
 export const getVerificationEmailTemplate = (params: {
@@ -12,24 +18,18 @@ export const getVerificationEmailTemplate = (params: {
   userName?: string | null;
 }) => {
   const { url, userName, expiresInSeconds } = params;
-
-  // Format expiration time in a human-readable way
-  const expiresInHours = expiresInSeconds / 3600;
-  const expirationText =
-    expiresInHours >= 1
-      ? `${expiresInHours} hour${expiresInHours > 1 ? 's' : ''}`
-      : `${expiresInSeconds / 60} minutes`;
+  const expirationText = formatEmailExpirationFa(expiresInSeconds);
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Verify your email</title>
+  <title>تأیید ایمیل</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <!-- Container -->
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     
@@ -42,38 +42,38 @@ export const getVerificationEmailTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Verify your email address
+          تأیید آدرس ایمیل
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
-          Let's get you signed in.
+          برای ورود، ایمیل خود را تأیید کنید.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
-        ${userName ? `<p style="margin: 0 0 16px 0;">Hi <strong>${userName}</strong>,</p>` : ''}
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
+        ${userName ? `<p style="margin: 0 0 16px 0;">سلام <strong>${userName}</strong>،</p>` : ''}
         
         <p style="margin: 0 0 24px 0;">
-          Thanks for creating an account with ${emailBrandName}. To access your account, please verify your email address by clicking the button below.
+          از ثبت‌نام در ${emailBrandName} سپاسگزاریم. برای دسترسی به حساب، لطفاً با کلیک روی دکمه زیر آدرس ایمیل خود را تأیید کنید.
         </p>
 
         <!-- Button -->
         <div style="text-align: center; margin: 36px 0;">
           <a href="${url}" target="_blank"
              style="display: inline-block; background-color: #000000; color: #ffffff; text-decoration: none; padding: 16px 36px; border-radius: 14px; font-weight: 600; font-size: 16px; transition: transform 0.1s ease; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            Verify Email Address
+            تأیید ایمیل
           </a>
         </div>
 
         <!-- Expiration Note -->
         <div style="background-color: #f9fafb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #f3f4f6;">
           <p style="color: #6b7280; font-size: 14px; margin: 0; text-align: center;">
-            ⏰ This link will expire in <strong>${expirationText}</strong>.
+            ⏰ این لینک تا <strong>${expirationText}</strong> دیگر منقضی می‌شود.
           </p>
         </div>
         
         <p style="color: #6b7280; font-size: 15px; margin: 0 0 8px 0;">
-          If you didn't create an account, you can safely ignore this email.
+          اگر شما حسابی نساخته‌اید، می‌توانید این ایمیل را نادیده بگیرید.
         </p>
       </div>
 
@@ -83,9 +83,9 @@ export const getVerificationEmailTemplate = (params: {
       <!-- Fallback Link -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          Button not working? Copy and paste this link into your browser:
+          دکمه کار نمی‌کند؟ این لینک را در مرورگر خود کپی و باز کنید:
         </p>
-        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4;">
+        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4; direction: ltr;">
           ${url}
         </a>
       </div>
@@ -104,7 +104,7 @@ export const getVerificationEmailTemplate = (params: {
 </body>
 </html>
     `,
-    subject: `Verify Your Email - ${emailBrandName}`,
-    text: `Please verify your email by clicking this link: ${url}\n\nThis link will expire in ${expirationText}.\n\n${getEmailSupportText()}`,
+    subject: `تأیید ایمیل — ${emailBrandName}`,
+    text: `لطفاً با کلیک روی این لینک ایمیل خود را تأیید کنید: ${url}\n\nاین لینک تا ${expirationText} دیگر منقضی می‌شود.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-invite.ts
+++ b/src/libs/better-auth/email-templates/workspace-invite.ts
@@ -1,9 +1,14 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  formatWorkspaceRoleFa,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 /**
- * Workspace invitation email template
+ * Workspace invitation email template (Persian)
  * Sent when a workspace owner invites someone (by email) to join their workspace.
  */
 export const getWorkspaceInviteEmailTemplate = (params: {
@@ -16,22 +21,23 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 }) => {
   const { url, workspaceName, inviterName, inviterEmail, role, expiresInDays } = params;
 
-  const inviterLabel = inviterName || inviterEmail || 'A teammate';
+  const inviterLabel = inviterName || inviterEmail || 'یکی از هم‌تیمی‌ها';
   const inviterByline =
     inviterEmail && inviterName ? `${inviterName} (${inviterEmail})` : inviterLabel;
-  const subject = `${inviterLabel} invited you to join ${workspaceName} on ${emailBrandName}`;
-  const roleLabel = role.charAt(0).toUpperCase() + role.slice(1);
+  const subject = `${inviterLabel} شما را به ${workspaceName} در ${emailBrandName} دعوت کرده است`;
+  const roleLabel = formatWorkspaceRoleFa(role);
+  const expiresDaysText = expiresInDays === 1 ? '۱ روز' : `${expiresInDays} روز`;
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${subject}</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
@@ -43,37 +49,37 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <!-- Header -->
       <div style="text-align: center; margin-bottom: 32px;">
         <h1 style="color: #111827; font-size: 24px; font-weight: 700; margin: 0 0 12px 0; letter-spacing: -0.5px;">
-          Join <strong>${workspaceName}</strong> on ${emailBrandName}
+          به <strong>${workspaceName}</strong> در ${emailBrandName} بپیوندید
         </h1>
         <p style="color: #6b7280; font-size: 16px; margin: 0;">
-          You've been invited as a <strong>${roleLabel}</strong>.
+          شما با نقش <strong>${roleLabel}</strong> دعوت شده‌اید.
         </p>
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
         <p style="margin: 0 0 24px 0;">
-          <strong>${inviterByline}</strong> has invited you to collaborate inside the
-          <strong>${workspaceName}</strong> workspace on ${emailBrandName}.
+          <strong>${inviterByline}</strong> شما را برای همکاری در فضای کاری
+          <strong>${workspaceName}</strong> در ${emailBrandName} دعوت کرده است.
         </p>
 
         <!-- Button -->
         <div style="text-align: center; margin: 36px 0;">
           <a href="${url}" target="_blank"
              style="display: inline-block; background-color: #000000; color: #ffffff; text-decoration: none; padding: 16px 36px; border-radius: 14px; font-weight: 600; font-size: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
-            Join the team
+            پیوستن به تیم
           </a>
         </div>
 
         <!-- Expiration Note -->
         <div style="background-color: #fffbeb; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #fde68a;">
           <p style="color: #92400e; font-size: 14px; margin: 0; text-align: center;">
-            ⏰ This invitation will expire in <strong>${expiresInDays} day${expiresInDays > 1 ? 's' : ''}</strong>.
+            ⏰ این دعوت‌نامه تا <strong>${expiresDaysText}</strong> دیگر منقضی می‌شود.
           </p>
         </div>
 
         <p style="color: #6b7280; font-size: 15px; margin: 0;">
-          If you don't have a ${emailBrandName} account yet, you'll be guided through a quick signup before joining the workspace.
+          اگر هنوز حساب ${emailBrandName} ندارید، قبل از پیوستن به فضای کاری، مراحل کوتاه ثبت‌نام را طی خواهید کرد.
         </p>
       </div>
 
@@ -83,9 +89,9 @@ export const getWorkspaceInviteEmailTemplate = (params: {
       <!-- Fallback Link -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0 0 8px 0;">
-          Button not working? Copy and paste this link into your browser:
+          دکمه کار نمی‌کند؟ این لینک را در مرورگر کپی کنید:
         </p>
-        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4;">
+        <a href="${url}" style="color: #2563eb; font-size: 13px; text-decoration: none; word-break: break-all; display: block; line-height: 1.4; direction: ltr;">
           ${url}
         </a>
       </div>
@@ -97,7 +103,7 @@ export const getWorkspaceInviteEmailTemplate = (params: {
         ${getEmailSupportHtml()}
       </p>
       <p style="color: #a1a1aa; font-size: 13px; margin: 0;">
-        If you weren't expecting this invitation, you can safely ignore this email.
+        اگر منتظر این دعوت نبودید، می‌توانید این ایمیل را نادیده بگیرید.
       </p>
     </div>
   </div>
@@ -105,6 +111,6 @@ export const getWorkspaceInviteEmailTemplate = (params: {
 </html>
     `,
     subject,
-    text: `${inviterByline} has invited you to join the "${workspaceName}" workspace on ${emailBrandName} as ${roleLabel}.\n\nAccept the invitation: ${url}\n\nThis invitation will expire in ${expiresInDays} day${expiresInDays > 1 ? 's' : ''}.\n\nIf you weren't expecting this invitation, you can safely ignore this email.\n\n${getEmailSupportText()}`,
+    text: `${inviterByline} شما را به فضای کاری «${workspaceName}» در ${emailBrandName} با نقش ${roleLabel} دعوت کرده است.\n\nپذیرش دعوت: ${url}\n\nاین دعوت‌نامه تا ${expiresDaysText} دیگر منقضی می‌شود.\n\nاگر منتظر این دعوت نبودید، می‌توانید این ایمیل را نادیده بگیرید.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/better-auth/email-templates/workspace-member-removed.ts
+++ b/src/libs/better-auth/email-templates/workspace-member-removed.ts
@@ -1,6 +1,11 @@
 import { getEmailSupportHtml, getEmailSupportText } from '@/libs/email/support';
 
-import { emailBrandName, getEmailBrandAutomatedMessage, getEmailBrandLogoHtml } from './branding';
+import {
+  EMAIL_FONT_STACK,
+  emailBrandName,
+  getEmailBrandAutomatedMessage,
+  getEmailBrandLogoHtml,
+} from './branding';
 
 export const getWorkspaceMemberRemovedEmailTemplate = (params: {
   reason: 'downgrade' | 'removed_by_owner';
@@ -10,24 +15,24 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
 
   const isDowngrade = reason === 'downgrade';
 
-  const subject = `You have been removed from ${workspaceName} on ${emailBrandName}`;
+  const subject = `شما از ${workspaceName} در ${emailBrandName} حذف شده‌اید`;
 
-  const heading = `Removed from <strong>${workspaceName}</strong>`;
+  const heading = `حذف از <strong>${workspaceName}</strong>`;
 
   const body = isDowngrade
-    ? `The workspace <strong>${workspaceName}</strong> has been downgraded, and all team members have been removed as a result. Your personal data and workspaces are not affected.`
-    : `The owner of <strong>${workspaceName}</strong> has removed you from the workspace. Your personal data and workspaces are not affected.`;
+    ? `فضای کاری <strong>${workspaceName}</strong> به نسخه پایین‌تر تغییر کرده و در نتیجه همه اعضای تیم حذف شده‌اند. داده‌ها و فضاهای کاری شخصی شما تحت تأثیر قرار نگرفته‌اند.`
+    : `مالک فضای کاری <strong>${workspaceName}</strong> شما را از این فضا حذف کرده است. داده‌ها و فضاهای کاری شخصی شما تحت تأثیر قرار نگرفته‌اند.`;
 
   return {
     html: `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${subject}</title>
 </head>
-<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f4f4f5; color: #1a1a1a;">
+<body style="margin: 0; padding: 0; font-family: ${EMAIL_FONT_STACK}; background-color: #f4f4f5; color: #1a1a1a; direction: rtl;">
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
 
     <!-- Logo -->
@@ -44,7 +49,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
       </div>
 
       <!-- Content -->
-      <div style="color: #374151; font-size: 16px; line-height: 1.6;">
+      <div style="color: #374151; font-size: 16px; line-height: 1.8;">
         <p style="margin: 0 0 24px 0;">
           ${body}
         </p>
@@ -52,7 +57,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
         <!-- Info Note -->
         <div style="background-color: #f0f9ff; border-radius: 12px; padding: 16px; margin-bottom: 24px; border: 1px solid #bae6fd;">
           <p style="color: #0c4a6e; font-size: 14px; margin: 0; text-align: center;">
-            If you believe this was a mistake, please contact the workspace owner.
+            اگر فکر می‌کنید اشتباهی رخ داده، با مالک فضای کاری تماس بگیرید.
           </p>
         </div>
       </div>
@@ -63,7 +68,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
       <!-- Footer note -->
       <div style="text-align: center;">
         <p style="color: #9ca3af; font-size: 13px; margin: 0;">
-          You can continue using ${emailBrandName} with your personal workspace.
+          می‌توانید با فضای کاری شخصی خود به استفاده از ${emailBrandName} ادامه دهید.
         </p>
       </div>
     </div>
@@ -83,7 +88,7 @@ export const getWorkspaceMemberRemovedEmailTemplate = (params: {
     `,
     subject,
     text: isDowngrade
-      ? `The workspace "${workspaceName}" has been downgraded, and all team members have been removed as a result. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.\n\n${getEmailSupportText()}`
-      : `The owner of "${workspaceName}" has removed you from the workspace. Your personal data and workspaces are not affected. If you believe this was a mistake, please contact the workspace owner.\n\n${getEmailSupportText()}`,
+      ? `فضای کاری «${workspaceName}» به نسخه پایین‌تر تغییر کرده و در نتیجه همه اعضای تیم حذف شده‌اند. داده‌ها و فضاهای کاری شخصی شما تحت تأثیر قرار نگرفته‌اند. اگر فکر می‌کنید اشتباهی رخ داده، با مالک فضای کاری تماس بگیرید.\n\n${getEmailSupportText()}`
+      : `مالک فضای کاری «${workspaceName}» شما را از این فضا حذف کرده است. داده‌ها و فضاهای کاری شخصی شما تحت تأثیر قرار نگرفته‌اند. اگر فکر می‌کنید اشتباهی رخ داده، با مالک فضای کاری تماس بگیرید.\n\n${getEmailSupportText()}`,
   };
 };

--- a/src/libs/email/support.ts
+++ b/src/libs/email/support.ts
@@ -6,8 +6,8 @@ interface EmailSupportCopy {
 }
 
 const DEFAULT_SUPPORT_COPY = {
-  contactSupport: 'Contact support',
-  joinDiscord: 'Join Discord',
+  contactSupport: 'تماس با پشتیبانی',
+  joinDiscord: 'عضویت در Discord',
 } satisfies Required<EmailSupportCopy>;
 
 const escapeHtml = (value: string) =>


### PR DESCRIPTION
#### 💥 Change Type
- [x] ✨ \`Features\`

#### 🔗 Related Issue
Fixes #195

Plane: [AICO-119](https://plane.panafor.com/panaforai/browse/AICO-119)

#### 📝 Description of Change
Localize all Better Auth transactional email templates (verification, OTP, magic link, password reset, change-email, workspace invite/removal) to Persian with \`lang=\"fa\"\` / \`dir=\"rtl\"\`, پاناچت branding, and Persian support/copyright footers.

#### 🧪 How to Test
- [x] Unit tests: \`src/libs/better-auth/email-templates/index.test.ts\`
- [ ] Trigger a verification / reset email and confirm Persian subject + RTL HTML body

Made with [Cursor](https://cursor.com)