### PR TITLE
🐛 fix(aico): chat RTL placement, OpenRouter brand, coins contrast, onboarding پاناچت

### DIFF
--- a/src/components/Branding/brandedModelId.test.ts
+++ b/src/components/Branding/brandedModelId.test.ts
@@ -25,4 +25,24 @@ describe('brandedModelId', () => {
     expect(isBrandedOpenRouterModelId('openrouter/auto')).toBe(false);
     expect(formatBrandedModelId('openrouter/auto')).toBe('openrouter/auto');
   });
+
+  it('rewrites openrouter provider label to branding name when custom branding is on', async () => {
+    vi.doMock('@/const/version', () => ({ isCustomBranding: true }));
+    const { formatBrandedProviderId, isBrandedOpenRouterProvider } =
+      await import('./brandedModelId');
+
+    expect(isBrandedOpenRouterProvider('openrouter')).toBe(true);
+    expect(isBrandedOpenRouterProvider('OpenRouter')).toBe(true);
+    expect(formatBrandedProviderId('openrouter')).toBe(BRANDING_NAME);
+    expect(formatBrandedProviderId('openai')).toBe('openai');
+  });
+
+  it('leaves provider labels unchanged when not custom branding', async () => {
+    vi.doMock('@/const/version', () => ({ isCustomBranding: false }));
+    const { formatBrandedProviderId, isBrandedOpenRouterProvider } =
+      await import('./brandedModelId');
+
+    expect(isBrandedOpenRouterProvider('openrouter')).toBe(false);
+    expect(formatBrandedProviderId('openrouter')).toBe('openrouter');
+  });
 });

--- a/src/components/Branding/brandedModelId.ts
+++ b/src/components/Branding/brandedModelId.ts
@@ -19,3 +19,13 @@ export const formatBrandedModelId = (modelId: string): string => {
   const rest = modelId.replace(/^openrouter\/?/i, '');
   return rest ? `${getBrandingModelSlug()}/${rest}` : getBrandingModelSlug();
 };
+
+/** True when this runtime provider id should show as product brand in the UI. */
+export const isBrandedOpenRouterProvider = (provider?: string): boolean =>
+  Boolean(isCustomBranding && provider && /^openrouter$/i.test(provider.trim()));
+
+/** Display-only provider label; runtime/API ids stay `openrouter`. */
+export const formatBrandedProviderId = (provider: string): string => {
+  if (!isBrandedOpenRouterProvider(provider)) return provider;
+  return BRANDING_NAME;
+};

--- a/src/components/Branding/index.ts
+++ b/src/components/Branding/index.ts
@@ -1,8 +1,10 @@
 export { BrandedModelIcon } from './BrandedModelIcon';
 export {
   formatBrandedModelId,
+  formatBrandedProviderId,
   getBrandingModelSlug,
   isBrandedOpenRouterModelId,
+  isBrandedOpenRouterProvider,
 } from './brandedModelId';
 export { BrandedModelTag } from './BrandedModelTag';
 export { OrgBrand } from './OrgBrand';

--- a/src/features/Conversation/ChatItem/ChatItem.tsx
+++ b/src/features/Conversation/ChatItem/ChatItem.tsx
@@ -72,6 +72,9 @@ const ChatItem = memo<ChatItemProps>(
         gap={8}
         paddingBlock={8}
         style={{
+          // Keep physical L/R placement under html[dir=rtl]: logical flex-end
+          // would flip user bubbles to the left in Persian.
+          direction: 'ltr',
           paddingInlineStart: isUser ? 36 : 0,
           ...style,
         }}

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
@@ -8,6 +8,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedProviderId } from '@/components/Branding/brandedModelId';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -57,7 +58,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
             <Flexbox horizontal align={'center'} gap={8} style={{ lineHeight: '12px' }}>
               {displayName || id}
             </Flexbox>
