### PR TITLE
🐛 fix(model-runtime): attribute provider requests as Panachat

### DIFF
--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BRANDING_NAME } from '@lobechat/const';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as modelParse from '../../utils/modelParse';
@@ -138,7 +139,7 @@ describe('LobeAiHubMixAI', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',
-            'APP-Code': 'Panachat',
+            'APP-Code': BRANDING_NAME,
           }),
         }),
       );
@@ -162,7 +163,7 @@ describe('LobeAiHubMixAI', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',
-            'APP-Code': 'Panachat',
+            'APP-Code': BRANDING_NAME,
           }),
         }),
       );

--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -138,7 +138,7 @@ describe('LobeAiHubMixAI', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',
-            'APP-Code': 'LobeHub',
+            'APP-Code': 'Panachat',
           }),
         }),
       );
@@ -162,7 +162,7 @@ describe('LobeAiHubMixAI', () => {
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',
-            'APP-Code': 'LobeHub',
+            'APP-Code': 'Panachat',
           }),
         }),
       );

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { CURRENT_VERSION } from '@lobechat/const';
+import { BRANDING_NAME, CURRENT_VERSION } from '@lobechat/const';
 import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -33,8 +33,8 @@ describe('LobeChatGPTAI', () => {
     expect(headers).toEqual(
       expect.objectContaining({
         'ChatGPT-Account-Id': 'account-id',
-        'User-Agent': `Panachat/${CURRENT_VERSION}`,
-        'originator': 'panachat',
+        'User-Agent': `${BRANDING_NAME}/${CURRENT_VERSION}`,
+        'originator': BRANDING_NAME.toLowerCase(),
         'session-id': expect.any(String),
         'version': CURRENT_VERSION,
       }),

--- a/packages/model-runtime/src/providers/chatGPT/index.test.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.test.ts
@@ -33,8 +33,8 @@ describe('LobeChatGPTAI', () => {
     expect(headers).toEqual(
       expect.objectContaining({
         'ChatGPT-Account-Id': 'account-id',
-        'User-Agent': `LobeHub/${CURRENT_VERSION}`,
-        'originator': 'lobehub',
+        'User-Agent': `Panachat/${CURRENT_VERSION}`,
+        'originator': 'panachat',
         'session-id': expect.any(String),
         'version': CURRENT_VERSION,
       }),

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -36,7 +36,7 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
           ...options.defaultHeaders,
           ...(chatgptAccountId && { 'ChatGPT-Account-Id': chatgptAccountId }),
           'User-Agent': USER_AGENT,
-          'originator': 'lobehub',
+          'originator': 'panachat',
           'session-id': crypto.randomUUID(),
           'version': CURRENT_VERSION,
         },

--- a/packages/model-runtime/src/providers/chatGPT/index.ts
+++ b/packages/model-runtime/src/providers/chatGPT/index.ts
@@ -36,7 +36,7 @@ export const LobeChatGPTAI = createOpenAICompatibleRuntime<ChatGPTClientOptions>
           ...options.defaultHeaders,
           ...(chatgptAccountId && { 'ChatGPT-Account-Id': chatgptAccountId }),
           'User-Agent': USER_AGENT,
-          'originator': 'panachat',
+          'originator': BRANDING_NAME.toLowerCase(),
           'session-id': crypto.randomUUID(),
           'version': CURRENT_VERSION,
         },

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -85,7 +85,7 @@ class CopilotTokenManager {
       headers: {
         'Accept': 'application/json',
         'Authorization': `Token ${githubToken}`,
-        'User-Agent': 'LobeChat/1.0',
+        'User-Agent': 'Panachat/1.0',
       },
       method: 'GET',
     });
@@ -220,8 +220,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           defaultHeaders: {
             'Authorization': `Bearer ${bearerToken}`,
             'Copilot-Integration-Id': 'vscode-chat',
-            'Editor-Plugin-Version': 'LobeChat/1.0',
-            'Editor-Version': 'LobeChat/1.0',
+            'Editor-Plugin-Version': 'Panachat/1.0',
+            'Editor-Version': 'Panachat/1.0',
             'anthropic-version': '2023-06-01',
           },
         });
@@ -283,8 +283,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
         baseURL: COPILOT_BASE_URL,
         defaultHeaders: {
           'Copilot-Integration-Id': 'vscode-chat',
-          'Editor-Plugin-Version': 'LobeChat/1.0',
-          'Editor-Version': 'LobeChat/1.0',
+          'Editor-Plugin-Version': 'Panachat/1.0',
+          'Editor-Version': 'Panachat/1.0',
         },
       });
 
