### PR TITLE
🔒 fix(auth): harden authentication & session security (AICO-102)

### DIFF
--- a/apps/server/src/agent-hono/handlers/messengerInstall.ts
+++ b/apps/server/src/agent-hono/handlers/messengerInstall.ts
@@ -45,7 +45,11 @@ export async function messengerInstall(c: Context): Promise<Response> {
   // 2. Session check — unauth users get bounced through sign-in and back.
   let session: Awaited<ReturnType<typeof auth.api.getSession>>;
   try {
-    session = await auth.api.getSession({ headers: req.headers });
+    // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
+    session = await auth.api.getSession({
+      headers: req.headers,
+      query: { disableCookieCache: true },
+    });
   } catch (error) {
     log('install: getSession failed: %O', error);
     session = null;

--- a/apps/server/src/services/sms/impls/debug.otpLogging.test.ts
+++ b/apps/server/src/services/sms/impls/debug.otpLogging.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('DebugSmsService — no OTP in console (MON-001)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('does not console.info OTP codes', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const { DebugSmsService } = await import('./debug');
+    await new DebugSmsService().sendSms({
+      code: '123456',
+      message: 'کد تایید شما: 123456',
+      to: '+989121234567',
+    });
+    expect(info).not.toHaveBeenCalled();
+  });
+});
+
+describe('SmsService AUTH_SMS_DEBUG_OTP production gate (MON-001)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('ignores AUTH_SMS_DEBUG_OTP in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('KAVENEGAR_API_KEY', 'test-key');
+    vi.stubEnv('AUTH_SMS_DEBUG_OTP', '1');
+    const { SmsService } = await import('../index');
+    const service = new SmsService();
+    expect((service as { debugMirror: unknown }).debugMirror).toBeNull();
+  });
+});

--- a/apps/server/src/services/sms/impls/debug.ts
+++ b/apps/server/src/services/sms/impls/debug.ts
@@ -5,14 +5,14 @@ import { type SmsPayload, type SmsResponse, type SmsServiceImpl } from './type';
 const log = debug('lobe-sms:debug');
 
 /**
- * Dev/fallback SMS impl — logs the OTP instead of sending.
- * Never enable as the sole provider in production without a real gateway.
+ * Dev/fallback SMS impl — logs the OTP via the `debug` namespace instead of sending.
+ * Never enable as the sole provider in production (see `createSmsServiceImpl`).
+ * Never write OTP codes to stdout/`console.*` — log aggregators must not retain secrets.
  */
 export class DebugSmsService implements SmsServiceImpl {
   async sendSms(payload: SmsPayload): Promise<SmsResponse> {
+    // Opt-in via DEBUG=lobe-sms:debug (local QA). Do not use console.info — OTPs are secrets.
     log('SMS (debug) to=%s code=%s message=%s', payload.to, payload.code, payload.message);
-    // Also surface in stdout so local Phase 1 QA can copy the OTP without DEBUG=*
-    console.info(`[sms:debug] OTP for ${payload.to}: ${payload.code ?? '(see message)'}`);
     return { messageId: `debug-${Date.now()}`, provider: 'debug' };
   }
 }

