### PR TITLE
🔒 fix(aico): harden control-plane service token and mock-auth gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,14 +152,15 @@ OPENROUTER_API_KEY=
 # Product servers must leave this unset — only the control plane holds it.
 OPENROUTER_MANAGEMENT_API_KEY=
 
-# Control plane (moz starts it; UI+API on one port)
-# AICO_CONTROL_PLANE_SERVICE_TOKEN=replace-with-long-random
+# Control plane (moz starts it; UI+API on one port, bound to 127.0.0.1)
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=   # required; moz generates openssl rand -hex 32 if missing
 # AICO_CONTROL_PLANE_URL=http://aico-control-plane:3020
 # AICO_CONTROL_PLANE_PORT=3020
 # Browser origin — set when hosting on a domain, e.g. https://admin.example.com
 # AICO_CONTROL_PLANE_PUBLIC_URL=http://localhost:3020
 # AICO_INSECURE_AUTH_COOKIES=1
 # AICO_CONTROL_PLANE_UI_URL=http://localhost:3020
+# AICO_ALLOW_INSECURE_CONTROL_PLANE=1  # local OpenRouter mock without management key only
 
 # Force in-process OpenRouter management mock (local QA only). Ignored / rejected in production.
 # AICO_OPENROUTER_MOCK=0

--- a/.env.example.aico
+++ b/.env.example.aico
@@ -53,12 +53,18 @@ SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
 # Management key belongs on the control plane only (moz starts it automatically).
 # OPENROUTER_MANAGEMENT_API_KEY=sk-or-v1-xxxx
 # Shared product ↔ control-plane token (default in compose: devtok)
-# AICO_CONTROL_PLANE_SERVICE_TOKEN=replace-with-long-random
+# Shared product ↔ control-plane token — REQUIRED. Use a long random value
+# (moz generates one if missing). The placeholder `devtok` is rejected at runtime.
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=
 # AICO_CONTROL_PLANE_PORT=3020
 # Browser origin for the control-plane UI/API (same process on :3020). Change when
 # you put it behind a domain, e.g. https://admin.example.com
 # AICO_CONTROL_PLANE_PUBLIC_URL=http://localhost:3020
 # AICO_INSECURE_AUTH_COOKIES=1   # set 0 when PUBLIC_URL is https://
+# Local moz only: allow OpenRouter mock without a management key (NODE_ENV=production)
+# AICO_ALLOW_INSECURE_CONTROL_PLANE=1
+# Never enable on a shared network:
+# AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH=1
 # COMPOSIO_API_KEY=ak_xxxx
 # QSTASH_TOKEN=xxxx
 

--- a/apps/aico-control-plane/README.md
+++ b/apps/aico-control-plane/README.md
@@ -11,18 +11,25 @@ Privileged operations app for Aico. **Not** part of the customer product surface
 
 ## Env
 
