### PR TITLE
🐛 fix(auth): serve /terms and /privacy on production without wrong-host links

### DIFF
--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -48,8 +48,12 @@ export const BLOG = urlJoin(OFFICIAL_SITE, 'blog');
 
 export const ABOUT = OFFICIAL_SITE;
 export const FEEDBACK = 'https://github.com/lobehub/lobe-chat/issues/new/choose';
-export const PRIVACY_URL = urlJoin(OFFICIAL_SITE, '/privacy');
-export const TERMS_URL = urlJoin(OFFICIAL_SITE, '/terms');
+/** Same-origin auth SPA routes — prefer these for in-app links. */
+export const PRIVACY_PATH = '/privacy';
+export const TERMS_PATH = '/terms';
+
+export const PRIVACY_URL = urlJoin(OFFICIAL_SITE, PRIVACY_PATH);
+export const TERMS_URL = urlJoin(OFFICIAL_SITE, TERMS_PATH);
 
 export const PLUGINS_INDEX_URL = 'https://chat-plugins.lobehub.com';
 

--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -371,6 +371,7 @@ export function sharedRendererDefine(options: { isElectron: boolean; isMobile: b
       .filter(([key]) => key.toUpperCase().startsWith('NEXT_PUBLIC_'))
       .map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)]),
   );
+  const appUrl = process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL;
 
   return {
     '__CI__': process.env.CI === 'true' ? 'true' : 'false',
@@ -379,6 +380,7 @@ export function sharedRendererDefine(options: { isElectron: boolean; isMobile: b
     '__MOBILE__': JSON.stringify(options.isMobile),
     '__REACT_SCAN__': process.env.REACT_SCAN === 'true' ? 'true' : 'false',
     '__TEST__': 'false',
+    ...(appUrl ? { 'process.env.APP_URL': JSON.stringify(appUrl) } : {}),
     ...nextPublicDefine,
     // Keep a safe fallback so generic `process.env` access won't crash in browser runtime.
     'process.env': '{}',

--- a/src/features/AuthShell/AuthAgreement.test.tsx
+++ b/src/features/AuthShell/AuthAgreement.test.tsx
@@ -34,6 +34,8 @@ const expectLinksToOpenInNewTabs = () => {
   const links = screen.getAllByRole('link');
 
   expect(links).toHaveLength(2);
+  expect(links[0]?.getAttribute('href')).toBe('/terms');
+  expect(links[1]?.getAttribute('href')).toBe('/privacy');
   for (const link of links) {
     expect(link.getAttribute('target')).toBe('_blank');
     expect(link.getAttribute('rel')).toBe('noopener noreferrer');

--- a/src/features/AuthShell/AuthAgreement.tsx
+++ b/src/features/AuthShell/AuthAgreement.tsx
@@ -6,7 +6,7 @@ import { createStaticStyles } from 'antd-style';
 import { memo, useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { PRIVACY_URL, TERMS_URL } from '@/const/url';
+import { PRIVACY_PATH, TERMS_PATH } from '@/const/url';
 
 /**
  * Remembers that the user already accepted the terms & privacy policy on this
@@ -80,12 +80,12 @@ const AgreementText = memo<AgreementTextProps>(({ i18nKey }) => {
       ns={'auth'}
       components={{
         privacy: (
-          <a className={styles.link} href={PRIVACY_URL} rel="noopener noreferrer" target="_blank">
+          <a className={styles.link} href={PRIVACY_PATH} rel="noopener noreferrer" target="_blank">
             {translate('footer.privacy')}
           </a>
         ),
         terms: (
-          <a className={styles.link} href={TERMS_URL} rel="noopener noreferrer" target="_blank">
+          <a className={styles.link} href={TERMS_PATH} rel="noopener noreferrer" target="_blank">
             {translate('footer.terms')}
           </a>
         ),

--- a/src/features/AuthShell/AuthFooterLinks.tsx
+++ b/src/features/AuthShell/AuthFooterLinks.tsx
@@ -5,7 +5,7 @@ import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { PRIVACY_URL, TERMS_URL } from '@/const/url';
+import { PRIVACY_PATH, TERMS_PATH } from '@/const/url';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   link: css`
@@ -22,11 +22,11 @@ const AuthFooterLinks = memo(() => {
   const { t } = useTranslation('auth');
   return (
     <Text align={'center'} fontSize={13} type={'secondary'}>
-      <a className={styles.link} href={TERMS_URL} rel="noopener noreferrer" target="_blank">
+      <a className={styles.link} href={TERMS_PATH} rel="noopener noreferrer" target="_blank">
         {t('footer.terms')}
       </a>
       <span style={{ marginInline: 8 }}>·</span>
-      <a className={styles.link} href={PRIVACY_URL} rel="noopener noreferrer" target="_blank">
+      <a className={styles.link} href={PRIVACY_PATH} rel="noopener noreferrer" target="_blank">
         {t('footer.privacy')}
       </a>
     </Text>

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+
+import { config } from './proxy';
+
+describe('proxy matcher', () => {
+  it('includes auth legal routes so middleware can rewrite them to the auth SPA', () => {
+    expect(config.matcher).toEqual(
+      expect.arrayContaining(['/terms(.*)', '/privacy(.*)', '/signin(.*)']),
+    );
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -54,6 +54,8 @@ export const config = {
 
     '/signup(.*)',
     '/signin(.*)',
+    '/terms(.*)',
+    '/privacy(.*)',
     '/verify-email(.*)',
     '/verify-phone(.*)',
     '/verify-im(.*)',


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #215

Plane: [AICO-127](https://plane.panafor.com/panaforai/browse/AICO-127)

#### Change Type

- [x] 🐛 Bug fix

#### Description of Change

Production users on `https://chat.panafor.com` could not read Terms or Privacy from the sign-in/sign-up flow:

1. **`/terms` and `/privacy` returned 404** — they were missing from the Next.js proxy matcher in `src/proxy.ts`, so middleware never rewrote them to the auth SPA (while `/signin` worked).
2. **Auth links could point at the wrong host** — footer and agreement links used absolute `TERMS_URL` / `PRIVACY_URL`; the Vite client bundle often fell back to `localhost:3210` when `APP_URL` was not injected at build time.

This PR:
- Adds `/terms(.*)` and `/privacy(.*)` to the proxy matcher
- Uses same-origin `/terms` and `/privacy` paths in `AuthFooterLinks` and `AuthAgreement`
- Exports `TERMS_PATH` / `PRIVACY_PATH` from `@lobechat/const`
- Injects `process.env.APP_URL` into the Vite client define when `APP_URL` or `NEXT_PUBLIC_APP_URL` is set
- Adds regression tests (`src/proxy.test.ts`, updated `AuthAgreement.test.tsx`)

#### How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Verify on deploy:**
```bash
curl -I https://chat.panafor.com/terms    # expect 200 + x-middleware-rewrite → /spa-auth/.../terms
curl -I https://chat.panafor.com/privacy  # expect 200
```
On `/signin`, Terms/Privacy links should be `/terms` and `/privacy` on the current host (not localhost).


Made with [Cursor](https://cursor.com)