--- a/apps/server/src/services/sms/index.ts
+++ b/apps/server/src/services/sms/index.ts
@@ -4,7 +4,8 @@ import { DebugSmsService } from './impls/debug';
 
 /**
  * SMS service — Kavenegar when `KAVENEGAR_API_KEY` is set, otherwise debug logger.
- * When `AUTH_SMS_DEBUG_OTP=1`, also mirrors OTP to the debug impl (local QA).
+ * When `AUTH_SMS_DEBUG_OTP=1` in non-production, also mirrors OTP to the debug impl (local QA).
+ * The mirror is ignored in production even if the env flag is set (MON-001).
  */
 export class SmsService {
   private smsImpl: SmsServiceImpl;
@@ -12,8 +13,10 @@ export class SmsService {
 
   constructor(implType?: SmsImplType) {
     this.smsImpl = createSmsServiceImpl(implType);
+    const isProduction = process.env.NODE_ENV === 'production';
     const debugOtp =
-      process.env.AUTH_SMS_DEBUG_OTP === '1' || process.env.AUTH_SMS_DEBUG_OTP === 'true';
+      !isProduction &&
+      (process.env.AUTH_SMS_DEBUG_OTP === '1' || process.env.AUTH_SMS_DEBUG_OTP === 'true');
     this.debugMirror = debugOtp ? new DebugSmsService() : null;
   }
 

--- a/locales/en-US/auth.json
+++ b/locales/en-US/auth.json
@@ -56,7 +56,7 @@
   "betterAuth.errors.loginFailed": "Sign in failed, please check your email and password",
   "betterAuth.errors.passwordFormat": "Password must contain both letters and numbers",
   "betterAuth.errors.passwordMaxLength": "Password must not exceed 64 characters",
-  "betterAuth.errors.passwordMinLength": "Password must be at least 8 characters",
+  "betterAuth.errors.passwordMinLength": "Password must be at least 10 characters",
   "betterAuth.errors.passwordMismatch": "The passwords do not match",
   "betterAuth.errors.passwordRequired": "Please enter your password",
   "betterAuth.errors.usernameNotRegistered": "This username is not registered",

--- a/locales/fa-IR/auth.json
+++ b/locales/fa-IR/auth.json
@@ -56,7 +56,7 @@
   "betterAuth.errors.loginFailed": "ورود ناموفق بود، لطفاً ایمیل و رمز عبور خود را بررسی کنید",
   "betterAuth.errors.passwordFormat": "رمز عبور باید شامل حروف و اعداد باشد",
   "betterAuth.errors.passwordMaxLength": "رمز عبور نباید بیش از ۶۴ کاراکتر باشد",
-  "betterAuth.errors.passwordMinLength": "رمز عبور باید حداقل ۸ کاراکتر باشد",
+  "betterAuth.errors.passwordMinLength": "رمز عبور باید حداقل ۱۰ کاراکتر باشد",
   "betterAuth.errors.passwordMismatch": "رمزهای عبور مطابقت ندارند",
   "betterAuth.errors.passwordRequired": "لطفاً رمز عبور خود را وارد کنید",
   "betterAuth.errors.usernameNotRegistered": "این نام کاربری ثبت نشده است",

--- a/locales/fr-FR/auth.json
+++ b/locales/fr-FR/auth.json
@@ -56,7 +56,7 @@
   "betterAuth.errors.loginFailed": "Échec de la connexion, veuillez vérifier votre e-mail et mot de passe",
   "betterAuth.errors.passwordFormat": "Le mot de passe doit contenir des lettres et des chiffres",
   "betterAuth.errors.passwordMaxLength": "Le mot de passe ne doit pas dépasser 64 caractères",
-  "betterAuth.errors.passwordMinLength": "Le mot de passe doit contenir au moins 8 caractères",
+  "betterAuth.errors.passwordMinLength": "Le mot de passe doit contenir au moins 10 caractères",
   "betterAuth.errors.passwordMismatch": "Les mots de passe ne correspondent pas",
   "betterAuth.errors.passwordRequired": "Veuillez saisir votre mot de passe",
   "betterAuth.errors.usernameNotRegistered": "Ce nom d'utilisateur n'est pas enregistré",

--- a/locales/zh-CN/auth.json
+++ b/locales/zh-CN/auth.json
@@ -56,7 +56,7 @@
   "betterAuth.errors.loginFailed": "登录遇到了问题。请检查账号与密码后重试",
   "betterAuth.errors.passwordFormat": "密码需同时包含字母和数字",
   "betterAuth.errors.passwordMaxLength": "密码最多 64 个字符",
-  "betterAuth.errors.passwordMinLength": "密码至少 8 个字符",
+  "betterAuth.errors.passwordMinLength": "密码至少 10 个字符",
   "betterAuth.errors.passwordMismatch": "两次输入的密码不一致",
   "betterAuth.errors.passwordRequired": "请输入密码",
   "betterAuth.errors.usernameNotRegistered": "该用户名尚未注册",

--- a/packages/locales/src/default/auth.ts
+++ b/packages/locales/src/default/auth.ts
@@ -56,7 +56,7 @@ export default {
   'betterAuth.errors.loginFailed': 'Sign in failed, please check your email and password',
   'betterAuth.errors.passwordFormat': 'Password must contain both letters and numbers',
   'betterAuth.errors.passwordMaxLength': 'Password must not exceed 64 characters',
-  'betterAuth.errors.passwordMinLength': 'Password must be at least 8 characters',
+  'betterAuth.errors.passwordMinLength': 'Password must be at least 10 characters',
   'betterAuth.errors.passwordMismatch': 'The passwords do not match',
   'betterAuth.errors.passwordRequired': 'Please enter your password',
   'betterAuth.errors.usernameNotRegistered': 'This username is not registered',

--- a/packages/trpc/src/lambda/context.test.ts
+++ b/packages/trpc/src/lambda/context.test.ts
@@ -403,6 +403,10 @@ describe('createLambdaContext', () => {
 
     expect(context.userId).toBe('session-user');
     expect(mockGetSession).toHaveBeenCalledOnce();
+    expect(mockGetSession).toHaveBeenCalledWith({
+      headers: request.headers,
+      query: { disableCookieCache: true },
+    });
   });
 
   it('should authenticate with active OIDC auth and skip session fallback', async () => {

--- a/packages/trpc/src/lambda/context.ts
+++ b/packages/trpc/src/lambda/context.ts
@@ -315,8 +315,10 @@ export const createLambdaContext = async (request: NextRequest): Promise<LambdaC
   // If OIDC is not enabled or validation fails, try Better Auth authentication
   log('Attempting Better Auth authentication');
   try {
+    // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
     const session = await auth.api.getSession({
       headers: request.headers,
+      query: { disableCookieCache: true },
     });
 
     if (session && session?.user?.id) {

--- a/packages/utils/src/server/auth.ts
+++ b/packages/utils/src/server/auth.ts
@@ -6,8 +6,10 @@ export const getUserAuth = async () => {
   const currentHeaders = await headers();
   const requestHeaders = Object.fromEntries(currentHeaders.entries());
 
+  // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
   const session = await auth.api.getSession({
     headers: requestHeaders,
+    query: { disableCookieCache: true },
   });
 
   const userId = session?.user?.id;

--- a/security-audit-reports/phase-01-identity-access/01-authentication-session-security.md
+++ b/security-audit-reports/phase-01-identity-access/01-authentication-session-security.md
@@ -1,0 +1,297 @@
+# Phase 01 — Authentication & Session Security
+
+| Field                 | Value                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Audit area**        | Authentication, Session Management, OTP, OAuth, Verification                            |
+| **Phase**             | Phase 1 — Identity & Access Security                                                    |
+| **Finding ID prefix** | `AUTH-xxx`                                                                              |
+| **Report path**       | `security-audit-reports/phase-01-identity-access/01-authentication-session-security.md` |
+| **Plane**             | [AICO-102](https://plane.panafor.com/panaforai/browse/AICO-102)                         |
+| **Date**              | 2026-08-08                                                                              |
+| **Method**            | Static review + practical Vitest attack/control suites (defensive; no exploit payloads) |
+| **Retest**            | AUTH-001 / AUTH-002 Fixed and regression-tested in this pass                            |
+
+---
+
+## Executive summary
+
+Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-config.ts`) with Aico overlays: Iranian phone OTP (Kavenegar), `phoneLoginGate`, org/trial phone gates, and redirect sanitization.
+
+**Core controls (Pass):** scrypt password hashing (bcrypt verify for Clerk migrations), 6-digit OTP / 300s TTL / 3 attempts / single-use, production rate limits on sign-in / OTP / password reset, HttpOnly + Secure (HTTPS) + SameSite=Lax cookies, `revokeSessionsOnPasswordReset: true`, OAuth trusted-origin + `sanitizeRedirectPath`, phone gates for org create / convertToManagement / trial.
+
+**This pass closed the two Medium findings:**
+
+| ID           | Fix                                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **AUTH-001** | `/api/auth/check-user` no longer returns `hasPassword`; IP sliding-window rate limit (10/60s); sign-in always uses password step for existing users |
+| **AUTH-002** | Server `getSession` calls use `query: { disableCookieCache: true }` on TRPC, chat middleware, proxy, utils auth, trusted-client, messenger install  |
+
+**Remaining:** AUTH-003 (Low, length-only password policy), AUTH-004 (Medium, Accepted Risk — email verification off by default), AUTH-005 (Low, `changePassword` revoke opt-in; UI uses reset which does revoke). MON-002/003 still Open (auth abuse alerting).
+
+**Verdict:** No open Critical/High in auth/session scope. Mediums either Fixed or Accepted Risk. Suitable for pilot from an auth-control perspective pending product acceptance of AUTH-004 and monitoring gaps (MON-002/003).
+
+---
+
+## Security checks matrix
+
+| #   | Check                                  | Result                  | Evidence                                                                                               |
+| --- | -------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| 1   | Password policy                        | Partial                 | `minPasswordLength: 8`, `maxPasswordLength: 64` — AUTH-003                                             |
+| 2   | Password hashing                       | Pass                    | Better Auth scrypt + bcrypt verify for `$2a$`/`$2b$`                                                   |
+| 3   | OTP expiration                         | Pass                    | `OTP_EXPIRES_IN = 300` — `auth.security.controls.test.ts`                                              |
+| 4   | OTP invalidate after use               | Pass                    | Better Auth phone/email OTP delete-on-success                                                          |
+| 5   | OTP replay                             | Pass                    | Single-use + `allowedAttempts: 3`                                                                      |
+| 6   | OTP rate limit                         | Pass                    | send-otp 3/60s; verify 10/60s — config test                                                            |
+| 7   | Login rate limit                       | Pass                    | Better Auth `/sign-in*` special rule (3/10s) in production                                             |
+| 8   | Password reset rate limit              | Pass                    | `/request-password-reset` 3/60s                                                                        |
+| 9   | Brute-force protection                 | Pass (partial residual) | Login + OTP + check-user rate limits; no CAPTCHA/account lockout                                       |
+| 10  | User enumeration                       | Pass (mitigated)        | `hasPassword` removed; check-user rate-limited — AUTH-001 Fixed (`exists` alone remains for signup UX) |
+| 11  | Session token unpredictability         | Pass                    | Better Auth CSPRNG session tokens                                                                      |
+| 12  | Session fixation                       | Pass                    | Fresh session on sign-in; logout deletes server session                                                |
+| 13  | Session hijacking mitigations          | Pass                    | Cookie flags + AUTH-002 Fixed (no cookie-cache auth window on APIs)                                    |
+| 14  | Logout invalidates session             | Pass                    | DB delete + `disableCookieCache` on sensitive `getSession`                                             |
+| 15  | Password change invalidates sessions   | Partial                 | Reset revokes all; direct `changePassword` — AUTH-005                                                  |
+| 16  | Cookies HttpOnly / Secure / SameSite   | Pass                    | Better Auth defaults                                                                                   |
+| 17  | OAuth redirect abuse                   | Pass                    | `trustedOrigins` + `sanitizeRedirectPath` tests                                                        |
+| 18  | Account linking takeover               | Pass (caveats)          | BA local email verify for link; `allowDifferentEmails: true` for logged-in link                        |
+| 19  | Phone verification bypass              | Pass                    | `requireVerifiedPhone` + `phone-login-gate` + RBAC tests                                               |
+| 20  | Email verification / API before verify | Accepted Risk           | Default `AUTH_EMAIL_VERIFICATION=false` — AUTH-004                                                     |
+
+---
+
+## Required attack tests (practical)
+
+| Attack test                           | Result                        | How tested                                                                                                    |
+| ------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Password brute-force                  | Pass                          | Config asserts login / reset rate limits (`auth.security.controls.test.ts`)                                   |
+| OTP brute-force                       | Pass                          | `allowedAttempts: 3` + verify rate limits asserted                                                            |
+| OTP replay                            | Pass                          | Single-use OTP design in BA plugins (config + BA behavior)                                                    |
+| Password Reset replay                 | Pass                          | Token consume + `revokeSessionsOnPasswordReset: true` asserted                                                |
+| Session reuse after logout            | Pass                          | AUTH-002 Fixed — `disableCookieCache` on TRPC/chat/proxy (`context.test.ts`, `middleware/auth/index.test.ts`) |
+| Session reuse after password change   | Pass                          | Reset revokes sessions + cookie cache bypass on APIs                                                          |
+| OAuth callback manipulation           | Pass                          | Trusted origins / origin checks (static + BA)                                                                 |
+| Open Redirect in OAuth                | Pass                          | `onboardingRedirect.test.ts` (17 cases) + controls test                                                       |
+| Phone Verification bypass             | Pass                          | `phone-login-gate.test.ts` (6) + org `PHONE_VERIFICATION_REQUIRED` in `aico.rbacIdor.test.ts`                 |
+| Email Verification bypass             | Accepted Risk                 | Default config off — AUTH-004 documented                                                                      |
+| Direct API access before verification | Partial / Pass for Aico spend | Org create / convert / trial blocked without phone; chat allowed with session by design                       |
+
+**Suite run (this pass):** `check-user` route + rateLimit, `auth.security.controls`, `phone-login-gate`, `onboardingRedirect`, `useSignIn`, TRPC context, auth middleware — **72+ related tests passed** (full related `bun run check` slice: **121 passed**).
+
+---
+
+## Findings
+
+### AUTH-001 — Unauthenticated email existence / auth-method oracle
+
+- **Finding ID:** AUTH-001
+
+- **Title:** `/api/auth/check-user` disclosed account existence and password capability
+
+- **Severity:** Medium
+
+- **Status:** Fixed
+
+- **Affected Component:** `src/app/(backend)/api/auth/check-user/route.ts`; `rateLimit.ts`; `src/features/Auth/SignIn/useSignIn.ts`
+
+- **Description:**\
+  Public POST previously returned `{ exists, hasPassword }` with no rate limit, enabling email + auth-method enumeration.
+
+- **Attack Scenario:**\
+  Bulk-check emails to prioritize credential stuffing and learn password vs OAuth-only accounts.
+
+- **Reproduction Steps (pre-fix):**
+  1. `POST /api/auth/check-user` with an email.
+  2. Observe `hasPassword` in JSON; no 429 under rapid fire.
+
+- **Impact:**\
+  Facilitates phishing and credential stuffing prioritization.
+
+- **Recommendation / Fix:**\
+  Dropped `hasPassword`; IP sliding-window rate limit (10/min); sign-in always opens password step for existing users (no magic-link auto-branch from oracle). Residual: `exists` still returned for signup redirect UX (throttled).
+
+- **Retest Result:** Pass — `route.test.ts`, `rateLimit.test.ts`, `useSignIn.test.ts`
+
+---
+
+### AUTH-002 — Session cookie cache survives DB session revocation
+
+- **Finding ID:** AUTH-002
+
+- **Title:** `session.cookieCache` authorized APIs without DB session check
+
+- **Severity:** Medium
+
+- **Status:** Fixed
+
+- **Affected Component:** TRPC lambda context; chat `middleware/auth`; Next proxy; `packages/utils` getUserAuth; trusted-client; messenger install
+
+- **Description:**\
+  Cookie cache (`maxAge: 2 min`) could authorize requests after logout / password-reset DB revoke when `getSession` did not pass `disableCookieCache`.
+
+- **Attack Scenario:**\
+  Stolen cookies remain valid on TRPC/chat for up to \~2 minutes after victim resets password or signs out elsewhere.
+
+- **Reproduction Steps (pre-fix):**
+  1. Note `cookieCache.enabled` in `define-config.ts`.
+  2. Confirm server `getSession` lacked `disableCookieCache`.
+
+- **Impact:**\
+  Undermined revoke-on-reset and cross-device logout on high-value APIs.
+
+- **Recommendation / Fix:**\
+  All sensitive server `getSession` calls now pass `query: { disableCookieCache: true }`.
+
+- **Retest Result:** Pass — `packages/trpc/src/lambda/context.test.ts`, `middleware/auth/index.test.ts`
+
+---
+
+### AUTH-003 — Password policy is length-only
+
+- **Finding ID:** AUTH-003
+
+- **Title:** No complexity or breached-password checks beyond 8–64 characters
+
+- **Severity:** Low
+
+- **Status:** Open
+
+- **Affected Component:** `define-config.ts`; signup/reset forms
+
+- **Description:** Length-only policy; weak passwords accepted server-side.
+
+- **Attack Scenario:** Guessing / stuffing against weak passwords (mitigated by login rate limit).
+
+- **Reproduction Steps:** Confirm only `minPasswordLength` / `maxPasswordLength` in Better Auth config.
+
+- **Impact:** Higher success rate for slow/distributed password guessing.
+
+- **Recommendation:** Add complexity or HIBP/zxcvbn blocklist; optionally raise minimum length.
+
+- **Retest Result:** N/A
+
+---
+
+### AUTH-004 — Email verification not required for authenticated APIs (Aico default)
+
+- **Finding ID:** AUTH-004
+
+- **Title:** Default Aico config leaves email-unverified users with full session/API access
+
+- **Severity:** Medium
+
+- **Status:** Accepted Risk
+
+- **Affected Component:** `packages/env/src/auth.ts`; `authedProcedure` / chat auth
+
+- **Description:**\
+  `AUTH_EMAIL_VERIFICATION` defaults false. Phone verification is the spend/org trust anchor.
+
+- **Attack Scenario:** Register with victim’s email (unverified) and use non-phone-gated APIs until phone gates apply.
+
+- **Reproduction Steps:** Confirm default env + no `emailVerified` check on `authedProcedure`.
+
+- **Impact:** Email is not a strong identity control; org/trial/spend paths still require phone.
+
+- **Recommendation:** Keep Accepted Risk with product sign-off; or enable `AUTH_EMAIL_VERIFICATION=1` in production.
+
+- **Retest Result:** N/A (Accepted Risk)
+
+---
+
+### AUTH-005 — `/change-password` does not revoke other sessions by default
+
+- **Finding ID:** AUTH-005
+
+- **Title:** Better Auth `changePassword` leaves other sessions unless `revokeOtherSessions: true`
+
+- **Severity:** Low
+
+- **Status:** Open
+
+- **Affected Component:** Better Auth change-password API; profile UI uses `requestPasswordReset` (which does revoke)
+
+- **Description:** Reset path revokes sessions. Direct change-password is opt-in for revoke. Stock UI uses reset.
+
+- **Attack Scenario:** Custom client calls `changePassword` without revoke flag; other device sessions remain.
+
+- **Reproduction Steps:** Confirm UI uses reset; BA `revokeOtherSessions` optional on change-password.
+
+- **Impact:** Latent footgun; low exploitability via stock UI.
+
+- **Recommendation:** Force `revokeOtherSessions` in a hook/wrapper for any change-password client.
+
+- **Retest Result:** N/A
+
+---
+
+## Positive controls
+
+| Control                                | Notes                                         |
+| -------------------------------------- | --------------------------------------------- |
+| OTP TTL + attempts + single-use        | emailOTP + phoneNumber plugins                |
+| Phone login gate                       | Blocks OTP login for never-verified numbers   |
+| Org/trial phone enforcement            | `PHONE_VERIFICATION_REQUIRED`                 |
+| Password reset anti-enumeration        | Better Auth reset path                        |
+| Cookie flags                           | HttpOnly, Lax, Secure on HTTPS                |
+| OAuth / open-redirect hardening        | `sanitizeRedirectPath` / `isSafeRedirectPath` |
+| SMS production fail-closed             | No Debug SMS without Kavenegar in production  |
+| OTP not on stdout                      | MON-001 Fixed                                 |
+| Phone PII redaction on SMS fail        | MON-005 Fixed                                 |
+| Session revoke on password reset       | `revokeSessionsOnPasswordReset: true`         |
+| Cookie cache bypass on APIs            | AUTH-002 Fixed                                |
+| check-user rate limit + no hasPassword | AUTH-001 Fixed                                |
+
+---
+
+## Related findings
+
+| ID                | Overlap                         | Status |
+| ----------------- | ------------------------------- | ------ |
+| MON-001           | OTP plaintext in logs           | Fixed  |
+| MON-005           | Phone PII in OTP failure logs   | Fixed  |
+| MON-002 / MON-003 | No alerting for login/OTP abuse | Open   |
+
+---
+
+## Finding rollup
+
+| Severity | Count | IDs                                                    |
+| -------- | ----- | ------------------------------------------------------ |
+| Critical | 0     | —                                                      |
+| High     | 0     | —                                                      |
+| Medium   | 3     | AUTH-001 Fixed; AUTH-002 Fixed; AUTH-004 Accepted Risk |
+| Low      | 2     | AUTH-003 Open; AUTH-005 Open                           |
+
+| Status        | Findings           |
+| ------------- | ------------------ |
+| Fixed         | AUTH-001, AUTH-002 |
+| Accepted Risk | AUTH-004           |
+| Open          | AUTH-003, AUTH-005 |
+
+---
+
+## Definition of Done checklist
+
+| Item                                     | Done?                                 |
+| ---------------------------------------- | ------------------------------------- |
+| All Authentication Flows reviewed/tested | Yes                                   |
+| Session Management reviewed              | Yes (+ AUTH-002 Fixed)                |
+| OAuth reviewed                           | Yes                                   |
+| Verification bypass tested               | Yes (phone Pass; email Accepted Risk) |
+| Brute-force scenarios tested             | Yes (config + rate-limit tests)       |
+| All Findings documented (`AUTH-xxx`)     | Yes                                   |
+| Report at required path                  | Yes                                   |
+
+---
+
+## References
+
+- `src/libs/better-auth/define-config.ts`
+- `src/app/(backend)/api/auth/check-user/route.ts`
+- `src/app/(backend)/api/auth/check-user/rateLimit.ts`
+- `packages/trpc/src/lambda/context.ts`
+- `src/app/(backend)/middleware/auth/index.ts`
+- `apps/server/src/routers/lambda/organization.ts`
+- `src/utils/onboardingRedirect.ts`
+- Tests: `auth.security.controls.test.ts`, `check-user/*.test.ts`, `phone-login-gate.test.ts`, `onboardingRedirect.test.ts`
+- Plane: <https://plane.panafor.com/panaforai/browse/AICO-102>

--- a/security-audit-reports/phase-01-identity-access/01-authentication-session-security.md
+++ b/security-audit-reports/phase-01-identity-access/01-authentication-session-security.md
@@ -9,7 +9,7 @@
 | **Plane**             | [AICO-102](https://plane.panafor.com/panaforai/browse/AICO-102)                         |
 | **Date**              | 2026-08-08                                                                              |
 | **Method**            | Static review + practical Vitest attack/control suites (defensive; no exploit payloads) |
-| **Retest**            | AUTH-001 / AUTH-002 Fixed and regression-tested in this pass                            |
+| **Retest**            | AUTH-001…005 closed in this pass (AUTH-004 Accepted Risk); MON-001/005 Fixed            |
 
 ---
 
@@ -19,14 +19,18 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 **Core controls (Pass):** scrypt password hashing (bcrypt verify for Clerk migrations), 6-digit OTP / 300s TTL / 3 attempts / single-use, production rate limits on sign-in / OTP / password reset, HttpOnly + Secure (HTTPS) + SameSite=Lax cookies, `revokeSessionsOnPasswordReset: true`, OAuth trusted-origin + `sanitizeRedirectPath`, phone gates for org create / convertToManagement / trial.
 
-**This pass closed the two Medium findings:**
+**This pass closed auth findings:**
 
 | ID           | Fix                                                                                                                                                 |
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **AUTH-001** | `/api/auth/check-user` no longer returns `hasPassword`; IP sliding-window rate limit (10/60s); sign-in always uses password step for existing users |
 | **AUTH-002** | Server `getSession` calls use `query: { disableCookieCache: true }` on TRPC, chat middleware, proxy, utils auth, trusted-client, messenger install  |
+| **AUTH-003** | `minPasswordLength: 10` + server `passwordPolicy` (letter + digit) on sign-up / change / reset                                                      |
+| **AUTH-005** | `forceChangePasswordRevoke` plugin always sets `revokeOtherSessions: true` on `/change-password`                                                    |
+| **MON-001**  | Debug SMS no longer `console.info`s OTPs; `AUTH_SMS_DEBUG_OTP` ignored in production                                                                |
+| **MON-005**  | OTP send failure logs redact phone to last 4 digits                                                                                                 |
 
-**Remaining:** AUTH-003 (Low, length-only password policy), AUTH-004 (Medium, Accepted Risk — email verification off by default), AUTH-005 (Low, `changePassword` revoke opt-in; UI uses reset which does revoke). MON-002/003 still Open (auth abuse alerting).
+**Remaining:** AUTH-004 (Medium, Accepted Risk — email verification off by default). MON-002/003 still Open (auth abuse alerting; owned by monitoring phase).
 
 **Verdict:** No open Critical/High in auth/session scope. Mediums either Fixed or Accepted Risk. Suitable for pilot from an auth-control perspective pending product acceptance of AUTH-004 and monitoring gaps (MON-002/003).
 
@@ -36,7 +40,7 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 | #   | Check                                  | Result                  | Evidence                                                                                               |
 | --- | -------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------ |
-| 1   | Password policy                        | Partial                 | `minPasswordLength: 8`, `maxPasswordLength: 64` — AUTH-003                                             |
+| 1   | Password policy                        | Pass                    | `minPasswordLength: 10` + letter/digit server policy — AUTH-003 Fixed                                  |
 | 2   | Password hashing                       | Pass                    | Better Auth scrypt + bcrypt verify for `$2a$`/`$2b$`                                                   |
 | 3   | OTP expiration                         | Pass                    | `OTP_EXPIRES_IN = 300` — `auth.security.controls.test.ts`                                              |
 | 4   | OTP invalidate after use               | Pass                    | Better Auth phone/email OTP delete-on-success                                                          |
@@ -50,7 +54,7 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 | 12  | Session fixation                       | Pass                    | Fresh session on sign-in; logout deletes server session                                                |
 | 13  | Session hijacking mitigations          | Pass                    | Cookie flags + AUTH-002 Fixed (no cookie-cache auth window on APIs)                                    |
 | 14  | Logout invalidates session             | Pass                    | DB delete + `disableCookieCache` on sensitive `getSession`                                             |
-| 15  | Password change invalidates sessions   | Partial                 | Reset revokes all; direct `changePassword` — AUTH-005                                                  |
+| 15  | Password change invalidates sessions   | Pass                    | Reset revokes all; `/change-password` forced revoke — AUTH-005 Fixed                                   |
 | 16  | Cookies HttpOnly / Secure / SameSite   | Pass                    | Better Auth defaults                                                                                   |
 | 17  | OAuth redirect abuse                   | Pass                    | `trustedOrigins` + `sanitizeRedirectPath` tests                                                        |
 | 18  | Account linking takeover               | Pass (caveats)          | BA local email verify for link; `allowDifferentEmails: true` for logged-in link                        |
@@ -153,9 +157,9 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 - **Severity:** Low
 
-- **Status:** Open
+- **Status:** Fixed
 
-- **Affected Component:** `define-config.ts`; signup/reset forms
+- **Affected Component:** `define-config.ts`; `plugins/password-policy.ts`; signup/reset forms
 
 - **Description:** Length-only policy; weak passwords accepted server-side.
 
@@ -165,9 +169,9 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 - **Impact:** Higher success rate for slow/distributed password guessing.
 
-- **Recommendation:** Add complexity or HIBP/zxcvbn blocklist; optionally raise minimum length.
+- **Recommendation / Fix:** Raised `minPasswordLength` to 10; added `passwordPolicy` plugin requiring letter + digit on sign-up / change-password / reset-password; UI validators aligned.
 
-- **Retest Result:** N/A
+- **Retest Result:** Pass — `password-policy.test.ts`, `auth.security.controls.test.ts`
 
 ---
 
@@ -206,11 +210,11 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 - **Severity:** Low
 
-- **Status:** Open
+- **Status:** Fixed
 
-- **Affected Component:** Better Auth change-password API; profile UI uses `requestPasswordReset` (which does revoke)
+- **Affected Component:** `plugins/force-change-password-revoke.ts`; Better Auth change-password API
 
-- **Description:** Reset path revokes sessions. Direct change-password is opt-in for revoke. Stock UI uses reset.
+- **Description:** Reset path revokes sessions. Direct change-password was opt-in for revoke.
 
 - **Attack Scenario:** Custom client calls `changePassword` without revoke flag; other device sessions remain.
 
@@ -218,9 +222,9 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 
 - **Impact:** Latent footgun; low exploitability via stock UI.
 
-- **Recommendation:** Force `revokeOtherSessions` in a hook/wrapper for any change-password client.
+- **Recommendation / Fix:** `forceChangePasswordRevoke` before-hook always injects `revokeOtherSessions: true`.
 
-- **Retest Result:** N/A
+- **Retest Result:** Pass — `force-change-password-revoke.test.ts`
 
 ---
 
@@ -260,13 +264,13 @@ Aico authentication is built on **Better Auth** (`src/libs/better-auth/define-co
 | Critical | 0     | —                                                      |
 | High     | 0     | —                                                      |
 | Medium   | 3     | AUTH-001 Fixed; AUTH-002 Fixed; AUTH-004 Accepted Risk |
-| Low      | 2     | AUTH-003 Open; AUTH-005 Open                           |
+| Low      | 2     | AUTH-003 Fixed; AUTH-005 Fixed                         |
 
-| Status        | Findings           |
-| ------------- | ------------------ |
-| Fixed         | AUTH-001, AUTH-002 |
-| Accepted Risk | AUTH-004           |
-| Open          | AUTH-003, AUTH-005 |
+| Status        | Findings                                                 |
+| ------------- | -------------------------------------------------------- |
+| Fixed         | AUTH-001, AUTH-002, AUTH-003, AUTH-005, MON-001, MON-005 |
+| Accepted Risk | AUTH-004                                                 |
+| Open          | — (auth scope); MON-002/003 monitoring                   |
 
 ---
 

--- a/src/app/(backend)/api/auth/check-user/rateLimit.test.ts
+++ b/src/app/(backend)/api/auth/check-user/rateLimit.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { consumeCheckUserRateLimit, resetCheckUserRateLimitForTests } from './rateLimit';
+
+describe('consumeCheckUserRateLimit (AUTH-001)', () => {
+  beforeEach(() => {
+    resetCheckUserRateLimitForTests();
+  });
+
+  it('allows requests under the max within the window', () => {
+    for (let i = 0; i < 10; i += 1) {
+      expect(consumeCheckUserRateLimit('ip-a', { max: 10, windowMs: 60_000 })).toBe(true);
+    }
+  });
+
+  it('blocks the request once the max is exceeded', () => {
+    for (let i = 0; i < 10; i += 1) {
+      consumeCheckUserRateLimit('ip-b', { max: 10, windowMs: 60_000 });
+    }
+    expect(consumeCheckUserRateLimit('ip-b', { max: 10, windowMs: 60_000 })).toBe(false);
+  });
+
+  it('isolates counters per client key', () => {
+    for (let i = 0; i < 10; i += 1) {
+      consumeCheckUserRateLimit('ip-c', { max: 10, windowMs: 60_000 });
+    }
+    expect(consumeCheckUserRateLimit('ip-d', { max: 10, windowMs: 60_000 })).toBe(true);
+  });
+});

--- a/src/app/(backend)/api/auth/check-user/rateLimit.ts
+++ b/src/app/(backend)/api/auth/check-user/rateLimit.ts
@@ -1,0 +1,39 @@
+/**
+ * In-process sliding-window limiter for the public check-user oracle (AUTH-001).
+ * Not a substitute for edge/WAF limits, but stops unbounded enumeration on a single node.
+ */
+
+export type CheckUserRateLimitOptions = {
+  max: number;
+  windowMs: number;
+};
+
+const DEFAULT_OPTIONS: CheckUserRateLimitOptions = {
+  max: 10,
+  windowMs: 60_000,
+};
+
+const hitsByKey = new Map<string, number[]>();
+
+export const consumeCheckUserRateLimit = (
+  key: string,
+  options: CheckUserRateLimitOptions = DEFAULT_OPTIONS,
+): boolean => {
+  const now = Date.now();
+  const windowStart = now - options.windowMs;
+  const recent = (hitsByKey.get(key) ?? []).filter((ts) => ts > windowStart);
+
+  if (recent.length >= options.max) {
+    hitsByKey.set(key, recent);
+    return false;
+  }
+
+  recent.push(now);
+  hitsByKey.set(key, recent);
+  return true;
+};
+
+/** Test-only helper — clears the in-memory window. */
+export const resetCheckUserRateLimitForTests = () => {
+  hitsByKey.clear();
+};

--- a/src/app/(backend)/api/auth/check-user/route.test.ts
+++ b/src/app/(backend)/api/auth/check-user/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { consumeCheckUserRateLimit } from './rateLimit';
+import { POST } from './route';
+
+const { mockLimit, mockSelect, mockFrom, mockWhere } = vi.hoisted(() => {
+  const mockLimit = vi.fn();
+  const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+  const mockFrom = vi.fn(() => ({ where: mockWhere }));
+  const mockSelect = vi.fn(() => ({ from: mockFrom }));
+  return { mockFrom, mockLimit, mockSelect, mockWhere };
+});
+
+vi.mock('@/database/server', () => ({
+  serverDB: {
+    select: mockSelect,
+  },
+}));
+
+vi.mock('@/database/schemas/user', () => ({
+  users: { email: 'email', id: 'id' },
+}));
+
+vi.mock('./rateLimit', () => ({
+  consumeCheckUserRateLimit: vi.fn(() => true),
+}));
+
+describe('POST /api/auth/check-user (AUTH-001)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(consumeCheckUserRateLimit).mockReturnValue(true);
+  });
+
+  const post = (body: unknown, headers?: HeadersInit) =>
+    POST(
+      new Request('https://example.com/api/auth/check-user', {
+        body: JSON.stringify(body),
+        headers: { 'content-type': 'application/json', ...headers },
+        method: 'POST',
+      }) as never,
+    );
+
+  it('returns exists without hasPassword when the user is found', async () => {
+    mockLimit.mockResolvedValueOnce([{ id: 'user-1' }]);
+
+    const res = await post({ email: 'User@Example.com' });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ exists: true });
+    expect(json).not.toHaveProperty('hasPassword');
+  });
+
+  it('returns exists:false without hasPassword when the user is missing', async () => {
+    mockLimit.mockResolvedValueOnce([]);
+
+    const res = await post({ email: 'missing@example.com' });
+    const json = await res.json();
+
+    expect(json).toEqual({ exists: false });
+    expect(json).not.toHaveProperty('hasPassword');
+  });
+
+  it('returns 429 when the rate limit is exceeded', async () => {
+    vi.mocked(consumeCheckUserRateLimit).mockReturnValueOnce(false);
+
+    const res = await post({ email: 'user@example.com' }, { 'x-forwarded-for': '203.0.113.10' });
+    const json = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(json.exists).toBe(false);
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits using the first x-forwarded-for hop', async () => {
+    mockLimit.mockResolvedValueOnce([]);
+
+    await post({ email: 'a@example.com' }, { 'x-forwarded-for': '198.51.100.1, 10.0.0.1' });
+
+    expect(consumeCheckUserRateLimit).toHaveBeenCalledWith('198.51.100.1');
+  });
+});

--- a/src/app/(backend)/api/auth/check-user/route.ts
+++ b/src/app/(backend)/api/auth/check-user/route.ts
@@ -1,23 +1,40 @@
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { type NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { account } from '@/database/schemas/betterAuth';
 import { users } from '@/database/schemas/user';
 import { serverDB } from '@/database/server';
 
+import { consumeCheckUserRateLimit } from './rateLimit';
+
 export interface CheckUserResponseData {
   exists: boolean;
-  hasPassword?: boolean;
 }
 
+const clientKeyFromRequest = (req: NextRequest): string => {
+  const forwarded = req.headers.get('x-forwarded-for');
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return req.headers.get('x-real-ip')?.trim() || 'anonymous';
+};
+
 /**
- * Check if a user exists by email
- * @param req - POST request with { email: string }
- * @returns { exists: boolean, emailVerified?: boolean }
+ * Check if a user exists by email.
+ *
+ * AUTH-001: Do not disclose `hasPassword` / auth methods. Rate-limit by client IP.
  */
 export async function POST(req: NextRequest) {
   try {
+    const clientKey = clientKeyFromRequest(req);
+    if (!consumeCheckUserRateLimit(clientKey)) {
+      return NextResponse.json(
+        { error: 'Too many requests', exists: false },
+        { status: 429, headers: { 'Retry-After': '60' } },
+      );
+    }
+
     const body = await req.json();
     const { email } = body;
 
@@ -25,10 +42,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Email is required', exists: false }, { status: 400 });
     }
 
-    // Query database for user with this email
     const [user] = await serverDB
       .select({
-        emailVerified: users.emailVerified,
         id: users.id,
       })
       .from(users)
@@ -36,25 +51,11 @@ export async function POST(req: NextRequest) {
       .limit(1);
 
     if (!user) {
-      return NextResponse.json({ exists: false });
+      return NextResponse.json({ exists: false } satisfies CheckUserResponseData);
     }
 
-    const accounts = await serverDB
-      .select({
-        password: account.password,
-        providerId: account.providerId,
-      })
-      .from(account)
-      .where(and(eq(account.userId, user.id)));
-    const hasPassword = accounts.some(
-      (a) =>
-        a.providerId === 'credential' && typeof a.password === 'string' && a.password.length > 0,
-    );
-
-    return NextResponse.json({
-      exists: true,
-      hasPassword,
-    } satisfies CheckUserResponseData);
+    // Intentionally omit hasPassword / emailVerified — auth-method oracle (AUTH-001).
+    return NextResponse.json({ exists: true } satisfies CheckUserResponseData);
   } catch (error) {
     console.error('Error checking user existence:', error);
     return NextResponse.json({ error: 'Internal server error', exists: false }, { status: 500 });

--- a/src/app/(backend)/middleware/auth/index.test.ts
+++ b/src/app/(backend)/middleware/auth/index.test.ts
@@ -121,8 +121,14 @@ describe('checkAuth', () => {
   });
 
   it('should return error response when no session is available', async () => {
+    const { auth } = await import('@/auth');
+
     await checkAuth(mockHandler)(mockRequest, mockOptions);
 
+    expect(auth.api.getSession).toHaveBeenCalledWith({
+      headers: mockRequest.headers,
+      query: { disableCookieCache: true },
+    });
     expect(AgentRuntimeError.createError).toHaveBeenCalledWith(ChatErrorType.Unauthorized);
     expect(createErrorResponse).toHaveBeenCalledWith(ChatErrorType.Unauthorized, {
       error: { errorType: ChatErrorType.Unauthorized },

--- a/src/app/(backend)/middleware/auth/index.ts
+++ b/src/app/(backend)/middleware/auth/index.ts
@@ -46,8 +46,7 @@ const getOIDCClientDebugInfo = (token?: string | null): OIDCClientDebugInfo => {
   try {
     const normalizedPayload = payload.replaceAll('-', '+').replaceAll('_', '/');
     const decodedPayload = JSON.parse(Buffer.from(normalizedPayload, 'base64').toString('utf8')) as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     const clientId =
       typeof decodedPayload?.client_id === 'string' ? decodedPayload.client_id : undefined;
@@ -92,8 +91,10 @@ export const checkAuth =
         await assertOIDCUserActive(serverDB, userId);
       } else {
         // Better Auth session authentication (web)
+        // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
         const session = await auth.api.getSession({
           headers: req.headers,
+          query: { disableCookieCache: true },
         });
 
         if (!session?.user?.id) {

--- a/src/features/Auth/ResetPassword/ResetPasswordContent.tsx
+++ b/src/features/Auth/ResetPassword/ResetPasswordContent.tsx
@@ -40,8 +40,17 @@ export const ResetPasswordContent = ({
         name="newPassword"
         rules={[
           { message: t('betterAuth.errors.passwordRequired'), required: true },
-          { message: t('betterAuth.errors.passwordMinLength'), min: 8 },
+          { message: t('betterAuth.errors.passwordMinLength'), min: 10 },
           { max: 64, message: t('betterAuth.errors.passwordMaxLength') },
+          {
+            message: t('betterAuth.errors.passwordFormat'),
+            validator: (_, value) => {
+              if (!value) return Promise.resolve();
+              const hasLetter = /[a-z]/i.test(value);
+              const hasNumber = /\d/.test(value);
+              return hasLetter && hasNumber ? Promise.resolve() : Promise.reject();
+            },
+          },
         ]}
       >
         <InputPassword

--- a/src/features/Auth/SignIn/useSignIn.test.ts
+++ b/src/features/Auth/SignIn/useSignIn.test.ts
@@ -176,7 +176,7 @@ describe('useSignIn', () => {
 
     it('should go to password step when user exists with password', async () => {
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -199,7 +199,7 @@ describe('useSignIn', () => {
         })
         // Second call: check-user
         .mockResolvedValueOnce({
-          json: async () => ({ exists: true, hasPassword: true }),
+          json: async () => ({ exists: true }),
           ok: true,
         });
 
@@ -250,7 +250,7 @@ describe('useSignIn', () => {
       });
 
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -286,7 +286,7 @@ describe('useSignIn', () => {
           return { error: null };
         });
         mockFetch.mockResolvedValueOnce({
-          json: async () => ({ exists: true, hasPassword: true }),
+          json: async () => ({ exists: true }),
           ok: true,
         });
 
@@ -310,7 +310,7 @@ describe('useSignIn', () => {
       });
 
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -338,7 +338,7 @@ describe('useSignIn', () => {
       });
 
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -458,7 +458,7 @@ describe('useSignIn', () => {
   describe('handleBackToEmail', () => {
     it('should reset to email step', async () => {
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -488,7 +488,7 @@ describe('useSignIn', () => {
       mockRequestPasswordReset.mockResolvedValue(undefined);
 
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -528,7 +528,7 @@ describe('useSignIn', () => {
       mockRequestPasswordReset.mockRejectedValue(new Error('fail'));
 
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -548,11 +548,11 @@ describe('useSignIn', () => {
   });
 
   describe('magic link', () => {
-    it('should land on email-sent state when a passwordless user triggers magic link', async () => {
+    it('does not auto-send magic link from check-user (AUTH-001: no auth-method oracle)', async () => {
       mockEnableMagicLink = true;
       mockSignInMagicLink.mockResolvedValue({ error: null });
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: false }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -562,11 +562,9 @@ describe('useSignIn', () => {
         await result.current.handleCheckUser({ email: 'user@example.com' });
       });
 
-      expect(mockSignInMagicLink).toHaveBeenCalledTimes(1);
-      expect(result.current.step).toBe('emailSent');
-      expect(result.current.sentInfo).toEqual(
-        expect.objectContaining({ email: 'user@example.com', type: 'magicLink' }),
-      );
+      expect(mockSignInMagicLink).not.toHaveBeenCalled();
+      expect(result.current.step).toBe('password');
+      expect(result.current.isSocialOnly).toBe(false);
     });
   });
 
@@ -574,7 +572,7 @@ describe('useSignIn', () => {
     it('should resend the password reset email and confirm', async () => {
       mockRequestPasswordReset.mockResolvedValue(undefined);
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 
@@ -603,7 +601,7 @@ describe('useSignIn', () => {
     it('should return to the email entry (not the password step) after a reset email', async () => {
       mockRequestPasswordReset.mockResolvedValue(undefined);
       mockFetch.mockResolvedValueOnce({
-        json: async () => ({ exists: true, hasPassword: true }),
+        json: async () => ({ exists: true }),
         ok: true,
       });
 

--- a/src/features/Auth/SignIn/useSignIn.ts
+++ b/src/features/Auth/SignIn/useSignIn.ts
@@ -80,7 +80,6 @@ export const useSignIn = () => {
   const { t } = useTranslation('auth');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const enableMagicLink = useAuthServerConfigStore((s) => s.serverConfig.enableMagicLink || false);
   const disableEmailPassword = useAuthServerConfigStore(
     (s) => s.serverConfig.disableEmailPassword || false,
   );
@@ -223,18 +222,11 @@ export const useSignIn = () => {
       }
 
       setEmail(targetEmail);
-      if (data.hasPassword) {
-        setStep('password');
-        return;
-      }
-
-      if (enableMagicLink) {
-        await handleSendMagicLink(targetEmail);
-        return;
-      }
-
-      // User has no password and magic link is disabled, they can only sign in via social
-      setIsSocialOnly(true);
+      // AUTH-001: check-user no longer returns hasPassword. Always offer the password
+      // step for existing accounts; social SSO remains on the email step (back).
+      // Magic-link auto-branch removed — it required an auth-method oracle.
+      setStep('password');
+      setIsSocialOnly(false);
     } catch (error) {
       console.error('Error checking user:', error);
       toast.error(t('betterAuth.signin.error'));

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
@@ -159,7 +159,7 @@ const BetterAuthSignUpForm = () => {
           name="password"
           rules={[
             { message: t('betterAuth.errors.passwordRequired'), required: true },
-            { message: t('betterAuth.errors.passwordMinLength'), min: 8 },
+            { message: t('betterAuth.errors.passwordMinLength'), min: 10 },
             { max: 64, message: t('betterAuth.errors.passwordMaxLength') },
             {
               message: t('betterAuth.errors.passwordFormat'),

--- a/src/libs/better-auth/auth.security.controls.test.ts
+++ b/src/libs/better-auth/auth.security.controls.test.ts
@@ -94,6 +94,15 @@ vi.mock('@/libs/better-auth/plugins/email-whitelist', () => ({
   emailWhitelist: vi.fn(() => ({ id: 'email-whitelist' })),
 }));
 
+vi.mock('@/libs/better-auth/plugins/force-change-password-revoke', () => ({
+  forceChangePasswordRevoke: vi.fn(() => ({ id: 'aico-force-change-password-revoke' })),
+}));
+
+vi.mock('@/libs/better-auth/plugins/password-policy', () => ({
+  PASSWORD_MIN_LENGTH: 10,
+  passwordPolicy: vi.fn(() => ({ id: 'aico-password-policy' })),
+}));
+
 vi.mock('@/libs/better-auth/plugins/phone-login-gate', () => ({
   phoneLoginGate: vi.fn(() => ({ id: 'phone-login-gate' })),
 }));
@@ -153,9 +162,13 @@ describe('AICO-102 authentication security controls', () => {
       expect.objectContaining({
         emailAndPassword: expect.objectContaining({
           maxPasswordLength: 64,
-          minPasswordLength: 8,
+          minPasswordLength: 10,
           revokeSessionsOnPasswordReset: true,
         }),
+        plugins: expect.arrayContaining([
+          expect.objectContaining({ id: 'aico-password-policy' }),
+          expect.objectContaining({ id: 'aico-force-change-password-revoke' }),
+        ]),
         rateLimit: expect.objectContaining({
           customRules: expect.objectContaining({
             '/phone-number/send-otp': { max: 3, window: 60 },

--- a/src/libs/better-auth/auth.security.controls.test.ts
+++ b/src/libs/better-auth/auth.security.controls.test.ts
@@ -1,0 +1,197 @@
+/**
+ * AICO-102 practical security-control tests (defensive — no exploit payloads).
+ * Phone login gate: see phone-login-gate.test.ts. Open redirect: onboardingRedirect.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isSafeRedirectPath, sanitizeRedirectPath } from '@/utils/onboardingRedirect';
+
+const mocks = vi.hoisted(() => ({
+  betterAuth: vi.fn((options) => options),
+  clearMismatchedOIDCSession: vi.fn(),
+  EnvHttpProxyAgent: vi.fn((options) => ({ options })),
+  serverDB: {},
+  setGlobalDispatcher: vi.fn(),
+}));
+
+vi.mock('@better-auth/expo', () => ({
+  expo: vi.fn(() => ({ id: 'expo' })),
+}));
+
+vi.mock('@better-auth/passkey', () => ({
+  passkey: vi.fn(() => ({ id: 'passkey' })),
+}));
+
+vi.mock('@lobechat/database', () => ({
+  createNanoId: vi.fn(() => vi.fn(() => 'generated-id')),
+  idGenerator: vi.fn(() => 'generated-user-id'),
+  serverDB: mocks.serverDB,
+}));
+
+vi.mock('@lobechat/database/schemas', () => ({}));
+
+vi.mock('bcryptjs', () => ({
+  default: { compare: vi.fn() },
+}));
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: vi.fn(() => ({ id: 'drizzle-adapter' })),
+}));
+
+vi.mock('better-auth/crypto', () => ({
+  verifyPassword: vi.fn(),
+}));
+
+vi.mock('better-auth/minimal', () => ({
+  betterAuth: mocks.betterAuth,
+}));
+
+vi.mock('better-auth/plugins', () => ({
+  admin: vi.fn(() => ({ id: 'admin' })),
+  emailOTP: vi.fn((opts) => ({ id: 'email-otp', options: opts })),
+  genericOAuth: vi.fn(() => ({ id: 'generic-oauth' })),
+  magicLink: vi.fn(() => ({ id: 'magic-link' })),
+  phoneNumber: vi.fn((opts) => ({ id: 'phone-number', options: opts })),
+}));
+
+vi.mock('undici', () => ({
+  EnvHttpProxyAgent: mocks.EnvHttpProxyAgent,
+  setGlobalDispatcher: mocks.setGlobalDispatcher,
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: { APP_URL: 'https://example.com' },
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    AUTH_DISABLE_EMAIL_PASSWORD: false,
+    AUTH_EMAIL_VERIFICATION: false,
+    AUTH_ENABLE_MAGIC_LINK: false,
+    AUTH_SECRET: 'test-secret',
+    AUTH_SSO_PROVIDERS: '',
+  },
+}));
+
+vi.mock('@/libs/better-auth/email-templates', () => ({
+  getChangeEmailVerificationTemplate: vi.fn(() => ({})),
+  getMagicLinkEmailTemplate: vi.fn(() => ({})),
+  getResetPasswordEmailTemplate: vi.fn(() => ({})),
+  getVerificationEmailTemplate: vi.fn(() => ({})),
+  getVerificationOTPEmailTemplate: vi.fn(() => ({})),
+}));
+
+vi.mock('@/libs/better-auth/phone', () => ({
+  isValidIranianPhoneNumber: vi.fn(() => true),
+  normalizeIranianPhoneNumber: vi.fn((v: string) => v),
+}));
+
+vi.mock('@/libs/better-auth/plugins/aico-ban-message', () => ({
+  aicoBanMessage: vi.fn(() => ({ id: 'aico-ban-message' })),
+}));
+
+vi.mock('@/libs/better-auth/plugins/email-whitelist', () => ({
+  emailWhitelist: vi.fn(() => ({ id: 'email-whitelist' })),
+}));
+
+vi.mock('@/libs/better-auth/plugins/phone-login-gate', () => ({
+  phoneLoginGate: vi.fn(() => ({ id: 'phone-login-gate' })),
+}));
+
+vi.mock('@/libs/better-auth/sso', () => ({
+  initBetterAuthSSOProviders: vi.fn(() => ({
+    genericOAuthProviders: [],
+    socialProviders: {},
+  })),
+}));
+
+vi.mock('@/libs/better-auth/utils/config', () => ({
+  createSecondaryStorage: vi.fn(),
+  getTrustedOrigins: vi.fn(() => ['https://example.com']),
+}));
+
+vi.mock('@/libs/better-auth/utils/server', () => ({
+  parseSSOProviders: vi.fn(() => []),
+}));
+
+vi.mock('@/libs/oidc-provider/session-cleanup', () => ({
+  clearMismatchedOIDCSession: mocks.clearMismatchedOIDCSession,
+}));
+
+vi.mock('@/server/services/email', () => ({
+  EmailService: vi.fn().mockImplementation(() => ({ sendMail: vi.fn() })),
+}));
+
+vi.mock('@/server/services/sms', () => ({
+  SmsService: vi.fn().mockImplementation(() => ({ sendOtp: vi.fn() })),
+}));
+
+vi.mock('@/server/services/user', () => ({
+  UserService: vi.fn().mockImplementation(() => ({ initUser: vi.fn() })),
+}));
+
+describe('AICO-102 authentication security controls', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.betterAuth.mockClear();
+    process.env = { ...originalEnv, NODE_ENV: 'test' };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('configures OTP expiry, attempts, password reset revoke, and auth rate limits', async () => {
+    const { defineConfig } = await import('./define-config');
+    const { emailOTP, phoneNumber } = await import('better-auth/plugins');
+
+    defineConfig({ plugins: [] });
+
+    expect(mocks.betterAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailAndPassword: expect.objectContaining({
+          maxPasswordLength: 64,
+          minPasswordLength: 8,
+          revokeSessionsOnPasswordReset: true,
+        }),
+        rateLimit: expect.objectContaining({
+          customRules: expect.objectContaining({
+            '/phone-number/send-otp': { max: 3, window: 60 },
+            '/phone-number/verify': { max: 10, window: 60 },
+            '/request-password-reset': { max: 3, window: 60 },
+          }),
+        }),
+        session: expect.objectContaining({
+          cookieCache: expect.objectContaining({
+            enabled: true,
+            maxAge: 120,
+          }),
+        }),
+      }),
+    );
+
+    expect(emailOTP).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedAttempts: 3,
+        expiresIn: 300,
+        otpLength: 6,
+      }),
+    );
+    expect(phoneNumber).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedAttempts: 3,
+        expiresIn: 300,
+        otpLength: 6,
+      }),
+    );
+  });
+
+  it('blocks open redirects used in OAuth / auth callback paths', () => {
+    expect(isSafeRedirectPath('https://evil.com')).toBe(false);
+    expect(isSafeRedirectPath('//evil.com')).toBe(false);
+    expect(sanitizeRedirectPath('https://evil.com', '/')).toBe('/');
+    expect(sanitizeRedirectPath('/chat', '/')).toBe('/chat');
+  });
+});

--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -83,6 +83,15 @@ vi.mock('@/libs/better-auth/plugins/email-whitelist', () => ({
   emailWhitelist: vi.fn(() => ({ id: 'email-whitelist' })),
 }));
 
+vi.mock('@/libs/better-auth/plugins/force-change-password-revoke', () => ({
+  forceChangePasswordRevoke: vi.fn(() => ({ id: 'aico-force-change-password-revoke' })),
+}));
+
+vi.mock('@/libs/better-auth/plugins/password-policy', () => ({
+  PASSWORD_MIN_LENGTH: 10,
+  passwordPolicy: vi.fn(() => ({ id: 'aico-password-policy' })),
+}));
+
 vi.mock('@/libs/better-auth/plugins/phone-login-gate', () => ({
   phoneLoginGate: vi.fn(() => ({ id: 'phone-login-gate' })),
 }));

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -23,6 +23,8 @@ import {
 import { isValidIranianPhoneNumber, normalizeIranianPhoneNumber } from '@/libs/better-auth/phone';
 import { aicoBanMessage } from '@/libs/better-auth/plugins/aico-ban-message';
 import { emailWhitelist } from '@/libs/better-auth/plugins/email-whitelist';
+import { forceChangePasswordRevoke } from '@/libs/better-auth/plugins/force-change-password-revoke';
+import { PASSWORD_MIN_LENGTH, passwordPolicy } from '@/libs/better-auth/plugins/password-policy';
 import { phoneLoginGate } from '@/libs/better-auth/plugins/phone-login-gate';
 import { initBetterAuthSSOProviders } from '@/libs/better-auth/sso';
 import { createSecondaryStorage, getTrustedOrigins } from '@/libs/better-auth/utils/config';
@@ -129,7 +131,7 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       disableSignUp: authEnv.AUTH_DISABLE_EMAIL_PASSWORD,
       enabled: !authEnv.AUTH_DISABLE_EMAIL_PASSWORD,
       maxPasswordLength: 64,
-      minPasswordLength: 8,
+      minPasswordLength: PASSWORD_MIN_LENGTH,
       requireEmailVerification: authEnv.AUTH_EMAIL_VERIFICATION,
       revokeSessionsOnPasswordReset: true,
 
@@ -303,6 +305,8 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       ...customOptions.plugins,
       emailWhitelist(),
       phoneLoginGate(),
+      passwordPolicy(),
+      forceChangePasswordRevoke(),
       expo(),
       aicoBanMessage(),
       admin({
@@ -356,7 +360,9 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
           try {
             await smsService.sendOtp(phone, code);
           } catch (error) {
-            console.error('[sms] failed to send OTP', { phone, error });
+            // Redact phone PII for log aggregators (MON-005) — keep last 4 digits only
+            const phoneFingerprint = phone.length > 4 ? `***${phone.slice(-4)}` : '***';
+            console.error('[sms] failed to send OTP', { phone: phoneFingerprint, error });
             throw error;
           }
         },

--- a/src/libs/better-auth/plugins/force-change-password-revoke.test.ts
+++ b/src/libs/better-auth/plugins/force-change-password-revoke.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('better-auth/api', () => ({
+  createAuthMiddleware: (handler: (ctx: unknown) => unknown) => handler,
+}));
+
+describe('forceChangePasswordRevoke', () => {
+  it('forces revokeOtherSessions on /change-password', async () => {
+    const { forceChangePasswordRevoke } = await import('./force-change-password-revoke');
+    const plugin = forceChangePasswordRevoke();
+    const hook = plugin.hooks?.before?.[0];
+    expect(hook?.matcher({ path: '/change-password' } as never)).toBe(true);
+    expect(hook?.matcher({ path: '/sign-up/email' } as never)).toBe(false);
+
+    const result = await (hook!.handler as (ctx: unknown) => Promise<unknown>)({
+      body: { currentPassword: 'old', newPassword: 'Password123!', revokeOtherSessions: false },
+      path: '/change-password',
+    });
+
+    expect(result).toEqual({
+      context: {
+        body: {
+          currentPassword: 'old',
+          newPassword: 'Password123!',
+          revokeOtherSessions: true,
+        },
+      },
+    });
+  });
+});

--- a/src/libs/better-auth/plugins/force-change-password-revoke.ts
+++ b/src/libs/better-auth/plugins/force-change-password-revoke.ts
@@ -1,0 +1,27 @@
+import { createAuthMiddleware } from 'better-auth/api';
+import { type BetterAuthPlugin } from 'better-auth/types';
+
+/**
+ * Force `revokeOtherSessions` on `/change-password` so custom clients cannot
+ * leave sibling sessions alive after a password change (AUTH-005).
+ */
+export const forceChangePasswordRevoke = (): BetterAuthPlugin => ({
+  id: 'aico-force-change-password-revoke',
+  hooks: {
+    before: [
+      {
+        matcher: (ctx) => ctx.path === '/change-password',
+        handler: createAuthMiddleware(async (ctx) => {
+          return {
+            context: {
+              body: {
+                ...(ctx.body as Record<string, unknown>),
+                revokeOtherSessions: true,
+              },
+            },
+          };
+        }),
+      },
+    ],
+  },
+});

--- a/src/libs/better-auth/plugins/password-policy.test.ts
+++ b/src/libs/better-auth/plugins/password-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { meetsPasswordComplexity, PASSWORD_MIN_LENGTH } from './password-policy';
+
+describe('meetsPasswordComplexity', () => {
+  it('exports the server min length used by Better Auth config', () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(10);
+  });
+
+  it('requires at least one letter and one digit', () => {
+    expect(meetsPasswordComplexity('abcdefghij')).toBe(false);
+    expect(meetsPasswordComplexity('1234567890')).toBe(false);
+    expect(meetsPasswordComplexity('Password1')).toBe(true);
+    expect(meetsPasswordComplexity('Password123!')).toBe(true);
+  });
+});

--- a/src/libs/better-auth/plugins/password-policy.ts
+++ b/src/libs/better-auth/plugins/password-policy.ts
@@ -1,0 +1,43 @@
+import { APIError, createAuthMiddleware } from 'better-auth/api';
+import { type BetterAuthPlugin } from 'better-auth/types';
+
+/** Server-enforced minimum (AUTH-003); keep in sync with signup/reset UI. */
+export const PASSWORD_MIN_LENGTH = 10;
+
+const PASSWORD_PATHS = new Set(['/sign-up/email', '/change-password', '/reset-password']);
+
+export const meetsPasswordComplexity = (password: string): boolean =>
+  /[A-Z]/i.test(password) && /\d/.test(password);
+
+const passwordFromBody = (body: Record<string, unknown> | undefined): string | null => {
+  if (!body) return null;
+  if (typeof body.password === 'string') return body.password;
+  if (typeof body.newPassword === 'string') return body.newPassword;
+  return null;
+};
+
+/**
+ * Better Auth plugin: require letter + digit on password-setting paths (AUTH-003).
+ * Length is still enforced via `emailAndPassword.minPasswordLength`.
+ */
+export const passwordPolicy = (): BetterAuthPlugin => ({
+  id: 'aico-password-policy',
+  hooks: {
+    before: [
+      {
+        matcher: (ctx) => PASSWORD_PATHS.has(ctx.path),
+        handler: createAuthMiddleware(async (ctx) => {
+          const password = passwordFromBody(ctx.body as Record<string, unknown> | undefined);
+          if (password === null) return;
+
+          if (!meetsPasswordComplexity(password)) {
+            throw new APIError('BAD_REQUEST', {
+              code: 'PASSWORD_TOO_WEAK',
+              message: 'PASSWORD_TOO_WEAK',
+            });
+          }
+        }),
+      },
+    ],
+  },
+});

--- a/src/libs/next/proxy/define-config.test.ts
+++ b/src/libs/next/proxy/define-config.test.ts
@@ -4,6 +4,8 @@
 import { NextRequest } from 'next/server';
 import { describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_LANG } from '@/utils/server/routeVariants';
+
 import { defineConfig } from './define-config';
 
 vi.mock('@/auth', () => ({
@@ -28,18 +30,18 @@ describe('defineConfig locale path-traversal hardening', () => {
     expect(new URL(rewrite!).pathname).toBe('/spa-auth/ja-JP/signin');
   });
 
-  it('falls back to en-US for a traversal locale (plain)', async () => {
+  it('falls back to DEFAULT_LANG for a traversal locale (plain)', async () => {
     const rewrite = await run('http://localhost:3010/signin?hl=../../api/dev/x');
     const { pathname } = new URL(rewrite!);
     expect(pathname.startsWith('/spa-auth/')).toBe(true);
-    expect(pathname).toBe('/spa-auth/en-US/signin');
+    expect(pathname).toBe(`/spa-auth/${DEFAULT_LANG}/signin`);
   });
 
-  it('falls back to en-US for a traversal locale (percent-encoded)', async () => {
+  it('falls back to DEFAULT_LANG for a traversal locale (percent-encoded)', async () => {
     const rewrite = await run('http://localhost:3010/signin?hl=..%2F..%2Fapi%2Fdev%2Fx');
     const { pathname } = new URL(rewrite!);
     expect(pathname.startsWith('/spa-auth/')).toBe(true);
-    expect(pathname).toBe('/spa-auth/en-US/signin');
+    expect(pathname).toBe(`/spa-auth/${DEFAULT_LANG}/signin`);
   });
 
   it('does not treat workspace slugs beginning with an auth route as auth SPA pages', async () => {

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -265,8 +265,10 @@ export function defineConfig() {
     if (!isProtected) return response;
 
     // Get full session with user data (Next.js 15.2.0+ feature)
+    // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
     const session = await auth.api.getSession({
       headers: req.headers,
+      query: { disableCookieCache: true },
     });
 
     const isLoggedIn = !!session?.user;

--- a/src/libs/trusted-client/getSessionUser.ts
+++ b/src/libs/trusted-client/getSessionUser.ts
@@ -12,8 +12,10 @@ export const getSessionUser = async (): Promise<TrustedClientUserInfo | undefine
     // Dynamic import to avoid validator ESM/CJS issue during sitemap generation
     const { auth } = await import('@/auth');
     const headersList = await headers();
+    // AUTH-002: skip cookie cache so logout / password-reset revoke is honored immediately
     const session = await auth.api.getSession({
       headers: headersList,
+      query: { disableCookieCache: true },
     });
 
     if (!session?.user?.id || !session?.user?.email) {


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| `/api/auth/check-user` returned `hasPassword` without rate limit; cookie cache could authorize ~2m after session revoke; length-only password policy; change-password did not force session revoke; debug SMS could log OTPs to stdout | check-user oracle hardened + rate-limited; sensitive `getSession` uses `disableCookieCache`; min password 10 + letter/digit server policy; change-password always revokes other sessions; OTP/debug SMS logging hardened |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test` on the auth/SMS/password-policy slice (15 related tests passed).

#### 🔗 Related Issue

Fixes #199

Plane: [AICO-102](https://plane.panafor.com/panaforai/browse/AICO-102/)

#### Description of Change

Phase 1 auth/session security audit closeout:

- **AUTH-001** — drop `hasPassword`, rate-limit `check-user`
- **AUTH-002** — `disableCookieCache: true` on sensitive server `getSession` paths
- **AUTH-003** — `minPasswordLength: 10` + server letter/digit policy plugin
- **AUTH-005** — force `revokeOtherSessions` on `/change-password`
- **AUTH-004** — Accepted Risk (email verification off by default; phone remains spend/org trust anchor)
- **MON-001 / MON-005** — no OTP on stdout; redact phone on SMS failure logs

Report: `security-audit-reports/phase-01-identity-access/01-authentication-session-security.md`


Made with [Cursor](https://cursor.com)