-| Variable                           | Required      | Notes                                                                                                                       |
-| ---------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `AICO_IS_CONTROL_PLANE`            | yes (`1`)     | Set automatically by `dev` entry                                                                                            |
-| `OPENROUTER_MANAGEMENT_API_KEY`    | production    | Real OpenRouter management key                                                                                              |
-| `AICO_CONTROL_PLANE_SERVICE_TOKEN` | yes           | Shared with product server                                                                                                  |
-| `DATABASE_URL` / auth secrets      | yes           | Same DB + Better Auth as product                                                                                            |
-| `AICO_CONTROL_PLANE_PORT`          | no            | Host port (default `3020`)                                                                                                  |
-| `AICO_CONTROL_PLANE_PUBLIC_URL`    | no            | Browser origin (default `http://localhost:3020`). Set to any domain when reverse-proxying, e.g. `https://admin.example.com` |
-| `AICO_INSECURE_AUTH_COOKIES`       | no            | `1` for HTTP; use `0` when PUBLIC\_URL is `https://`                                                                        |
-| `AICO_OPENROUTER_MOCK`             | non-prod only | In-process mock when no key                                                                                                 |
+| Variable                             | Required   | Notes                                                                                                                       |
+| ------------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `AICO_IS_CONTROL_PLANE`              | yes (`1`)  | Set automatically by `dev` entry                                                                                            |
+| `OPENROUTER_MANAGEMENT_API_KEY`      | production | Real OpenRouter management key                                                                                              |
+| `AICO_CONTROL_PLANE_SERVICE_TOKEN`   | yes        | Shared with product. ≥24 chars; `devtok` rejected at startup                                                                |
+| `DATABASE_URL` / auth secrets        | yes        | Same DB + Better Auth as product                                                                                            |
+| `AICO_CONTROL_PLANE_PORT`            | no         | Host port (default `3020`, moz binds `127.0.0.1` only)                                                                      |
+| `AICO_CONTROL_PLANE_PUBLIC_URL`      | no         | Browser origin (default `http://localhost:3020`). Set to any domain when reverse-proxying, e.g. `https://admin.example.com` |
+| `AICO_INSECURE_AUTH_COOKIES`         | no         | `1` for HTTP; use `0` when PUBLIC\_URL is `https://`                                                                        |
+| `AICO_OPENROUTER_MOCK`               | local QA   | Mock when no management key; needs `AICO_ALLOW_INSECURE_CONTROL_PLANE=1` under `NODE_ENV=production`                        |
+| `AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH` | no         | Never set in shared envs — re-enables tRPC mock-user bypass on the control plane                                            |
 
 Better Auth runs **on this process** (`/api/auth/*`). `APP_URL` must equal the public browser origin.
+
+### Security notes
+
+- Do **not** use placeholder tokens (`devtok`). `moz` generates `openssl rand -hex 32` when missing/weak.
+- Control plane defaults to `NODE_ENV=production` so `ENABLE_MOCK_DEV_USER` / `lobe-auth-dev-backend-api` cannot elevate to platform admin.
+- Publish `:3020` on loopback only unless you put TLS + network policy in front.
 
 ## Product server env
 

