### PR TITLE
🐛 fix(aico): auth fa-IR locale, signup layout, chat RTL and Persian streaming

### DIFF
--- a/index.auth.html
+++ b/index.auth.html
@@ -69,8 +69,11 @@
         var hl = new URLSearchParams(location.search).get('hl');
         var m = document.cookie.match(/(?:^|;\s*)LOBE_LOCALE=([^;]*)/);
         var cookie = m ? decodeURIComponent(m[1]) : '';
+        // Aico default is Persian. Match server parseBrowserLanguage: when DEFAULT_LANG
+        // is not en-US, do not follow navigator.language for the `auto` cookie value.
         var locale = hl || cookie || 'fa-IR';
-        if (locale === 'auto') locale = navigator.language || 'fa-IR';
+        if (locale === 'auto') locale = 'fa-IR';
+        if (locale.toLowerCase().indexOf('fa') === 0) locale = 'fa-IR';
         if (hl && !cookie) {
           document.cookie =
             'LOBE_LOCALE=' + encodeURIComponent(hl) + ';path=/;max-age=7776000;SameSite=Lax';

--- a/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
+++ b/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
@@ -152,6 +152,35 @@ describe('fetchSSE', () => {
     });
   });
 
+  it('should smooth-stream Persian without splitting grapheme clusters', async () => {
+    const mockOnMessageHandle = vi.fn();
+    const mockOnFinish = vi.fn();
+    const persian = 'سلام';
+
+    (fetchEventSource as any).mockImplementationOnce(
+      async (url: string, options: FetchEventSourceInit) => {
+        options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
+        options.onmessage!({ event: 'text', data: JSON.stringify(persian) } as any);
+      },
+    );
+
+    await fetchSSE('/', {
+      onMessageHandle: mockOnMessageHandle,
+      onFinish: mockOnFinish,
+      responseAnimation: 'smooth',
+    });
+
+    const allTexts = mockOnMessageHandle.mock.calls
+      .map((call) => call[0])
+      .filter((c) => c.type === 'text')
+      .map((c) => c.text);
+
+    expect(allTexts.join('')).toBe(persian);
+    // Each smooth delta should be a whole grapheme (not a UTF-16 half or empty).
+    expect(allTexts.every((t) => t.length > 0)).toBe(true);
+    expect(mockOnFinish).toHaveBeenCalledWith(persian, expect.objectContaining({ type: 'done' }));
+  });
+
   it('should not handle text events', async () => {
     const mockOnMessageHandle = vi.fn();
     const mockOnFinish = vi.fn();

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -216,7 +216,16 @@ const createSmoothMessage = (params: {
   };
 
   const pushToQueue = (text: string) => {
-    outputQueue.push(...text.split(''));
+    // Grapheme-safe enqueue so Persian/emoji/combining marks are not split mid-cluster.
+    // (Cursive joining itself is preserved by contiguous string buffers; char-based
+    // DOM wraps are handled separately via streamAnimationGranularity: 'word'.)
+    if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+      for (const part of new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text)) {
+        outputQueue.push(part.segment);
+      }
+      return;
+    }
+    outputQueue.push(...Array.from(text));
   };
 
   const flushQueue = () => {

--- a/src/features/AuthShell/AuthContainer.tsx
+++ b/src/features/AuthShell/AuthContainer.tsx
@@ -31,7 +31,7 @@ const AuthContainer: FC<PropsWithChildren> = ({ children }) => {
         height={'100%'}
         width={'100%'}
       >
-        <Flexbox horizontal align={'center'} padding={16} width={'100%'}>
+        <Flexbox horizontal align={'center'} flex={'none'} padding={16} width={'100%'}>
           <a aria-label={BRANDING_NAME} href={'/'} style={{ display: 'inline-flex' }}>
             <ProductLogo size={40} />
           </a>
@@ -41,11 +41,26 @@ const AuthContainer: FC<PropsWithChildren> = ({ children }) => {
             {children}
           </Flexbox>
         ) : (
-          <Center height={'100%'} padding={16} width={'100%'}>
-            {children}
-          </Center>
+          // Keep locale/theme footer visible: tall signup forms must scroll inside
+          // this pane instead of Center height=100% + overflow:hidden clipping.
+          <Flexbox flex={1} style={{ minHeight: 0, overflow: 'auto' }} width={'100%'}>
+            <Center
+              padding={16}
+              style={{ boxSizing: 'border-box', minHeight: '100%' }}
+              width={'100%'}
+            >
+              {children}
+            </Center>
+          </Flexbox>
         )}
-        <Flexbox horizontal align={'center'} justify={'space-between'} padding={16} width={'100%'}>
+        <Flexbox
+          horizontal
+          align={'center'}
+          flex={'none'}
+          justify={'space-between'}
+          padding={16}
+          width={'100%'}
+        >
           <Flexbox horizontal align={'center'}>
             <AuthLangButton size={18} />
             <Divider className={styles.divider} orientation={'vertical'} />

--- a/src/features/AuthShell/AuthLocale.tsx
+++ b/src/features/AuthShell/AuthLocale.tsx
@@ -2,9 +2,11 @@
 
 import { ConfigProvider } from 'antd';
 import { memo, type PropsWithChildren, useEffect, useState } from 'react';
+import { I18nextProvider } from 'react-i18next';
 import { isRtlLang } from 'rtl-detect';
 
 import { DEFAULT_LANG } from '@/const/locale';
+import { normalizeLocale } from '@/locales/resources';
 import { applyDocumentDirection } from '@/utils/client/applyDocumentDirection';
 
 import { createAuthI18n } from './createAuthI18n';
@@ -14,43 +16,61 @@ interface AuthLocaleProps extends PropsWithChildren {
 }
 
 const AuthLocale = memo<AuthLocaleProps>(({ children, defaultLang }) => {
-  const [i18n] = useState(() => createAuthI18n(defaultLang));
-  const [lang, setLang] = useState(defaultLang ?? DEFAULT_LANG);
-
-  if (!i18n.instance.isInitialized) {
-    i18n.init();
-  }
+  const initialLang = normalizeLocale(defaultLang ?? DEFAULT_LANG);
+  const [i18n] = useState(() => createAuthI18n(initialLang));
+  const [lang, setLang] = useState(initialLang);
+  const [ready, setReady] = useState(i18n.instance.isInitialized);
 
   useEffect(() => {
+    let canceled = false;
+    void i18n.init({ initAsync: false }).then(() => {
+      if (!canceled) setReady(true);
+    });
+    return () => {
+      canceled = true;
+    };
+  }, [i18n]);
+
+  useEffect(() => {
+    if (!ready) return;
+
     applyDocumentDirection(lang);
-  }, [lang]);
+  }, [lang, ready]);
 
   useEffect(() => {
+    if (!ready) return;
+
     const handleLang = (lng: string) => {
-      setLang((prev) => (prev === lng ? prev : lng));
+      const next = normalizeLocale(lng);
+      setLang((prev) => (prev === next ? prev : next));
     };
 
+    handleLang(i18n.instance.language || initialLang);
     i18n.instance.on('languageChanged', handleLang);
     return () => {
       i18n.instance.off('languageChanged', handleLang);
     };
-  }, [i18n]);
+  }, [i18n, initialLang, ready]);
+
+  if (!ready) return null;
 
   const documentDir = isRtlLang(lang) ? 'rtl' : 'ltr';
 
   return (
-    <ConfigProvider
-      direction={documentDir}
-      theme={{
-        components: {
-          Button: {
-            contentFontSizeSM: 12,
+    <I18nextProvider i18n={i18n.instance}>
+      <ConfigProvider
+        direction={documentDir}
+        theme={{
+          components: {
+            Button: {
+              contentFontSizeSM: 12,
+            },
           },
-        },
-      }}
-    >
-      {children}
-    </ConfigProvider>
+        }}
+      >
+        {children}
+      </ConfigProvider>
+    </I18nextProvider>
   );
 });
 