@@ -452,8 +452,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
             'Accept': 'application/json',
             'Authorization': `Bearer ${bearerToken}`,
             'Copilot-Integration-Id': 'vscode-chat',
-            'Editor-Plugin-Version': 'LobeChat/1.0',
-            'Editor-Version': 'LobeChat/1.0',
+            'Editor-Plugin-Version': 'Panachat/1.0',
+            'Editor-Version': 'Panachat/1.0',
           },
           method: 'GET',
         });

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { BRANDING_NAME } from '@lobechat/const';
 import { type ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 import OpenAI from 'openai';
@@ -85,7 +86,7 @@ class CopilotTokenManager {
       headers: {
         'Accept': 'application/json',
         'Authorization': `Token ${githubToken}`,
-        'User-Agent': 'Panachat/1.0',
+        'User-Agent': `${BRANDING_NAME}/1.0`,
       },
       method: 'GET',
     });
@@ -220,8 +221,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           defaultHeaders: {
             'Authorization': `Bearer ${bearerToken}`,
             'Copilot-Integration-Id': 'vscode-chat',
-            'Editor-Plugin-Version': 'Panachat/1.0',
-            'Editor-Version': 'Panachat/1.0',
+            'Editor-Plugin-Version': `${BRANDING_NAME}/1.0`,
+            'Editor-Version': `${BRANDING_NAME}/1.0`,
             'anthropic-version': '2023-06-01',
           },
         });
@@ -283,8 +284,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
         baseURL: COPILOT_BASE_URL,
         defaultHeaders: {
           'Copilot-Integration-Id': 'vscode-chat',
-          'Editor-Plugin-Version': 'Panachat/1.0',
-          'Editor-Version': 'Panachat/1.0',
+          'Editor-Plugin-Version': `${BRANDING_NAME}/1.0`,
+          'Editor-Version': `${BRANDING_NAME}/1.0`,
         },
       });
 
@@ -452,8 +453,8 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
             'Accept': 'application/json',
             'Authorization': `Bearer ${bearerToken}`,
             'Copilot-Integration-Id': 'vscode-chat',
-            'Editor-Plugin-Version': 'Panachat/1.0',
-            'Editor-Version': 'Panachat/1.0',
+            'Editor-Plugin-Version': `${BRANDING_NAME}/1.0`,
+            'Editor-Version': `${BRANDING_NAME}/1.0`,
           },
           method: 'GET',
         });

--- a/packages/model-runtime/src/providers/higress/index.ts
+++ b/packages/model-runtime/src/providers/higress/index.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME } from '@lobechat/const';
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import type { ChatModelCard } from '@lobechat/types';
 import { uniqueId } from 'es-toolkit/compat';
 import { ModelProvider } from 'model-bank';
