### PR TITLE
✨ feat(aico): thousand-group money InputNumber fields

### DIFF
--- a/src/features/AicoBilling/FxTopupFields.tsx
+++ b/src/features/AicoBilling/FxTopupFields.tsx
@@ -6,6 +6,8 @@ import { type FormInstance } from 'antd/es/form';
 import { createStaticStyles } from 'antd-style';
 import { useTranslation } from 'react-i18next';
 
+import { groupedNumberInputProps } from './groupedNumberInput';
+
 export type FxTopupChargeField = 'toman' | 'usd';
 
 export interface FxTopupFormValues {
@@ -111,6 +113,7 @@ export const FxTopupFields = ({
       <div className={styles.row}>
         <Form.Item label={t(tomanLabelKey)} name="amountToman" style={{ marginBottom: 0 }}>
           <InputNumber
+            {...groupedNumberInputProps}
             disabled={disabled}
             min={tomanMin}
             step={1000}
@@ -125,6 +128,7 @@ export const FxTopupFields = ({
         </Form.Item>
         <Form.Item label={t(usdLabelKey)} name="amountUsd" style={{ marginBottom: 0 }}>
           <InputNumber
+            {...groupedNumberInputProps}
             disabled={disabled}
             min={usdMin}
             step={0.5}

--- a/src/features/AicoBilling/groupedNumberInput.test.ts
+++ b/src/features/AicoBilling/groupedNumberInput.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatGroupedNumberInput, parseGroupedNumberInput } from './groupedNumberInput';
+
+describe('formatGroupedNumberInput', () => {
+  it('groups every three digits', () => {
+    expect(formatGroupedNumberInput(1000)).toBe('1,000');
+    expect(formatGroupedNumberInput(1_234_567)).toBe('1,234,567');
+    expect(formatGroupedNumberInput('1234567.89')).toBe('1,234,567.89');
+  });
+
+  it('preserves sign and empty values', () => {
+    expect(formatGroupedNumberInput(-12_345)).toBe('-12,345');
+    expect(formatGroupedNumberInput(undefined)).toBe('');
+    expect(formatGroupedNumberInput('')).toBe('');
+    expect(formatGroupedNumberInput(0)).toBe('0');
+  });
+});
+
+describe('parseGroupedNumberInput', () => {
+  it('strips ascii and unicode grouping separators', () => {
+    expect(parseGroupedNumberInput('1,234,567.89')).toBe('1234567.89');
+    expect(parseGroupedNumberInput('1٬234٬567')).toBe('1234567');
+    expect(parseGroupedNumberInput('1 234 567')).toBe('1234567');
+  });
+
+  it('normalizes arabic decimal separator', () => {
+    expect(parseGroupedNumberInput('12٫5')).toBe('12.5');
+  });
+
+  it('returns empty for missing input', () => {
+    expect(parseGroupedNumberInput(undefined)).toBe('');
+    expect(parseGroupedNumberInput('')).toBe('');
+  });
+});

--- a/src/features/AicoBilling/groupedNumberInput.ts
+++ b/src/features/AicoBilling/groupedNumberInput.ts
@@ -1,0 +1,33 @@
+/**
+ * Thousand-grouped display helpers for Ant Design `InputNumber`.
+ * Keeps Latin digits + comma grouping so paste/parse stays predictable across locales.
+ */
+
+const GROUP_SEP = /[,\u066C\s]/g;
+const ARABIC_DECIMAL = /\u066B/g;
+
+/** Format a numeric InputNumber value as `1,234,567.89`. */
+export const formatGroupedNumberInput = (value: string | number | undefined): string => {
+  if (value === undefined || value === null || value === '') return '';
+
+  const raw = String(value);
+  const negative = raw.startsWith('-');
+  const unsigned = negative ? raw.slice(1) : raw;
+  const [intPart, ...fracParts] = unsigned.split('.');
+  const grouped = intPart.replaceAll(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const body = fracParts.length > 0 ? `${grouped}.${fracParts.join('.')}` : grouped;
+
+  return negative ? `-${body}` : body;
+};
+
+/** Strip grouping separators (and normalize Persian decimal) for InputNumber parsing. */
+export const parseGroupedNumberInput = (value: string | undefined): string => {
+  if (!value) return '';
+  return value.replaceAll(ARABIC_DECIMAL, '.').replaceAll(GROUP_SEP, '');
+};
+
+/** Spread onto Ant Design `InputNumber` for thousand-separated display. */
+export const groupedNumberInputProps = {
+  formatter: formatGroupedNumberInput,
+  parser: parseGroupedNumberInput,
+} as const;

--- a/src/features/OrgAdmin/OrgAdminMembers.tsx
+++ b/src/features/OrgAdmin/OrgAdminMembers.tsx
@@ -18,6 +18,7 @@ import {
   FxTopupFields,
   type FxTopupFormValues,
 } from '@/features/AicoBilling/FxTopupFields';
+import { groupedNumberInputProps } from '@/features/AicoBilling/groupedNumberInput';
 import { aicoPanelStyles } from '@/features/AicoPanels';
 import { presentInviteLink } from '@/features/OrgAdmin/InviteLinkModal';
 import { buildPhoneVerifyRedirectUrl, isValidIranianPhoneNumber } from '@/libs/better-auth/phone';
@@ -538,10 +539,10 @@ export const OrgAdminMembers = () => {
                     />
                   </Form.Item>
                   <Form.Item
+                    label={inviteType === 'phone' ? t('org.invite.phone') : t('org.invite.email')}
                     name="identifierValue"
                     rules={[{ required: true }]}
                     style={{ flex: 1, minWidth: 220 }}
-                    label={inviteType === 'phone' ? t('org.invite.phone') : t('org.invite.email')}
                   >
                     <Input
                       autoComplete={inviteType === 'phone' ? 'tel' : 'email'}
@@ -626,7 +627,12 @@ export const OrgAdminMembers = () => {
                     rules={[{ required: true }]}
                     style={{ minWidth: 140 }}
                   >
-                    <InputNumber min={0.01} step={0.5} style={{ width: '100%' }} />
+                    <InputNumber
+                      {...groupedNumberInputProps}
+                      min={0.01}
+                      step={0.5}
+                      style={{ width: '100%' }}
+                    />
                   </Form.Item>
                 </Flexbox>
                 <Button disabled={readOnly} htmlType="submit" loading={busy} type="primary">

--- a/src/features/PlatformAdmin/PlatformAdminPanel.tsx
+++ b/src/features/PlatformAdmin/PlatformAdminPanel.tsx
@@ -20,6 +20,7 @@ import {
   type FxTopupFormValues,
   resolveFxTopupPayload,
 } from '@/features/AicoBilling/FxTopupFields';
+import { groupedNumberInputProps } from '@/features/AicoBilling/groupedNumberInput';
 import { AICO_TABLE_SCROLL, aicoPanelStyles } from '@/features/AicoPanels';
 import { useClientDataSWR } from '@/libs/swr';
 import { controlPlaneClient } from '@/libs/trpc/client/controlPlane';
@@ -562,14 +563,19 @@ export const PlatformAdminPanel = () => {
                   name="maxRequests"
                   style={{ minWidth: 160 }}
                 >
-                  <InputNumber min={1} style={{ width: '100%' }} />
+                  <InputNumber {...groupedNumberInputProps} min={1} style={{ width: '100%' }} />
                 </Form.Item>
                 <Form.Item
                   label={t('platform.trialBudgetUsd')}
                   name="trialBudgetUsd"
                   style={{ minWidth: 160 }}
                 >
-                  <InputNumber min={0.01} step={0.1} style={{ width: '100%' }} />
+                  <InputNumber
+                    {...groupedNumberInputProps}
+                    min={0.01}
+                    step={0.1}
+                    style={{ width: '100%' }}
+                  />
                 </Form.Item>
               </div>
               <Form.Item label={t('platform.trialModels')} name="allowedModelIds">


### PR DESCRIPTION
## Summary

- Add shared `formatter`/`parser` helpers so Ant Design `InputNumber` shows thousand separators (e.g. `1,250,000`)
- Apply on FX top-up toman/USD fields, org USD allocation, and platform trial max-requests / budget fields
- Cover grouping + paste/parse edge cases with unit tests

## Test plan

- [ ] Open wallet / platform credit form: type a large toman amount and confirm commas appear while the submitted value stays numeric
- [ ] Switch toman ↔ USD and confirm conversion still works with grouped display
- [ ] Org member allocate USD: enter `1234.5` / paste `1,234.5` and save successfully
- [ ] Platform trial: large max-requests / budget display with separators

Fixes #229

Plane: [AICO-141](https://plane.panafor.com/panaforai/browse/AICO-141)


Made with [Cursor](https://cursor.com)