--- a/src/features/AuthShell/AuthShell.tsx
+++ b/src/features/AuthShell/AuthShell.tsx
@@ -7,6 +7,7 @@ import BusinessAuthProvider from '@/business/client/BusinessAuthProvider';
 import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyticsProviderWrapper';
 import { mapFeatureFlagsEnvToState } from '@/config/featureFlags';
 import { DEFAULT_LANG } from '@/const/locale';
+import { normalizeLocale } from '@/locales/resources';
 import type { AuthSPAServerConfig } from '@/types/spaServerConfig';
 
 import AuthContainer from './AuthContainer';
@@ -16,7 +17,7 @@ import AuthThemeLite from './AuthThemeLite';
 
 const AuthShell = memo<PropsWithChildren>(({ children }) => {
   const serverConfig = window.__SERVER_CONFIG__ as unknown as AuthSPAServerConfig | undefined;
-  const locale = document.documentElement.lang || DEFAULT_LANG;
+  const locale = normalizeLocale(document.documentElement.lang || DEFAULT_LANG);
 
   return (
     <AuthLocale defaultLang={locale}>

--- a/src/features/AuthShell/createAuthI18n.test.ts
+++ b/src/features/AuthShell/createAuthI18n.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createAuthI18n, loadAuthNamespace } from './createAuthI18n';
 
@@ -17,6 +17,13 @@ describe('loadAuthNamespace', () => {
     expect(resources['betterAuth.signin.submit']).toBeTruthy();
     expect(resources['betterAuth.signin.submit']).not.toBe('Sign in');
   });
+
+  it('loads French auth copy for visible fr-FR locale', async () => {
+    const resources = await loadAuthNamespace('fr-FR', 'auth');
+
+    expect(resources['betterAuth.signin.submit']).toBeTruthy();
+    expect(resources['betterAuth.signin.submit']).not.toBe('Sign in');
+  });
 });
 
 describe('createAuthI18n', () => {
@@ -24,17 +31,22 @@ describe('createAuthI18n', () => {
     // each test gets a fresh instance via createAuthI18n
   });
 
-  it('switches login phone strings to Persian after changeLanguage', async () => {
+  it('switches login phone strings to Persian after changeLanguage without manual reload', async () => {
     const { init, instance } = createAuthI18n('en-US');
     await init({ initAsync: false });
 
-    expect(instance.t('betterAuth.signin.phone.title', { ns: 'auth' })).toBe('Sign in with phone');
+    // languageChanged reload for en-US is async — wait for English store
+    await vi.waitFor(() => {
+      expect(instance.t('betterAuth.signin.phone.title', { ns: 'auth' })).toBe(
+        'Sign in with phone',
+      );
+    });
 
     await instance.changeLanguage('fa-IR');
-    // languageChanged triggers reloadResources asynchronously — wait for store
-    await instance.reloadResources(['fa-IR'], ['auth']);
 
-    expect(instance.t('betterAuth.signin.phone.title', { ns: 'auth' })).toBe('ورود با موبایل');
+    await vi.waitFor(() => {
+      expect(instance.t('betterAuth.signin.phone.title', { ns: 'auth' })).toBe('ورود با موبایل');
+    });
     expect(instance.t('betterAuth.signin.phone.sendCode', { ns: 'auth' })).toBe('ارسال کد');
   });
 
@@ -45,5 +57,13 @@ describe('createAuthI18n', () => {
     expect(instance.t('betterAuth.verifyPhone.title', { ns: 'auth' })).toBe(
       'فعال‌سازی دوره آزمایشی — تأیید موبایل',
     );
+  });
+
+  it('normalizes bare fa to fa-IR on boot', async () => {
+    const { init, instance } = createAuthI18n('fa');
+    await init({ initAsync: false });
+
+    expect(instance.language).toBe('fa-IR');
+    expect(instance.t('betterAuth.signin.phone.title', { ns: 'auth' })).toBe('ورود با موبایل');
   });
 });

--- a/src/features/AuthShell/createAuthI18n.ts
+++ b/src/features/AuthShell/createAuthI18n.ts
@@ -16,6 +16,8 @@ import defaultError from '@/locales/default/error';
 import defaultMarketAuth from '@/locales/default/marketAuth';
 import defaultOauth from '@/locales/default/oauth';
 import { normalizeLocale } from '@/locales/resources';
+import { unwrapESMModule } from '@/utils/esm/unwrapESMModule';
+import { loadI18nNamespaceModule } from '@/utils/i18n/loadI18nNamespaceModule';
 
 const mergeNamespace = (
   fallbackResources: Record<string, unknown>,
@@ -46,6 +48,8 @@ const bundledDefaultResources = {
 type AuthI18nNamespace = keyof typeof defaultResources;
 
 const isAllowedNamespace = (ns: string): ns is AuthI18nNamespace => ns in defaultResources;
+
+const authNamespaces = Object.keys(defaultResources);
 
 type LocaleModule = { default?: Record<string, string> } | Record<string, string>;
 
@@ -102,13 +106,28 @@ const loadFaNamespace = async (ns: AuthI18nNamespace) => {
 export const loadAuthNamespace = async (lng: string, ns: string) => {
   const safeNamespace = isAllowedNamespace(ns) ? ns : 'auth';
   const normalizedLocale = normalizeLocale(lng);
+  const english = defaultResources[safeNamespace] as Record<string, unknown>;
 
   try {
     if (normalizedLocale === 'zh-CN') {
-      return unwrapLocaleModule(await loadZhNamespace(safeNamespace));
+      return mergeNamespace(english, unwrapLocaleModule(await loadZhNamespace(safeNamespace)));
     }
     if (normalizedLocale === 'fa-IR') {
-      return unwrapLocaleModule(await loadFaNamespace(safeNamespace));
+      return mergeNamespace(english, unwrapLocaleModule(await loadFaNamespace(safeNamespace)));
+    }
+    if (normalizedLocale !== 'en-US') {
+      // Visible locales like fr-FR (and any other non-English) load from locales/.
+      return mergeNamespace(
+        english,
+        unwrapESMModule(
+          await loadI18nNamespaceModule({
+            defaultLang: DEFAULT_LANG,
+            lng: normalizedLocale,
+            normalizeLocale,
+            ns: safeNamespace,
+          }),
+        ) as Record<string, unknown>,
+      );
     }
   } catch {
     // fall through to bundled default namespace
@@ -123,12 +142,14 @@ export const createAuthI18n = (lang?: string) => {
     .use(initReactI18next)
     .use(resourcesToBackend(loadAuthNamespace));
 
-  // With ns: [] and the en-US fallback bundled, i18next considers every namespace
-  // "loaded" and never asks the backend after a language switch — fetch explicitly.
+  const initialLang = normalizeLocale(lang);
+
+  // With ns: [] and partialBundledLanguages, i18next may not re-read the backend after
+  // a language switch — fetch explicitly for every locale, including DEFAULT_LANG (fa-IR),
+  // so switching back to Persian after English/French actually reloads Persian copy.
   instance.on('languageChanged', (lng) => {
     const locale = normalizeLocale(lng);
-    if (locale === DEFAULT_LANG) return;
-    void instance.reloadResources([locale], Object.keys(defaultResources));
+    void instance.reloadResources([locale], authNamespaces);
   });
 
   return {
@@ -141,7 +162,7 @@ export const createAuthI18n = (lang?: string) => {
         initAsync,
         interpolation: { escapeValue: false },
         keySeparator: false,
-        lng: lang,
+        lng: initialLang,
         ns: [],
         // Bundle fa-IR synchronously so the first render never suspends: with the
         // default useSuspense=true and no Suspense boundary above AuthShell, every

--- a/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
+++ b/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
@@ -2,7 +2,7 @@ import { useLexicalComposerContext } from '@lobehub/editor';
 import { $getRoot, $isElementNode } from 'lexical';
 import { type FC, useEffect } from 'react';
 
-import { getTextDirectionFromFirstStrong } from './getTextDirectionFromFirstStrong';
+import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
 
 const AUTO_DIR_TAG = 'chat-input-auto-direction';
 

--- a/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.test.ts
+++ b/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.test.ts
@@ -2,29 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { getTextDirectionFromFirstStrong } from './getTextDirectionFromFirstStrong';
 
-describe('getTextDirectionFromFirstStrong', () => {
-  it('returns rtl when the first strong character is Persian/Arabic', () => {
-    expect(getTextDirectionFromFirstStrong('سلام world')).toBe('rtl');
-    expect(getTextDirectionFromFirstStrong('  سلام')).toBe('rtl');
-  });
-
-  it('returns ltr when the first strong character is Latin', () => {
-    expect(getTextDirectionFromFirstStrong('hello سلام')).toBe('ltr');
-    expect(getTextDirectionFromFirstStrong('  hello')).toBe('ltr');
-  });
-
-  it('keeps rtl when English appears mid Persian sentence', () => {
-    expect(getTextDirectionFromFirstStrong('من از GPT استفاده می‌کنم')).toBe('rtl');
-  });
-
-  it('ignores leading digits and punctuation', () => {
-    expect(getTextDirectionFromFirstStrong('123 سلام')).toBe('rtl');
-    expect(getTextDirectionFromFirstStrong('...hello')).toBe('ltr');
-  });
-
-  it('returns null for empty or neutral-only text', () => {
-    expect(getTextDirectionFromFirstStrong('')).toBeNull();
-    expect(getTextDirectionFromFirstStrong('   ')).toBeNull();
-    expect(getTextDirectionFromFirstStrong('123')).toBeNull();
+describe('getTextDirectionFromFirstStrong (ChatInput re-export)', () => {
+  it('still resolves rtl for Persian via the shared util', () => {
+    expect(getTextDirectionFromFirstStrong('سلام')).toBe('rtl');
   });
 });

--- a/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.ts
+++ b/src/features/ChatInput/InputEditor/getTextDirectionFromFirstStrong.ts
@@ -1,18 +1,2 @@
-export type TextDirection = 'ltr' | 'rtl' | null;
-
-/**
- * First-strong character direction (Unicode bidi base direction).
- * Skips neutrals; returns rtl for Arabic/Persian/Hebrew strong chars,
- * ltr for Latin (and other LTR) letters. Digits alone do not set direction.
- */
-const RTL_STRONG =
-  /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
-const LTR_STRONG = /[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0400-\u04FF]/u;
-
-export const getTextDirectionFromFirstStrong = (text: string): TextDirection => {
-  for (const char of text) {
-    if (RTL_STRONG.test(char)) return 'rtl';
-    if (LTR_STRONG.test(char)) return 'ltr';
-  }
-  return null;
-};
+/** @deprecated Import from `@/utils/textDirection` instead. */
+export { getTextDirectionFromFirstStrong, type TextDirection } from '@/utils/textDirection';

--- a/src/features/Conversation/Markdown/index.tsx
+++ b/src/features/Conversation/Markdown/index.tsx
@@ -1,33 +1,60 @@
 import { type MarkdownProps } from '@lobehub/ui';
 import { Markdown } from '@lobehub/ui';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
+import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
 
-const MarkdownMessage = memo<MarkdownProps>(({ children, componentProps, ...rest }) => {
-  const { highlighterTheme, mermaidTheme, fontSize } = useUserStore(
-    userGeneralSettingsSelectors.config,
-  );
+const MarkdownMessage = memo<MarkdownProps>(
+  ({
+    children,
+    componentProps,
+    dir: dirProp,
+    streamAnimationGranularity,
+    style,
+    animated,
+    ...rest
+  }) => {
+    const { highlighterTheme, mermaidTheme, fontSize } = useUserStore(
+      userGeneralSettingsSelectors.config,
+    );
 
-  return (
-    <Markdown
-      fontSize={fontSize}
-      variant={'chat'}
-      componentProps={{
-        ...componentProps,
-        highlight: {
-          fullFeatured: true,
-          theme: highlighterTheme,
-          ...componentProps?.highlight,
-        },
-        mermaid: { fullFeatured: false, theme: mermaidTheme, ...componentProps?.mermaid },
-      }}
-      {...rest}
-    >
-      {children}
-    </Markdown>
-  );
-});
+    // Match chat input: base direction from first strong char so Persian replies
+    // align RTL even when the UI locale is English (and vice versa).
+    const autoDir = useMemo(
+      () => (typeof children === 'string' ? getTextDirectionFromFirstStrong(children) : null),
+      [children],
+    );
+
+    return (
+      <Markdown
+        fontSize={fontSize}
+        variant={'chat'}
+        componentProps={{
+          ...componentProps,
+          highlight: {
+            fullFeatured: true,
+            theme: highlighterTheme,
+            ...componentProps?.highlight,
+          },
+          mermaid: { fullFeatured: false, theme: mermaidTheme, ...componentProps?.mermaid },
+        }}
+        {...rest}
+        animated={animated}
+        dir={dirProp ?? autoDir ?? undefined}
+        // Per-character stream spans break Arabic/Persian cursive joining.
+        // Default to word granularity whenever fade-in animation is on.
+        streamAnimationGranularity={streamAnimationGranularity ?? (animated ? 'word' : undefined)}
+        style={{
+          unicodeBidi: 'plaintext',
+          ...style,
+        }}
+      >
+        {children}
+      </Markdown>
+    );
+  },
+);
 
 export default MarkdownMessage;

--- a/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
+++ b/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
@@ -13,7 +13,10 @@ interface RichTextMessageProps {
 }
 
 const LINE_HEIGHT = 1.6;
-const style: CSSProperties = { '--common-line-height': LINE_HEIGHT } as CSSProperties;
+const style: CSSProperties = {
+  '--common-line-height': LINE_HEIGHT,
+  'unicodeBidi': 'plaintext',
+} as CSSProperties;
 const EXTRA_NODES = [ActionTagNode, ReferTopicNode, LocalFileTagNode];
 
 const RichTextMessage = memo<RichTextMessageProps>(({ editorState }) => {

--- a/src/features/Conversation/Messages/useChatMarkdown.test.tsx
+++ b/src/features/Conversation/Messages/useChatMarkdown.test.tsx
@@ -68,4 +68,15 @@ describe('useChatMarkdown (assistant / grouped message pipeline)', () => {
     expect(result.current.markdownProps.animated).toBe(false);
     expect(result.current.markdownProps.enableStream).toBe(false);
   });
+
+  it('uses word-level stream animation so Persian cursive joining is preserved', () => {
+    mockTransitionMode = 'fadeIn';
+
+    const { result } = renderHook(() =>
+      useChatMarkdown({ enableStream: true, id: 'a5', isGenerating: true }),
+    );
+
+    expect(result.current.markdownProps.animated).toBe(true);
+    expect(result.current.markdownProps.streamAnimationGranularity).toBe('word');
+  });
 });

--- a/src/features/Conversation/Messages/useChatMarkdown.tsx
+++ b/src/features/Conversation/Messages/useChatMarkdown.tsx
@@ -72,6 +72,9 @@ export const useChatMarkdown = ({
         rehypePlugins,
         remarkPlugins,
         showFootnotes: !citations?.length || citations.every((item) => item.title !== item.url),
+        // Per-character stream spans break Arabic/Persian cursive joining (سلام → س ل ا م).
+        // Word granularity keeps each word in one text node — same idea as onboarding PlainTypewriter.
+        streamAnimationGranularity: 'word',
       }) satisfies Partial<MarkdownProps>,
     [animated, citations, components, enableStream],
   );

--- a/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/ChatTransitionPreview.tsx
+++ b/src/routes/(main)/settings/chat-appearance/features/ChatAppearance/ChatTransitionPreview.tsx
@@ -65,7 +65,12 @@ const ChatTransitionPreview = memo<ChatTransitionPreviewProps>(({ mode }) => {
 
   return (
     <Flexbox height={180}>
-      <Markdown enableStream animated={mode === 'fadeIn'} variant={'chat'}>
+      <Markdown
+        enableStream
+        animated={mode === 'fadeIn'}
+        streamAnimationGranularity={'word'}
+        variant={'chat'}
+      >
         {streamedContent}
       </Markdown>
     </Flexbox>

--- a/src/utils/textDirection.test.ts
+++ b/src/utils/textDirection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTextDirectionFromFirstStrong } from './textDirection';
+
+describe('getTextDirectionFromFirstStrong', () => {
+  it('returns rtl when the first strong character is Persian/Arabic', () => {
+    expect(getTextDirectionFromFirstStrong('سلام world')).toBe('rtl');
+    expect(getTextDirectionFromFirstStrong('  سلام')).toBe('rtl');
+  });
+
+  it('returns ltr when the first strong character is Latin', () => {
+    expect(getTextDirectionFromFirstStrong('hello سلام')).toBe('ltr');
+    expect(getTextDirectionFromFirstStrong('  hello')).toBe('ltr');
+  });
+
+  it('keeps rtl when English appears mid Persian sentence', () => {
+    expect(getTextDirectionFromFirstStrong('من از GPT استفاده می‌کنم')).toBe('rtl');
+  });
+
+  it('ignores leading digits and punctuation', () => {
+    expect(getTextDirectionFromFirstStrong('123 سلام')).toBe('rtl');
+    expect(getTextDirectionFromFirstStrong('...hello')).toBe('ltr');
+  });
+
+  it('returns null for empty or neutral-only text', () => {
+    expect(getTextDirectionFromFirstStrong('')).toBeNull();
+    expect(getTextDirectionFromFirstStrong('   ')).toBeNull();
+    expect(getTextDirectionFromFirstStrong('123')).toBeNull();
+  });
+});

--- a/src/utils/textDirection.ts
+++ b/src/utils/textDirection.ts
@@ -1,0 +1,18 @@
+export type TextDirection = 'ltr' | 'rtl' | null;
+
+/**
+ * First-strong character direction (Unicode bidi base direction).
+ * Skips neutrals; returns rtl for Arabic/Persian/Hebrew strong chars,
+ * ltr for Latin (and other LTR) letters. Digits alone do not set direction.
+ */
+const RTL_STRONG =
+  /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u08A0-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u;
+const LTR_STRONG = /[A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02B8\u0400-\u04FF]/u;
+
+export const getTextDirectionFromFirstStrong = (text: string): TextDirection => {
+  for (const char of text) {
+    if (RTL_STRONG.test(char)) return 'rtl';
+    if (LTR_STRONG.test(char)) return 'ltr';
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary

- **Auth locale**: Wire auth SPA through `I18nextProvider`, normalize `fa-IR`, reload Persian resources on language switch, and default `auto` locale to Persian in `index.auth.html`.
- **Sign-up layout**: Make the auth form area scrollable so tall sign-up forms no longer clip locale/theme footer controls.
- **Chat Persian streaming**: Use word-level stream animation (instead of per-character spans) so Persian cursive joining is preserved during fade-in; grapheme-safe smooth SSE queue.
- **Chat RTL/LTR**: Apply first-strong text direction + `unicode-bidi: plaintext` on message markdown (matching chat input behavior).

| Before | After |
| ------ | ----- |
| Auth locale switch unreliable; sign-up footer clipped | Persian default + scrollable signup; locale/theme always visible |
| Persian chat streamed as disconnected letters | Words stream with joined Persian glyphs |
| Responses ignored content direction | Persian → RTL, English → LTR per message |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #217

Made with [Cursor](https://cursor.com)