--- a/apps/aico-control-plane/src/hono/index.ts
+++ b/apps/aico-control-plane/src/hono/index.ts
@@ -43,8 +43,10 @@ const MIME_BY_EXT: Record<string, string> = {
 const safeSpaPath = (requestPath: string): string | null => {
   const decoded = decodeURIComponent(requestPath.split('?')[0] || '/');
   const relative = decoded === '/' ? 'index.html' : decoded.replace(/^\//, '');
-  const full = path.normalize(path.join(spaRoot, relative));
-  if (!full.startsWith(spaRoot)) return null;
+  const rootResolved = path.resolve(spaRoot);
+  const full = path.resolve(rootResolved, relative);
+  const rootPrefix = rootResolved.endsWith(path.sep) ? rootResolved : `${rootResolved}${path.sep}`;
+  if (full !== rootResolved && !full.startsWith(rootPrefix)) return null;
   return full;
 };
 

--- a/apps/aico-control-plane/src/hono/openrouterInternal.ts
+++ b/apps/aico-control-plane/src/hono/openrouterInternal.ts
@@ -2,19 +2,13 @@ import { Hono } from 'hono';
 
 import { createOpenRouterManagementClient } from '@/server/services/openrouter/management';
 
+import { assertBearerServiceToken } from './serviceToken';
+
 const unauthorized = () =>
   new Response(JSON.stringify({ error: 'unauthorized' }), {
     headers: { 'Content-Type': 'application/json' },
     status: 401,
   });
-
-const assertServiceToken = (req: Request): boolean => {
-  const expected = process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN;
-  if (!expected) return false;
-  const header = req.headers.get('authorization') || '';
-  const token = header.startsWith('Bearer ') ? header.slice('Bearer '.length).trim() : '';
-  return Boolean(token) && token === expected;
-};
 
 /**
  * Token-gated OpenRouter Management API proxy for the product server.
@@ -24,7 +18,7 @@ export const createOpenRouterInternalApp = () => {
   const app = new Hono();
 
   app.use('*', async (c, next) => {
-    if (!assertServiceToken(c.req.raw)) return unauthorized();
+    if (!assertBearerServiceToken(c.req.raw)) return unauthorized();
     return next();
   });
 

--- a/apps/aico-control-plane/src/hono/serviceToken.test.ts
+++ b/apps/aico-control-plane/src/hono/serviceToken.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertBearerServiceToken,
+  assertServiceTokenConfigured,
+  isWeakControlPlaneServiceToken,
+  timingSafeStringEqual,
+} from './serviceToken';
+
+describe('control-plane serviceToken', () => {
+  it('rejects weak / placeholder tokens', () => {
+    expect(isWeakControlPlaneServiceToken(undefined)).toBe(true);
+    expect(isWeakControlPlaneServiceToken('')).toBe(true);
+    expect(isWeakControlPlaneServiceToken('devtok')).toBe(true);
+    expect(isWeakControlPlaneServiceToken('DEVTOK')).toBe(true);
+    expect(isWeakControlPlaneServiceToken('short')).toBe(true);
+    expect(isWeakControlPlaneServiceToken('a'.repeat(24))).toBe(false);
+  });
+
+  it('timingSafeStringEqual matches equal strings', () => {
+    expect(timingSafeStringEqual('abc', 'abc')).toBe(true);
+    expect(timingSafeStringEqual('abc', 'abd')).toBe(false);
+    expect(timingSafeStringEqual('short', 'longer-value')).toBe(false);
+  });
+
+  it('assertServiceTokenConfigured throws on weak env', () => {
+    expect(() => assertServiceTokenConfigured('devtok')).toThrow(/too weak|missing/);
+    expect(assertServiceTokenConfigured('x'.repeat(32))).toHaveLength(32);
+  });
+
+  it('assertBearerServiceToken requires matching Bearer', () => {
+    const strong = `cp_${'a'.repeat(40)}`;
+    const prev = process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN;
+    process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN = strong;
+    try {
+      expect(
+        assertBearerServiceToken(
+          new Request('http://localhost/internal', {
+            headers: { authorization: `Bearer ${strong}` },
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        assertBearerServiceToken(
+          new Request('http://localhost/internal', {
+            headers: { authorization: 'Bearer wrong-token-value-xxxxxxxxxxxx' },
+          }),
+        ),
+      ).toBe(false);
+      expect(assertBearerServiceToken(new Request('http://localhost/internal'))).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN;
+      else process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN = prev;
+    }
+  });
+});

--- a/apps/aico-control-plane/src/hono/serviceToken.ts
+++ b/apps/aico-control-plane/src/hono/serviceToken.ts
@@ -1,0 +1,52 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** Tokens that must never gate `/internal/*` (public examples / placeholders). */
+const FORBIDDEN_SERVICE_TOKENS = new Set(['', 'devtok', 'changeme', 'secret', 'password', 'token']);
+
+const MIN_TOKEN_LENGTH = 24;
+
+export const isWeakControlPlaneServiceToken = (token: string | undefined | null): boolean => {
+  if (token == null) return true;
+  const trimmed = token.trim();
+  if (trimmed.length < MIN_TOKEN_LENGTH) return true;
+  if (FORBIDDEN_SERVICE_TOKENS.has(trimmed.toLowerCase())) return true;
+  return false;
+};
+
+/** Constant-time string compare via SHA-256 digests (length-independent). */
+export const timingSafeStringEqual = (a: string, b: string): boolean => {
+  const ha = createHash('sha256').update(a).digest();
+  const hb = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ha, hb);
+};
+
+/**
+ * Validate the shared product ↔ control-plane bearer token before serving
+ * `/internal/*`. Weak tokens (including the old `devtok` default) are rejected.
+ */
+export const assertServiceTokenConfigured = (
+  token: string | undefined = process.env.AICO_CONTROL_PLANE_SERVICE_TOKEN,
+): string => {
+  if (isWeakControlPlaneServiceToken(token)) {
+    throw new Error(
+      'AICO_CONTROL_PLANE_SERVICE_TOKEN is missing or too weak. Set a random token ' +
+        `(≥${MIN_TOKEN_LENGTH} chars), e.g. \`openssl rand -hex 32\`. ` +
+        'The placeholder `devtok` is not allowed.',
+    );
+  }
+  return token!.trim();
+};
+
+export const assertBearerServiceToken = (req: Request): boolean => {
+  let expected: string;
+  try {
+    expected = assertServiceTokenConfigured();
+  } catch {
+    return false;
+  }
+
+  const header = req.headers.get('authorization') || '';
+  const token = header.startsWith('Bearer ') ? header.slice('Bearer '.length).trim() : '';
+  if (!token) return false;
+  return timingSafeStringEqual(token, expected);
+};

--- a/apps/aico-control-plane/src/hono/standalone.ts
+++ b/apps/aico-control-plane/src/hono/standalone.ts
@@ -3,6 +3,7 @@ import { createServer } from 'node:http';
 import { Readable } from 'node:stream';
 
 import honoApp from './index';
+import { assertServiceTokenConfigured } from './serviceToken';
 
 type HonoStandaloneGlobal = typeof globalThis & {
   __aicoControlPlaneServer?: Server;
@@ -97,6 +98,9 @@ const closePreviousServer = (previousServer: Server | undefined) =>
   });
 
 const startServer = async () => {
+  // Fail closed before binding — weak/default tokens must never gate /internal/*.
+  assertServiceTokenConfigured();
+
   const standaloneGlobal = globalThis as HonoStandaloneGlobal;
 
   await closePreviousServer(standaloneGlobal.__aicoControlPlaneServer);

--- a/apps/server/src/services/openrouter/management.ts
+++ b/apps/server/src/services/openrouter/management.ts
@@ -257,8 +257,13 @@ export const createOpenRouterManagementClient = (
     return new HttpOpenRouterManagementClient(aicoEnv.OPENROUTER_MANAGEMENT_API_KEY);
   }
 
-  // `AICO_OPENROUTER_MOCK` is a non-production QA convenience only — ignored in production.
-  if (!isProduction && aicoEnv.AICO_OPENROUTER_MOCK) {
+  // `AICO_OPENROUTER_MOCK` is a non-production QA convenience — ignored in
+  // production except on the control plane when explicitly allowed for local moz
+  // (no real management key yet).
+  if (
+    aicoEnv.AICO_OPENROUTER_MOCK &&
+    (!isProduction || (isControlPlane && process.env.AICO_ALLOW_INSECURE_CONTROL_PLANE === '1'))
+  ) {
     return new MockOpenRouterManagementClient();
   }
 

--- a/docker-compose/deploy/.env.example.aico
+++ b/docker-compose/deploy/.env.example.aico
@@ -9,6 +9,9 @@ RUSTFS_ADMIN_PORT=9001
 # AICO_CONTROL_PLANE_PORT=3020
 # AICO_CONTROL_PLANE_PUBLIC_URL=http://localhost:3020
 # AICO_INSECURE_AUTH_COOKIES=1
+# Required strong token (moz generates if missing). `devtok` is rejected.
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=
+# AICO_ALLOW_INSECURE_CONTROL_PLANE=1
 
 # Database
 LOBE_DB_NAME=lobechat

--- a/docker-compose/deploy/docker-compose.aico.control-plane.override.yml
+++ b/docker-compose/deploy/docker-compose.aico.control-plane.override.yml
@@ -6,12 +6,18 @@
 #
 # Runtime uses the repo bind-mount so `node dist/standalone.js` can resolve
 # monorepo node_modules (same pattern as local `bun run dev:control-plane`).
+#
+# Security defaults:
+# - Strong random AICO_CONTROL_PLANE_SERVICE_TOKEN required (moz generates if missing)
+# - NODE_ENV=production so tRPC mock-auth bypass is off
+# - Port published on 127.0.0.1 only (not all interfaces)
+# - Dev mock user env cleared even if present in repo .env
 
 services:
   lobe:
     environment:
       AICO_CONTROL_PLANE_URL: http://aico-control-plane:3020
-      AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:-devtok}
+      AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:?set AICO_CONTROL_PLANE_SERVICE_TOKEN}
       # Browser origin of the control-plane UI (any host/domain later)
       AICO_CONTROL_PLANE_UI_URL: ${AICO_CONTROL_PLANE_PUBLIC_URL:-http://localhost:${AICO_CONTROL_PLANE_PORT:-3020}}
       # Clear management key on the product container even if present in env_file.
@@ -34,7 +40,7 @@ services:
       AICO_IS_CONTROL_PLANE: '1'
       AICO_CONTROL_PLANE_PORT: '3020'
       HONO_HOST: '0.0.0.0'
-      AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:-devtok}
+      AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:?set AICO_CONTROL_PLANE_SERVICE_TOKEN}
       OPENROUTER_MANAGEMENT_API_KEY: ${OPENROUTER_MANAGEMENT_API_KEY:-}
       # Prefer the compose network DB/Redis, not host-only URLs from repo .env
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}
@@ -50,13 +56,20 @@ services:
       APP_URL: ${AICO_CONTROL_PLANE_PUBLIC_URL:-http://localhost:${AICO_CONTROL_PLANE_PORT:-3020}}
       AICO_CONTROL_PLANE_UI_URL: ${AICO_CONTROL_PLANE_PUBLIC_URL:-http://localhost:${AICO_CONTROL_PLANE_PORT:-3020}}
       INTERNAL_APP_URL: ${INTERNAL_APP_URL:-http://lobe:3210}
-      # HTTP public URL → non-__Secure cookies; override with 0 behind HTTPS TLS
+      # HTTP public URL → non-__Secure cookies; set 0 when PUBLIC_URL is https://
       AICO_INSECURE_AUTH_COOKIES: ${AICO_INSECURE_AUTH_COOKIES:-1}
-      # development allows OpenRouter mock when management key is unset (local moz)
-      NODE_ENV: ${CONTROL_PLANE_NODE_ENV:-development}
+      # production disables tRPC ENABLE_MOCK_DEV_USER / debug-header bypass
+      NODE_ENV: ${CONTROL_PLANE_NODE_ENV:-production}
+      # Clear any mock-auth flags leaked from repo .env
+      ENABLE_MOCK_DEV_USER: '0'
+      MOCK_DEV_USER_ID: ''
+      AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH: '0'
+      # Local OpenRouter mock without a real management key (requires allow flag)
       AICO_OPENROUTER_MOCK: ${AICO_OPENROUTER_MOCK:-1}
+      AICO_ALLOW_INSECURE_CONTROL_PLANE: ${AICO_ALLOW_INSECURE_CONTROL_PLANE:-1}
     ports:
-      - '${AICO_CONTROL_PLANE_PORT:-3020}:3020'
+      # Loopback only — do not publish admin/API on all interfaces
+      - '127.0.0.1:${AICO_CONTROL_PLANE_PORT:-3020}:3020'
     depends_on:
       postgresql:
         condition: service_healthy

--- a/packages/trpc/src/lambda/context.test.ts
+++ b/packages/trpc/src/lambda/context.test.ts
@@ -464,4 +464,39 @@ describe('createLambdaContext', () => {
     expect(mockValidateOIDCJWT).toHaveBeenCalledWith('oidc-token');
     expect(mockGetSession).not.toHaveBeenCalled();
   });
+
+  it('should not apply mock-dev auth bypass on the control plane', async () => {
+    const prev = {
+      allow: process.env.AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH,
+      isCp: process.env.AICO_IS_CONTROL_PLANE,
+      mock: process.env.ENABLE_MOCK_DEV_USER,
+      mockId: process.env.MOCK_DEV_USER_ID,
+      nodeEnv: process.env.NODE_ENV,
+    };
+    process.env.NODE_ENV = 'development';
+    process.env.AICO_IS_CONTROL_PLANE = '1';
+    process.env.ENABLE_MOCK_DEV_USER = '1';
+    process.env.MOCK_DEV_USER_ID = 'user_mock_admin';
+    delete process.env.AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH;
+
+    try {
+      const request = new NextRequest('https://example.com/trpc/lambda', {
+        headers: { 'lobe-auth-dev-backend-api': '1' },
+      });
+      const context = await createLambdaContext(request);
+      // Falls through to session auth — not the mock user id
+      expect(context.userId).not.toBe('user_mock_admin');
+      expect(mockGetSession).toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prev.nodeEnv;
+      if (prev.isCp === undefined) delete process.env.AICO_IS_CONTROL_PLANE;
+      else process.env.AICO_IS_CONTROL_PLANE = prev.isCp;
+      if (prev.mock === undefined) delete process.env.ENABLE_MOCK_DEV_USER;
+      else process.env.ENABLE_MOCK_DEV_USER = prev.mock;
+      if (prev.mockId === undefined) delete process.env.MOCK_DEV_USER_ID;
+      else process.env.MOCK_DEV_USER_ID = prev.mockId;
+      if (prev.allow === undefined) delete process.env.AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH;
+      else process.env.AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH = prev.allow;
+    }
+  });
 });

--- a/packages/trpc/src/lambda/context.ts
+++ b/packages/trpc/src/lambda/context.ts
@@ -133,12 +133,20 @@ export type LambdaContext = Awaited<ReturnType<typeof createContextInner>>;
 export const createLambdaContext = async (request: NextRequest): Promise<LambdaContext> => {
   const clientMetadata = parseClientMetadata(request.headers);
 
-  // we have a special header to debug the api endpoint in development mode
-  // IT WON'T GO INTO PRODUCTION ANYMORE
+  // Dev-only mock / debug header auth. Disabled on the control plane so a
+  // published :3020 with NODE_ENV=development cannot elevate to platformAdmin
+  // via `lobe-auth-dev-backend-api` / ENABLE_MOCK_DEV_USER from repo .env.
   const isDebugApi = request.headers.get('lobe-auth-dev-backend-api') === '1';
   const isMockUser = process.env.ENABLE_MOCK_DEV_USER === '1';
+  const controlPlaneBlocksDevAuthBypass =
+    process.env.AICO_IS_CONTROL_PLANE === '1' &&
+    process.env.AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH !== '1';
 
-  if (process.env.NODE_ENV === 'development' && (isDebugApi || isMockUser)) {
+  if (
+    process.env.NODE_ENV === 'development' &&
+    !controlPlaneBlocksDevAuthBypass &&
+    (isDebugApi || isMockUser)
+  ) {
     return createContextInner({
       clientMetadata,
       userId: process.env.MOCK_DEV_USER_ID,

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -88,8 +88,10 @@ Environment:
                           (intentional wipe / first bootstrap after delete)
   MOZ_ALLOW_DB_DRIFT=1    Allow redeploy when live DB fingerprint differs from
                           the last known good snapshot (users dropped, etc.)
-  AICO_CONTROL_PLANE_SERVICE_TOKEN   Shared product↔control-plane token (default: devtok)
-  AICO_CONTROL_PLANE_PORT            Host port for control plane (default: 3020)
+  AICO_CONTROL_PLANE_SERVICE_TOKEN   Shared product↔control-plane token
+                          (moz generates a strong random token if missing/weak;
+                           `devtok` is rejected)
+  AICO_CONTROL_PLANE_PORT            Host port for control plane (default: 3020; bound to 127.0.0.1)
   OPENROUTER_MANAGEMENT_API_KEY      Set in repo .env — loaded only by control plane
 
 Backups:
@@ -463,6 +465,48 @@ compose_in_deploy_dir() {
 
 CONTROL_PLANE_CONTAINER="aico-control-plane"
 
+# Upsert KEY=VALUE in an env file (create file if missing).
+upsert_env_kv() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  mkdir -p "$(dirname "$file")"
+  touch "$file"
+  if grep -qE "^${key}=" "$file" 2>/dev/null; then
+    # portable-ish in-place replace
+    local tmp
+    tmp="$(mktemp)"
+    awk -v k="$key" -v v="$value" 'BEGIN{FS=OFS="="} $1==k{$0=k"="v} {print}' "$file" >"$tmp"
+    mv "$tmp" "$file"
+  else
+    printf '%s=%s\n' "$key" "$value" >>"$file"
+  fi
+}
+
+# Strong shared token required — never use the old `devtok` placeholder.
+ensure_control_plane_service_token() {
+  local root_env="$ROOT/.env"
+  local deploy_env="$DEPLOY_DIR/.env"
+  local tok=""
+
+  tok="$(grep -E '^AICO_CONTROL_PLANE_SERVICE_TOKEN=' "$root_env" 2>/dev/null | cut -d= -f2- || true)"
+  if [[ -z "$tok" ]]; then
+    tok="$(grep -E '^AICO_CONTROL_PLANE_SERVICE_TOKEN=' "$deploy_env" 2>/dev/null | cut -d= -f2- || true)"
+  fi
+
+  if [[ -z "$tok" || "$tok" == "devtok" || ${#tok} -lt 24 ]]; then
+    tok="$(openssl rand -hex 32)"
+    echo "==> Generated AICO_CONTROL_PLANE_SERVICE_TOKEN (was missing/weak)"
+    upsert_env_kv "$root_env" "AICO_CONTROL_PLANE_SERVICE_TOKEN" "$tok"
+    upsert_env_kv "$deploy_env" "AICO_CONTROL_PLANE_SERVICE_TOKEN" "$tok"
+  else
+    # Keep deploy/.env in sync so compose --env-file sees it
+    upsert_env_kv "$deploy_env" "AICO_CONTROL_PLANE_SERVICE_TOKEN" "$tok"
+  fi
+
+  export AICO_CONTROL_PLANE_SERVICE_TOKEN="$tok"
+}
+
 ensure_control_plane_build() {
   echo "==> Building control-plane SPA + API"
   cd "$ROOT"
@@ -690,6 +734,7 @@ fi
 
 load_panachat_data_dir
 ensure_panachat_data_env
+ensure_control_plane_service_token
 
 if [[ $STATUS -eq 1 ]]; then
   set +e


### PR DESCRIPTION
<!-- Brief and heads-up -->

Security hardening that missed the #210 merge window — lands the token/mock-auth/bind fixes on `canary`.

#### 🤯 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] ⚡️ perf
- [ ] 📝 docs
- [x] ✅ test
- [ ] 🔨 build
- [ ] 🔖 release

#### 🔗 Related Issue

Fixes #211

Plane: [AICO-138](https://plane.panafor.com/panaforai/browse/AICO-138)

Related (already merged): #209 / [AICO-137](https://plane.panafor.com/panaforai/browse/AICO-137) / PR #210

#### Description of Change

- Reject weak/`devtok` `AICO_CONTROL_PLANE_SERVICE_TOKEN` at startup; timing-safe Bearer compare
- `moz` generates `openssl rand -hex 32` when token missing/weak
- Control plane defaults to `NODE_ENV=production`; clears mock-user env; blocks tRPC mock-auth when `AICO_IS_CONTROL_PLANE=1`
- Publish `:3020` on `127.0.0.1` only
- Safer SPA static path resolution

#### How to Test

- [x] Unit tests for service token + control-plane mock-auth block
- [ ] `moz -u` rotates weak token; control plane starts
- [ ] `/internal/openrouter/v1/keys` rejects missing/wrong Bearer
- [ ] With `ENABLE_MOCK_DEV_USER=1` in `.env`, control-plane tRPC still requires a real session

Made with [Cursor](https://cursor.com)