-            <span className={styles.desc}>{provider}</span>
+            <span className={styles.desc}>{formatBrandedProviderId(provider)}</span>
           </Flexbox>
         </Flexbox>
         {!!pricing && (

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -20,7 +20,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     height: 28px;
     border-radius: 6px;
 
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
 
     :hover {
       background: ${cssVar.colorFillTertiary};

--- a/src/routes/(desktop)/desktop-onboarding/features/WelcomeStep.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/WelcomeStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BRANDING_INBOX_NAME } from '@lobechat/business-const';
+import { getLocalizedBrandingInboxName } from '@lobechat/business-const';
 import { type IconProps } from '@lobehub/ui';
 import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
@@ -19,7 +19,8 @@ interface WelcomeStepProps {
 }
 
 const WelcomeStep = memo<WelcomeStepProps>(({ onNext }) => {
-  const { t } = useTranslation('onboarding');
+  const { t, i18n } = useTranslation('onboarding');
+  const brandInboxName = getLocalizedBrandingInboxName(i18n.language);
   const updateGeneralConfig = useUserStore((s) => s.updateGeneralConfig);
 
   const handleNext = () => {
@@ -57,7 +58,7 @@ const WelcomeStep = memo<WelcomeStepProps>(({ onNext }) => {
             pauseDuration={16_000}
             typingSpeed={64}
             sentences={[
-              t('telemetry.title', { name: BRANDING_INBOX_NAME }),
+              t('telemetry.title', { name: brandInboxName }),
               t('telemetry.title2'),
               t('telemetry.title3'),
             ]}

--- a/src/routes/onboarding/features/TelemetryStep.tsx
+++ b/src/routes/onboarding/features/TelemetryStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BRANDING_INBOX_NAME, BRANDING_NAME } from '@lobechat/business-const';
+import { getLocalizedBrandingInboxName, getLocalizedBrandingName } from '@lobechat/business-const';
 import { type IconProps } from '@lobehub/ui';
 import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { Button, Switch } from '@lobehub/ui/base-ui';
@@ -20,7 +20,9 @@ interface TelemetryStepProps {
 }
 
 const TelemetryStep = memo<TelemetryStepProps>(({ onNext }) => {
-  const { t } = useTranslation('onboarding');
+  const { t, i18n } = useTranslation('onboarding');
+  const brandName = getLocalizedBrandingName(i18n.language);
+  const brandInboxName = getLocalizedBrandingInboxName(i18n.language);
   const [check, setCheck] = useState(true);
   const [isNavigating, setIsNavigating] = useState(false);
   const isNavigatingRef = useRef(false);
@@ -66,7 +68,7 @@ const TelemetryStep = memo<TelemetryStepProps>(({ onNext }) => {
             pauseDuration={16_000}
             typingSpeed={64}
             sentences={[
-              t('telemetry.title', { name: BRANDING_INBOX_NAME }),
+              t('telemetry.title', { name: brandInboxName }),
               t('telemetry.title2'),
               t('telemetry.title3'),
             ]}
@@ -121,12 +123,12 @@ const TelemetryStep = memo<TelemetryStepProps>(({ onNext }) => {
       />
       <Flexbox gap={8}>
         <Text as={'p'} color={cssVar.colorTextSecondary}>
-          {t('telemetry.rows.privacy.desc', { appName: BRANDING_NAME })}
+          {t('telemetry.rows.privacy.desc', { appName: brandName })}
         </Text>
         <Flexbox horizontal align="center" gap={8}>
           <Switch checked={check} size={'small'} onChange={(v) => setCheck(v)} />
           <Text fontSize={12} type={check ? undefined : 'secondary'}>
-            {t('telemetry.rows.privacy.title', { appName: BRANDING_NAME })}
+            {t('telemetry.rows.privacy.title', { appName: brandName })}
           </Text>
         </Flexbox>
       </Flexbox>


### PR DESCRIPTION
## Summary

- **Chat placement**: Force `direction: ltr` on ChatItem chrome so user messages stay on the physical right under Persian `html[dir=rtl]` (assistant stays left; Markdown body direction unchanged).
- **OpenRouter branding**: Add `formatBrandedProviderId` and use it in usage `ModelCard` so the subtitle shows `Panachat` instead of raw `openrouter` when custom branding is on.
- **Coins contrast**: Raise message-action Coins chip color from `colorTextSecondary` to `colorText`.
- **Onboarding FA brand**: Use `getLocalizedBrandingName` / `getLocalizedBrandingInboxName` in web TelemetryStep and desktop WelcomeStep so fa-IR shows پاناچت / پاناچت AI.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #222

Made with [Cursor](https://cursor.com)