@@ -19,7 +19,7 @@ export interface HigressModelCard {
 export const params = {
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://chat.panafor.com',
+      'HTTP-Referer': OFFICIAL_URL,
       'X-Title': BRANDING_NAME,
       'x-Request-Id': uniqueId('lobe-chat-'),
     },

--- a/packages/model-runtime/src/providers/higress/index.ts
+++ b/packages/model-runtime/src/providers/higress/index.ts
@@ -19,7 +19,7 @@ export interface HigressModelCard {
 export const params = {
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://lobehub.com',
+      'HTTP-Referer': 'https://chat.panafor.com',
       'X-Title': BRANDING_NAME,
       'x-Request-Id': uniqueId('lobe-chat-'),
     },

--- a/packages/model-runtime/src/providers/newapi/index.test.ts
+++ b/packages/model-runtime/src/providers/newapi/index.test.ts
@@ -658,7 +658,7 @@ describe('NewAPI Runtime - 100% Branch Coverage', () => {
 
     it('should export params with correct defaultHeaders', () => {
       expect(params.defaultHeaders).toEqual({
-        'X-Client': 'LobeHub',
+        'X-Client': 'Panachat',
       });
     });
 

--- a/packages/model-runtime/src/providers/newapi/index.test.ts
+++ b/packages/model-runtime/src/providers/newapi/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BRANDING_NAME } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -658,7 +659,7 @@ describe('NewAPI Runtime - 100% Branch Coverage', () => {
 
     it('should export params with correct defaultHeaders', () => {
       expect(params.defaultHeaders).toEqual({
-        'X-Client': 'Panachat',
+        'X-Client': BRANDING_NAME,
       });
     });
 

--- a/packages/model-runtime/src/providers/newapi/index.ts
+++ b/packages/model-runtime/src/providers/newapi/index.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/const';
 import { LOBE_DEFAULT_MODEL_LIST, ModelProvider } from 'model-bank';
 import urlJoin from 'url-join';
 
@@ -76,7 +77,7 @@ export const params = {
     chatCompletion: () => process.env.DEBUG_NEWAPI_CHAT_COMPLETION === '1',
   },
   defaultHeaders: {
-    'X-Client': 'LobeHub',
+    'X-Client': BRANDING_NAME,
   },
   id: ModelProvider.NewAPI,
   models: async ({ client: openAIClient, options }) => {

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { LobeOpenAICompatibleRuntime } from '../../core/BaseAI';
@@ -60,10 +61,8 @@ describe('LobeOpenRouterAI - custom features', () => {
     it('should have constructorOptions with headers', () => {
       expect(params.constructorOptions).toBeDefined();
       expect(params.constructorOptions.defaultHeaders).toBeDefined();
-      expect(params.constructorOptions.defaultHeaders['HTTP-Referer']).toBe(
-        'https://chat.panafor.com',
-      );
-      expect(params.constructorOptions.defaultHeaders['X-Title']).toBe('Panachat');
+      expect(params.constructorOptions.defaultHeaders['HTTP-Referer']).toBe(OFFICIAL_URL);
+      expect(params.constructorOptions.defaultHeaders['X-Title']).toBe(BRANDING_NAME);
     });
 
     it('should have debug configuration', () => {

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -60,8 +60,10 @@ describe('LobeOpenRouterAI - custom features', () => {
     it('should have constructorOptions with headers', () => {
       expect(params.constructorOptions).toBeDefined();
       expect(params.constructorOptions.defaultHeaders).toBeDefined();
-      expect(params.constructorOptions.defaultHeaders['HTTP-Referer']).toBe('https://lobehub.com');
-      expect(params.constructorOptions.defaultHeaders['X-Title']).toBe('LobeHub');
+      expect(params.constructorOptions.defaultHeaders['HTTP-Referer']).toBe(
+        'https://chat.panafor.com',
+      );
+      expect(params.constructorOptions.defaultHeaders['X-Title']).toBe('Panachat');
     });
 
     it('should have debug configuration', () => {

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME } from '@lobechat/const';
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
@@ -87,7 +87,7 @@ export const params = {
   },
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://chat.panafor.com',
+      'HTTP-Referer': OFFICIAL_URL,
       'X-Title': BRANDING_NAME,
     },
   },

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -87,7 +87,7 @@ export const params = {
   },
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://lobehub.com',
+      'HTTP-Referer': 'https://chat.panafor.com',
       'X-Title': BRANDING_NAME,
     },
   },

--- a/packages/model-runtime/src/providers/togetherai/index.test.ts
+++ b/packages/model-runtime/src/providers/togetherai/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -35,8 +36,8 @@ describe('LobeTogetherAI - custom features', () => {
 
     it('should have custom defaultHeaders', () => {
       expect(params.constructorOptions?.defaultHeaders).toEqual({
-        'HTTP-Referer': 'https://chat.panafor.com',
-        'X-Title': 'Panachat',
+        'HTTP-Referer': OFFICIAL_URL,
+        'X-Title': BRANDING_NAME,
       });
     });
 

--- a/packages/model-runtime/src/providers/togetherai/index.test.ts
+++ b/packages/model-runtime/src/providers/togetherai/index.test.ts
@@ -35,8 +35,8 @@ describe('LobeTogetherAI - custom features', () => {
 
     it('should have custom defaultHeaders', () => {
       expect(params.constructorOptions?.defaultHeaders).toEqual({
-        'HTTP-Referer': 'https://chat-preview.lobehub.com',
-        'X-Title': 'Lobe Chat',
+        'HTTP-Referer': 'https://chat.panafor.com',
+        'X-Title': 'Panachat',
       });
     });
 

--- a/packages/model-runtime/src/providers/togetherai/index.ts
+++ b/packages/model-runtime/src/providers/togetherai/index.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME } from '@lobechat/const';
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import type { ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 
@@ -10,7 +10,7 @@ export const params = {
   baseURL: 'https://api.together.xyz/v1',
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://chat.panafor.com',
+      'HTTP-Referer': OFFICIAL_URL,
       'X-Title': BRANDING_NAME,
     },
   },

--- a/packages/model-runtime/src/providers/togetherai/index.ts
+++ b/packages/model-runtime/src/providers/togetherai/index.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/const';
 import type { ChatModelCard } from '@lobechat/types';
 import { ModelProvider } from 'model-bank';
 
@@ -9,8 +10,8 @@ export const params = {
   baseURL: 'https://api.together.xyz/v1',
   constructorOptions: {
     defaultHeaders: {
-      'HTTP-Referer': 'https://chat-preview.lobehub.com',
-      'X-Title': 'Lobe Chat',
+      'HTTP-Referer': 'https://chat.panafor.com',
+      'X-Title': BRANDING_NAME,
     },
   },
   debug: {

--- a/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -40,8 +41,8 @@ describe('LobeVercelAIGatewayAI - custom features', () => {
     it('should have constructor options with default headers', () => {
       expect(params.constructorOptions).toBeDefined();
       expect(params.constructorOptions?.defaultHeaders).toEqual({
-        'http-referer': 'https://chat.panafor.com',
-        'x-title': 'Panachat',
+        'http-referer': OFFICIAL_URL,
+        'x-title': BRANDING_NAME,
       });
     });
   });

--- a/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.test.ts
@@ -40,8 +40,8 @@ describe('LobeVercelAIGatewayAI - custom features', () => {
     it('should have constructor options with default headers', () => {
       expect(params.constructorOptions).toBeDefined();
       expect(params.constructorOptions?.defaultHeaders).toEqual({
-        'http-referer': 'https://lobehub.com',
-        'x-title': 'LobeHub',
+        'http-referer': 'https://chat.panafor.com',
+        'x-title': 'Panachat',
       });
     });
   });

--- a/packages/model-runtime/src/providers/vercelaigateway/index.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.ts
@@ -1,4 +1,4 @@
-import { BRANDING_NAME } from '@lobechat/const';
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
@@ -80,7 +80,7 @@ export const params = {
   },
   constructorOptions: {
     defaultHeaders: {
-      'http-referer': 'https://chat.panafor.com',
+      'http-referer': OFFICIAL_URL,
       'x-title': BRANDING_NAME,
     },
   },

--- a/packages/model-runtime/src/providers/vercelaigateway/index.ts
+++ b/packages/model-runtime/src/providers/vercelaigateway/index.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/const';
 import { ModelProvider } from 'model-bank';
 
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
@@ -79,8 +80,8 @@ export const params = {
   },
   constructorOptions: {
     defaultHeaders: {
-      'http-referer': 'https://lobehub.com',
-      'x-title': 'LobeHub',
+      'http-referer': 'https://chat.panafor.com',
+      'x-title': BRANDING_NAME,
     },
   },
   debug: {

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME, OFFICIAL_URL } from '@lobechat/const';
 import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 
 interface UriParserResult {
@@ -152,7 +153,7 @@ export const validateExternalUrl = async (url: string): Promise<ExternalUrlValid
       url,
       {
         headers: {
-          'User-Agent': 'Panachat/1.0 (https://chat.panafor.com)',
+          'User-Agent': `${BRANDING_NAME}/1.0 (${OFFICIAL_URL})`,
         },
         method: 'HEAD',
       },

--- a/packages/model-runtime/src/utils/uriParser.ts
+++ b/packages/model-runtime/src/utils/uriParser.ts
@@ -152,7 +152,7 @@ export const validateExternalUrl = async (url: string): Promise<ExternalUrlValid
       url,
       {
         headers: {
-          'User-Agent': 'LobeChat/1.0 (https://lobehub.com)',
+          'User-Agent': 'Panachat/1.0 (https://chat.panafor.com)',
         },
         method: 'HEAD',
       },


### PR DESCRIPTION
## Summary

- LLM provider attribution headers no longer advertise LobeHub / lobehub.com
- OpenRouter, Higress, TogetherAI, and Vercel AI Gateway send `HTTP-Referer: https://chat.panafor.com` and `X-Title` / `x-title` = Panachat
- NewAPI `X-Client`, AiHubMix `APP-Code`, ChatGPT Codex `originator` / User-Agent, GitHub Copilot editor headers, and external URL fetch User-Agent updated to Panachat

#### 🔗 Related Issue

Fixes #227

## Test plan

- [x] Unit tests for openrouter / togetherai / vercelaigateway / higress / newapi / aihubmix / chatGPT
- [ ] Spot-check an OpenRouter chat request in network logs: `HTTP-Referer` = `https://chat.panafor.com`, `X-Title` = `Panachat`


Made with [Cursor](https://cursor.com)