### PR TITLE
🔒 fix(aico): harden data secrets and privacy (DATA-001…009)

### DIFF
--- a/.env.desktop
+++ b/.env.desktop
@@ -1,7 +1,8 @@
 # copy this file to .env when you want to develop the desktop app or you will fail
 APP_URL=http://localhost:3015
 FEATURE_FLAGS=-check_updates,+pin_list
-KEY_VAULTS_SECRET=oLXWIiR/AKF+rWaqy9lHkrYgzpATbW3CtJp3UfkVgpE=
+# Generate locally: openssl rand -base64 32
+KEY_VAULTS_SECRET=replace_with_local_openssl_rand_base64_32
 DATABASE_URL=postgresql://postgres@localhost:5432/postgres
 SEARCH_PROVIDERS=search1api
 DESKTOP_BUILD=true

--- a/.env.example.development
+++ b/.env.example.development
@@ -8,9 +8,10 @@ APP_URL=http://localhost:3010
 # https://lobehub.com/docs/self-hosting/environment-variables/basic#ssrf-allow-private-ip-address
 SSRF_ALLOW_PRIVATE_IP_ADDRESS=1
 
-# Secrets (pre-generated for development only)
-KEY_VAULTS_SECRET=ww+0igxjGRAAR/eTNFQ55VmhQB5KE5trFZseuntThJs=
-AUTH_SECRET=ww+0igxjGRAAR/eTNFQ55VmhQB5KE5trFZseuntThJs=
+# Secrets — generate locally (do not commit real values):
+#   openssl rand -base64 32
+KEY_VAULTS_SECRET=replace_me_generate_with_openssl_rand_base64_32
+AUTH_SECRET=replace_me_generate_with_openssl_rand_base64_32
 
 # Database (PostgreSQL)
 DATABASE_URL=postgresql://postgres:change_this_password_on_production@localhost:5432/lobechat

--- a/apps/server/src/services/mcp/index.ts
+++ b/apps/server/src/services/mcp/index.ts
@@ -309,7 +309,7 @@ export class MCPService {
         throw new TRPCError({
           cause: error,
           code: 'SERVICE_UNAVAILABLE',
-          message: errorMessage,
+          message: 'Failed to initialize MCP client',
         });
       }
 
@@ -323,7 +323,8 @@ export class MCPService {
       throw new TRPCError({
         cause: error,
         code: 'INTERNAL_SERVER_ERROR',
-        message: errorMessage, // Use complete error message directly
+        // DATA-015: generic client message; details stay in server logs above
+        message: 'Failed to initialize MCP client',
       });
     }
   }

--- a/apps/server/src/services/openrouter/management.ts
+++ b/apps/server/src/services/openrouter/management.ts
@@ -46,7 +46,12 @@ class HttpOpenRouterManagementClient implements OpenRouterManagementClient {
 
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      throw new Error(`OpenRouter Management API ${res.status}: ${body || res.statusText}`);
+      // DATA-013: do not embed upstream response bodies in Error.message
+      console.warn('[openrouter] management API error', {
+        bodyPreview: body.slice(0, 200),
+        status: res.status,
+      });
+      throw new Error(`OpenRouter Management API ${res.status}: ${res.statusText}`);
     }
 
     if (res.status === 204) return undefined as T;
@@ -116,7 +121,12 @@ export class RemoteOpenRouterManagementClient implements OpenRouterManagementCli
 
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      throw new Error(`Control plane OpenRouter proxy ${res.status}: ${body || res.statusText}`);
+      // DATA-013: do not embed upstream response bodies in Error.message
+      console.warn('[openrouter] control-plane proxy error', {
+        bodyPreview: body.slice(0, 200),
+        status: res.status,
+      });
+      throw new Error(`Control plane OpenRouter proxy ${res.status}: ${res.statusText}`);
     }
 
     if (res.status === 204) return undefined as T;

--- a/docker-compose/production/grafana/docker-compose.yml
+++ b/docker-compose/production/grafana/docker-compose.yml
@@ -174,8 +174,8 @@ services:
 
     environment:
       - 'AUTH_SSO_PROVIDERS=casdoor'
-      - 'KEY_VAULTS_SECRET=Kix2wcUONd4CX51E/ZPAd36BqM4wzJgKjPtz2sGztqQ='
-      - 'AUTH_SECRET=NX2kaPE923dt6BL2U8e9oSre5RfoT7hg'
+      - 'KEY_VAULTS_SECRET=${KEY_VAULTS_SECRET}'
+      - 'AUTH_SECRET=${AUTH_SECRET}'
       - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}'
       - 'S3_BUCKET=${MINIO_LOBE_BUCKET}'
       - 'S3_ENABLE_PATH_STYLE=1'

--- a/docs/self-hosting/platform/docker.mdx
+++ b/docs/self-hosting/platform/docker.mdx
@@ -75,14 +75,14 @@ Here is the process for deploying the LobeHub server database version on a Linux
   APP_URL=https://your-prod-domain.com
 
   # DB required environment variables
-  KEY_VAULTS_SECRET=jgwsK28dspyVQoIf8/M3IIHl1h6LYYceSYNXeLpy6uk=
+  KEY_VAULTS_SECRET=<generate with: openssl rand -base64 32>
   # Postgres database connection string
   # Format: postgres://username:password@host:port/dbname; if your pg instance is a Docker container, use the container name
   DATABASE_URL=postgres://postgres:mysecretpassword@my-postgres:5432/postgres
 
   # Authentication (Better Auth)
   # Session encryption key (generate with: openssl rand -base64 32)
-  AUTH_SECRET=jgwsK28dspyVQoIf8/M3IIHl1h6LYYceSYNXeLpy6uk=
+  AUTH_SECRET=<generate with: openssl rand -base64 32>
   # JWKS key for signing and verifying JWTs
   JWKS_KEY='{"keys":[...]}'
 
@@ -139,8 +139,8 @@ The script command you need to execute is:
 ```shell
 $ docker run -it -d --name lobehub -p 3210:3210 \
   -e DATABASE_URL=postgres://postgres:mysecretpassword@host.docker.internal:5432/postgres \
-  -e KEY_VAULTS_SECRET=jgwsK28dspyVQoIf8/M3IIHl1h6LYYceSYNXeLpy6uk= \
-  -e AUTH_SECRET=jgwsK28dspyVQoIf8/M3IIHl1h6LYYceSYNXeLpy6uk= \
+  -e KEY_VAULTS_SECRET=<generate with: openssl rand -base64 32> \
+  -e AUTH_SECRET=<generate with: openssl rand -base64 32> \
   -e JWKS_KEY='{"keys":[...]}' \
   -e APP_URL=http://localhost:3210 \
   -e S3_ACCESS_KEY_ID=xxxxxxxxxx \

--- a/locales/en-US/auth.json
+++ b/locales/en-US/auth.json
@@ -14,6 +14,8 @@
   "apikey.display.show": "Show",
   "apikey.display.unavailable": "Secret unavailable",
   "apikey.display.unavailableDescription": "This secret cannot be displayed. Recreate the API Key if you no longer have it.",
+  "apikey.form.createdDone": "Done",
+  "apikey.form.createdHint": "Copy this API key now. For security, it will not be shown again after you close this dialog.",
   "apikey.form.fields.expiresAt.label": "Expiration Date",
   "apikey.form.fields.expiresAt.placeholder": "Never expires",
   "apikey.form.fields.name.label": "Name",

--- a/locales/fa-IR/auth.json
+++ b/locales/fa-IR/auth.json
@@ -14,6 +14,8 @@
   "apikey.display.show": "نمایش",
   "apikey.display.unavailable": "کلید مخفی در دسترس نیست",
   "apikey.display.unavailableDescription": "این کلید مخفی قابل نمایش نیست. اگر دیگر آن را ندارید، کلید API را دوباره ایجاد کنید.",
+  "apikey.form.createdDone": "انجام شد",
+  "apikey.form.createdHint": "این کلید API را همین حالا کپی کنید. به‌دلایل امنیتی پس از بستن این پنجره دوباره نمایش داده نمی‌شود.",
   "apikey.form.fields.expiresAt.label": "تاریخ انقضا",
   "apikey.form.fields.expiresAt.placeholder": "بدون تاریخ انقضا",
   "apikey.form.fields.name.label": "نام",

--- a/locales/fr-FR/auth.json
+++ b/locales/fr-FR/auth.json
@@ -14,6 +14,8 @@
   "apikey.display.show": "Afficher",
   "apikey.display.unavailable": "Secret indisponible",
   "apikey.display.unavailableDescription": "Ce secret ne peut pas être affiché. Recréez la clé API si vous ne l'avez plus.",
+  "apikey.form.createdDone": "Terminé",
+  "apikey.form.createdHint": "Copiez cette clé API maintenant. Pour des raisons de sécurité, elle ne sera plus affichée après la fermeture de cette boîte de dialogue.",
   "apikey.form.fields.expiresAt.label": "Date d'expiration",
   "apikey.form.fields.expiresAt.placeholder": "N'expire jamais",
   "apikey.form.fields.name.label": "Nom",

--- a/locales/zh-CN/auth.json
+++ b/locales/zh-CN/auth.json
@@ -14,6 +14,8 @@
   "apikey.display.show": "显示",
   "apikey.display.unavailable": "密钥内容无法显示",
   "apikey.display.unavailableDescription": "当前无法显示这条密钥的内容。如果你没有留存原始密钥，请重新创建。",
+  "apikey.form.createdDone": "完成",
+  "apikey.form.createdHint": "请立即复制此 API Key。出于安全考虑，关闭此对话框后将无法再次查看。",
   "apikey.form.fields.expiresAt.label": "过期时间",
   "apikey.form.fields.expiresAt.placeholder": "永久有效",
   "apikey.form.fields.name.label": "名称",

--- a/packages/database/src/models/__tests__/apiKey.test.ts
+++ b/packages/database/src/models/__tests__/apiKey.test.ts
@@ -44,8 +44,8 @@ describe('ApiKeyModel', () => {
       expect(result.id).toBeDefined();
       expect(result.name).toBe(params.name);
       expect(result.enabled).toBe(params.enabled);
-      expect(result.key).toBeDefined();
-      expect(result.key).not.toMatch(/^sk-lh-[\da-z]{16}$/);
+      // Show-once plaintext on create
+      expect(result.key).toMatch(/^sk-lh-[\da-z]{16}$/);
       expect(result.userId).toBe(userId);
 
       const apiKey = await serverDB.query.apiKeys.findFirst({
@@ -53,6 +53,7 @@ describe('ApiKeyModel', () => {
       });
       expect(apiKey).toMatchObject({ ...params, userId });
       expect(apiKey?.key).toContain(':');
+      expect(apiKey?.key).not.toBe(result.key);
       expect(apiKey?.keyHash).toMatch(/^[\da-f]{64}$/);
     });
 
@@ -139,13 +140,14 @@ describe('ApiKeyModel', () => {
   });
 
   describe('query', () => {
-    it('should query API keys for the user', async () => {
+    it('should query API keys for the user with masked secrets only', async () => {
       await apiKeyModel.create({ name: 'Key 1', enabled: true });
       await apiKeyModel.create({ name: 'Key 2', enabled: true });
 
       const keys = await apiKeyModel.query();
       expect(keys).toHaveLength(2);
-      expect(keys[0].key).toMatch(/^sk-lh-[\da-z]{16}$/);
+      expect(keys[0].key).toBe('sk-lh-****************');
+      expect(keys[0].key).not.toMatch(/^sk-lh-[\da-z]{16}$/);
     });
 
     it('should query API keys ordered by updatedAt desc', async () => {
@@ -171,7 +173,7 @@ describe('ApiKeyModel', () => {
       expect(keys[0].name).toBe('User 1 Key');
     });
 
-    it('should keep the list available when one API key cannot be decrypted', async () => {
+    it('lists keys without decrypting vault ciphertext after secret rotation', async () => {
       const staleKey = await apiKeyModel.create({ name: 'Stale Key', enabled: true });
 
       process.env.KEY_VAULTS_SECRET = 'Q10pwdq00KXUu9R+c8A8p4PSlIRWi7KwgUophBtkHVk=';
@@ -183,9 +185,14 @@ describe('ApiKeyModel', () => {
       const freshResult = keys.find(({ id }) => id === freshKey.id);
 
       expect(keys).toHaveLength(2);
-      expect(staleResult).toMatchObject({ key: '', keyDecryptionFailed: true });
-      expect(freshResult).toMatchObject({ keyDecryptionFailed: false });
-      expect(freshResult?.key).toMatch(/^sk-lh-[\da-z]{16}$/);
+      expect(staleResult).toMatchObject({
+        key: 'sk-lh-****************',
+        keyDecryptionFailed: false,
+      });
+      expect(freshResult).toMatchObject({
+        key: 'sk-lh-****************',
+        keyDecryptionFailed: false,
+      });
     });
   });
 

--- a/packages/database/src/models/apiKey.ts
+++ b/packages/database/src/models/apiKey.ts
@@ -1,4 +1,9 @@
-import { generateApiKey, isApiKeyExpired, validateApiKeyFormat } from '@lobechat/utils/apiKey';
+import {
+  generateApiKey,
+  isApiKeyExpired,
+  MASKED_API_KEY_PLACEHOLDER,
+  validateApiKeyFormat,
+} from '@lobechat/utils/apiKey';
 import { hashApiKey } from '@lobechat/utils/server';
 import { and, desc, eq, getTableColumns } from 'drizzle-orm';
 
@@ -66,7 +71,8 @@ export class ApiKeyModel {
       )
       .returning();
 
-    return result;
+    // DATA-009: plaintext is returned only on create (show-once).
+    return { ...result, key };
   };
 
   delete = async (id: string) => {
@@ -78,10 +84,8 @@ export class ApiKeyModel {
   };
 
   /**
-   * List keys visible in the current scope. In workspace mode the caller sees
-   * every key row (with its creator), but the decrypted plaintext is returned
-   * only for the caller's own keys. Other owners' rows come back with an empty
-   * `key`; the router owns the workspace authorization policy.
+   * List keys visible in the current scope. Never returns decryptable plaintext
+   * (DATA-009) — only a masked placeholder. The router owns workspace authZ.
    */
   query = async () => {
     const rows = await this.db
@@ -96,36 +100,17 @@ export class ApiKeyModel {
       .where(this.ownership())
       .orderBy(desc(apiKeys.updatedAt));
 
-    const gateKeeper = await this.getGateKeeper();
+    return rows.map(({ creatorEmail, creatorFullName, creatorUsername, ...apiKey }) => {
+      const isMine = apiKey.userId === this.userId;
 
-    return Promise.all(
-      rows.map(async ({ creatorEmail, creatorFullName, creatorUsername, ...apiKey }) => {
-        const isMine = apiKey.userId === this.userId;
-
-        let key = '';
-        let keyDecryptionFailed = false;
-        if (isMine) {
-          const decrypted = await gateKeeper.decrypt(apiKey.key);
-
-          if (!decrypted.wasAuthentic) {
-            keyDecryptionFailed = true;
-            console.error('Failed to decrypt API key; returning the key as unavailable', {
-              apiKeyId: apiKey.id,
-            });
-          } else {
-            key = decrypted.plaintext;
-          }
-        }
-
-        return {
-          ...apiKey,
-          creator: creatorFullName || creatorUsername || creatorEmail || null,
-          isMine,
-          key,
-          keyDecryptionFailed,
-        };
-      }),
-    );
+      return {
+        ...apiKey,
+        creator: creatorFullName || creatorUsername || creatorEmail || null,
+        isMine,
+        key: isMine ? MASKED_API_KEY_PLACEHOLDER : '',
+        keyDecryptionFailed: false,
+      };
+    });
   };
 
   findByKey = async (key: string) => {

--- a/packages/locales/src/default/auth.ts
+++ b/packages/locales/src/default/auth.ts
@@ -23,6 +23,9 @@ export default {
   'apikey.form.fields.name.placeholder': 'Please enter API Key name',
   'apikey.form.submit': 'Create',
   'apikey.form.title': 'Create API Key',
+  'apikey.form.createdHint':
+    'Copy this API key now. For security, it will not be shown again after you close this dialog.',
+  'apikey.form.createdDone': 'Done',
   'apikey.list.actions.create': 'Create API Key',
   'apikey.list.actions.delete': 'Delete',
   'apikey.list.actions.deleteConfirm.actions.cancel': 'Cancel',

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -227,10 +227,12 @@ export type StreamErrorContext = {
  *   one this enrichment is meant to diagnose.
  */
 const buildStreamErrorPayload = (error: Error, context?: StreamErrorContext): string => {
+  const includeStack = process.env.NODE_ENV !== 'production';
   const payload: Record<string, unknown> = {
     message: error.message,
     name: error.name,
-    stack: error.stack,
+    // DATA-008: omit stack traces from client-facing stream errors in production
+    ...(includeStack ? { stack: error.stack } : {}),
   };
 
   if (context?.provider) payload.provider = context.provider;

--- a/packages/utils/src/apiKey.test.ts
+++ b/packages/utils/src/apiKey.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { generateApiKey, isApiKeyExpired, validateApiKeyFormat } from './apiKey';
+import { generateApiKey, isApiKeyExpired, maskApiKey, validateApiKeyFormat } from './apiKey';
 
 describe('apiKey', () => {
   describe('generateApiKey', () => {
@@ -128,6 +128,13 @@ describe('apiKey', () => {
     it('should validate generated keys', () => {
       const generatedKey = generateApiKey();
       expect(validateApiKeyFormat(generatedKey)).toBe(true);
+    });
+  });
+
+  describe('maskApiKey', () => {
+    it('masks the secret while keeping the format prefix', () => {
+      expect(maskApiKey('sk-lh-abcdef0123456789')).toBe('sk-lh-****************');
+      expect(maskApiKey('')).toBe('');
     });
   });
 });

--- a/packages/utils/src/apiKey.ts
+++ b/packages/utils/src/apiKey.ts
@@ -49,6 +49,22 @@ export function isApiKeyExpired(expiresAt: Date | null): boolean {
 }
 
 /**
+ * Mask an API key for list/display responses (DATA-009).
+ * Keeps the `sk-lh-` prefix so the UI still shows the key format.
+ */
+export function maskApiKey(key: string): string {
+  if (!key) return '';
+  const prefixEnd = key.lastIndexOf('-') + 1;
+  if (prefixEnd <= 0) return '*'.repeat(Math.min(key.length, 16));
+  return `${key.slice(0, prefixEnd)}${'*'.repeat(Math.max(0, key.length - prefixEnd))}`;
+}
+
+/**
+ * Canonical mask for listed LobeHub API keys when plaintext is unavailable.
+ */
+export const MASKED_API_KEY_PLACEHOLDER = 'sk-lh-****************';
+
+/**
  * Validate API Key format
  * @param key - API Key to validate
  * @returns Whether the key has a valid format

--- a/packages/utils/src/server/__tests__/sse.test.ts
+++ b/packages/utils/src/server/__tests__/sse.test.ts
@@ -149,7 +149,8 @@ describe('createSSEWriter', () => {
   });
 
   describe('writeError', () => {
-    it('should write error event with Error object', () => {
+    it('should write error event with Error object and stack in development', () => {
+      vi.stubEnv('NODE_ENV', 'development');
       const mockController = { enqueue: vi.fn() };
       const writer = createSSEWriter(mockController as any);
       const error = new Error('Something went wrong');
@@ -168,6 +169,22 @@ describe('createSSEWriter', () => {
       expect(mockController.enqueue).toHaveBeenCalledWith(
         expect.stringContaining('"stack":"Error: Something went wrong'),
       );
+      vi.unstubAllEnvs();
+    });
+
+    it('should omit stack traces outside development (DATA-003)', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      const mockController = { enqueue: vi.fn() };
+      const writer = createSSEWriter(mockController as any);
+      const error = new Error('Something went wrong');
+      error.stack = 'Error: Something went wrong\n  at test.ts:10';
+
+      writer.writeError(error, 'op-prod', 'processing', 1);
+
+      const call = mockController.enqueue.mock.calls[0][0] as string;
+      expect(call).toContain('"error":"Something went wrong"');
+      expect(call).not.toContain('"stack"');
+      vi.unstubAllEnvs();
     });
 
     it('should write error event without stack trace when not available', () => {

--- a/packages/utils/src/server/sse.ts
+++ b/packages/utils/src/server/sse.ts
@@ -76,7 +76,10 @@ export function createSSEWriter(controller: ReadableStreamDefaultController<stri
           data: {
             error: error.message || String(error),
             phase: phase || 'unknown',
-            ...(error.stack && { stack: error.stack }),
+            // DATA-003: never send stack traces to clients outside development
+            ...(process.env.NODE_ENV === 'development' && error.stack
+              ? { stack: error.stack }
+              : {}),
           },
           operationId,
           timestamp,

--- a/security-audit-reports/phase-03-application-data/07-data-secrets-privacy-security.md
+++ b/security-audit-reports/phase-03-application-data/07-data-secrets-privacy-security.md
@@ -1,0 +1,209 @@
+# Data, Secrets & Privacy Security Audit
+
+| Field              | Value                                                                          |
+| ------------------ | ------------------------------------------------------------------------------ |
+| **Plane**          | [AICO-108](https://plane.panafor.com/panaforai/browse/AICO-108/)               |
+| **Phase**          | Phase 3 — Application & Data Security                                          |
+| **Finding prefix** | DATA-001 …                                                                     |
+| **Audit date**     | 2026-08-10                                                                     |
+| **Method**         | Static review + targeted regression tests                                      |
+| **Scope**          | Sensitive data inventory, DB storage, logs, production errors, secret scanning |
+
+---
+
+## 1. Executive summary
+
+Aico already hashed passwords, encrypted OpenRouter / API-key vault material, stripped invite tokens from member lists, and gated TRPC stacks behind `isDev`. This audit still found **real gaps**: plaintext phone/email OTPs in `verifications`, client-facing stack traces on SSE/stream errors, committed `KEY_VAULTS_SECRET` / `AUTH_SECRET` samples, raw OIDC/MCP/OpenRouter error bodies, and forever-revealable user API keys on list.
+
+**Fixes in this delivery** close DATA-001…009 (P0/P1). DATA-010…014 are deferred / accepted with rationale below.
+
+| Severity   | Open / Accepted | Fixed |
+| ---------- | --------------: | ----: |
+| High       |               0 |     5 |
+| Medium     |               4 |     4 |
+| Low / Info |               2 |     0 |
+
+---
+
+## 2. Sensitive data inventory
+
+| Data                 | Where                                      | Protection (post-fix)                                          |
+| -------------------- | ------------------------------------------ | -------------------------------------------------------------- |
+| Password             | `accounts.password`                        | scrypt (+ bcrypt verify for migrations) — Pass                 |
+| Email OTP            | `verifications`                            | `storeOTP: "hashed"` — Fixed DATA-002                          |
+| Phone OTP            | `verifications`                            | hashed via verification hook + `verifyOTP` — Fixed DATA-001    |
+| Session token        | cookie / session table                     | HttpOnly + Secure (prod) — Pass (AUTH prior)                   |
+| Phone / Email        | `users`                                    | PII; SMS logs redacted — Pass                                  |
+| User API key         | `api_keys.key` ciphertext + `keyHash`      | Encrypted; list masked; plaintext create-only — Fixed DATA-009 |
+| OpenRouter key       | `member_budgets` / user wallets ciphertext | Encrypted; not returned on wallet SPA — Pass                   |
+| Wallet / usage / org | DB + security events                       | AuthZ + FIN audit trail — Pass (prior)                         |
+| Admin activity       | `aico_security_audit_logs`                 | Metadata contract forbids secrets — Pass                       |
+
+---
+
+## 3. Findings
+
+### DATA-001 — Phone OTP stored plaintext
+
+| Field                  | Value                                                                                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | High                                                                                                                             |
+| **Status**             | Fixed                                                                                                                            |
+| **Affected component** | Better Auth `phoneNumber` plugin / `verifications`                                                                               |
+| **Description**        | Phone plugin wrote digit OTPs as `code:attempts` plaintext.                                                                      |
+| **Fix**                | `verification.create` before-hook hashes digit OTPs; custom `verifyOTP` compares hashes with attempt limits (`phoneOtpHash.ts`). |
+| **Retest**             | Pass — `phoneOtpHash.test.ts` + `auth.security.controls.test.ts`                                                                 |
+| **Residual**           | Unused phone password-reset path still assumes plaintext if enabled without further work — Accepted until product enables it.    |
+
+### DATA-002 — Email OTP stored plaintext
+
+| Field        | Value                                                     |
+| ------------ | --------------------------------------------------------- |
+| **Severity** | High                                                      |
+| **Status**   | Fixed                                                     |
+| **Fix**      | `emailOTP({ storeOTP: 'hashed' })` in `define-config.ts`. |
+| **Retest**   | Pass — security controls assert `storeOTP: 'hashed'`.     |
+
+### DATA-003 — Agent SSE errors leak stacks
+
+| Field        | Value                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------- |
+| **Severity** | High                                                                                  |
+| **Status**   | Fixed                                                                                 |
+| **Fix**      | `createSSEWriter.writeError` includes `stack` only when `NODE_ENV === 'development'`. |
+| **Retest**   | Pass — `sse.test.ts` production case.                                                 |
+
+### DATA-004 — Hardcoded secrets in Grafana production compose
+
+| Field        | Value                                                                            |
+| ------------ | -------------------------------------------------------------------------------- |
+| **Severity** | High                                                                             |
+| **Status**   | Fixed                                                                            |
+| **Fix**      | Compose uses `${KEY_VAULTS_SECRET}` / `${AUTH_SECRET}`.                          |
+| **Note**     | Operators must rotate any environment that previously used the committed values. |
+
+### DATA-005 — Tracked `.env.desktop` secret
+
+| Field        | Value                                                                                                                                                             |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity** | High                                                                                                                                                              |
+| **Status**   | Fixed                                                                                                                                                             |
+| **Fix**      | Placeholder + generate instructions. Rotate vaults that used the old secret. Git history still contains the old value — treat as compromised for that sample key. |
+
+### DATA-006 — `.env.example.development` concrete secrets
+
+| Field        | Value              |
+| ------------ | ------------------ |
+| **Severity** | Medium             |
+| **Status**   | Fixed              |
+| **Fix**      | Placeholders only. |
+
+### DATA-007 — OIDC route echoes `error.message`
+
+| Field        | Value                                                                 |
+| ------------ | --------------------------------------------------------------------- |
+| **Severity** | Medium                                                                |
+| **Status**   | Fixed                                                                 |
+| **Fix**      | Client gets `Internal Server Error`; details stay in `console.error`. |
+
+### DATA-008 — Model stream FIRST\_CHUNK\_ERROR includes stack
+
+| Field        | Value                                                                     |
+| ------------ | ------------------------------------------------------------------------- |
+| **Severity** | Medium                                                                    |
+| **Status**   | Fixed                                                                     |
+| **Fix**      | `buildStreamErrorPayload` omits `stack` when `NODE_ENV === 'production'`. |
+
+### DATA-009 — API keys forever revealable via list
+
+| Field        | Value                                                                                                                  |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| **Severity** | Medium                                                                                                                 |
+| **Status**   | Fixed                                                                                                                  |
+| **Fix**      | `ApiKeyModel.create` returns plaintext once; `query` returns masked placeholder only; create modal shows copy-once UI. |
+| **Retest**   | Pass — `apiKey.test.ts` + UI tests.                                                                                    |
+
+### DATA-010 — Invite tokens plaintext at rest
+
+| Field         | Value                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------- |
+| **Severity**  | Medium                                                                                      |
+| **Status**    | Accepted Risk (deferred)                                                                    |
+| **Rationale** | List strips tokens; short TTL. Hash-at-rest needs invite-link redesign. Track as follow-up. |
+
+### DATA-011 — Connector `clientSecret` plaintext JSONB
+
+| Field         | Value                                                             |
+| ------------- | ----------------------------------------------------------------- |
+| **Severity**  | Medium                                                            |
+| **Status**    | Accepted Risk (deferred)                                          |
+| **Rationale** | Access tokens encrypted; clientSecret schema migration is larger. |
+
+### DATA-012 — OAuth access/refresh tokens plaintext in `accounts`
+
+| Field         | Value                                                           |
+| ------------- | --------------------------------------------------------------- |
+| **Severity**  | Medium                                                          |
+| **Status**    | Accepted Risk                                                   |
+| **Rationale** | Better Auth default; encrypting breaks BA without adapter work. |
+
+### DATA-013 — OpenRouter management errors embed response body
+
+| Field        | Value                                                |
+| ------------ | ---------------------------------------------------- |
+| **Severity** | Medium                                               |
+| **Status**   | Fixed                                                |
+| **Fix**      | Throw statusText only; log body preview server-side. |
+
+### DATA-014 — Docs sample KEY\_VAULTS / AUTH secrets
+
+| Field        | Value                     |
+| ------------ | ------------------------- |
+| **Severity** | Low                       |
+| **Status**   | Fixed (docs placeholders) |
+
+### DATA-015 — MCP init errors return raw `error.message`
+
+| Field        | Value                                             |
+| ------------ | ------------------------------------------------- |
+| **Severity** | Low                                               |
+| **Status**   | Fixed                                             |
+| **Fix**      | Generic TRPC message; details logged server-side. |
+
+### DATA-016 — Example DB URLs with passwords
+
+| Field         | Value                       |
+| ------------- | --------------------------- |
+| **Severity**  | Info                        |
+| **Status**    | Accepted                    |
+| **Rationale** | Local/CI placeholders only. |
+
+---
+
+## 4. Definition of Done checklist
+
+| Criterion                 | Status                                                                   |
+| ------------------------- | ------------------------------------------------------------------------ |
+| Sensitive data identified | ✅ Inventory section                                                     |
+| Database review           | ✅ Passwords / OTP / keys                                                |
+| Log review                | ✅ OTP not in stdout; SMS redacted (prior); OR body not in Error.message |
+| Error handling review     | ✅ OIDC / SSE / stream / MCP                                             |
+| Secret scan               | ✅ Compose / .env.desktop / examples / docs scrubbed                     |
+| Git history               | ⚠️ Old sample secrets remain in history — rotate operational keys        |
+
+---
+
+## 5. Key files
+
+| Path                                                                                   | Role                    |
+| -------------------------------------------------------------------------------------- | ----------------------- |
+| `src/libs/better-auth/define-config.ts`                                                | OTP hashing config      |
+| `src/libs/better-auth/phoneOtpHash.ts`                                                 | Phone OTP hash helpers  |
+| `packages/utils/src/server/sse.ts`                                                     | SSE stack gating        |
+| `packages/model-runtime/src/core/streams/protocol.ts`                                  | Stream error payload    |
+| `packages/database/src/models/apiKey.ts`                                               | Show-once / masked list |
+| `security-audit-reports/phase-03-application-data/07-data-secrets-privacy-security.md` | This report             |
+
+---
+
+_Retest file (if needed): `07-data-secrets-privacy-security-retest.md`_

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -89,7 +89,8 @@ const handler = async (req: NextRequest) => {
     // `lobe-oidc:route` namespace, which is disabled in production, so 500s otherwise
     // land with no application-layer error signature (monitoring blind spot).
     console.error(`[OIDC Route] Error handling ${req.method} ${requestUrl.pathname}:`, error);
-    return new NextResponse(`Internal Server Error: ${(error as Error).message}`, { status: 500 });
+    // DATA-007: never echo raw error.message (SQL / paths / internals) to clients
+    return new NextResponse('Internal Server Error', { status: 500 });
   }
 };
 

--- a/src/libs/better-auth/auth.security.controls.test.ts
+++ b/src/libs/better-auth/auth.security.controls.test.ts
@@ -196,6 +196,7 @@ describe('AICO-102 authentication security controls', () => {
         allowedAttempts: 3,
         expiresIn: 300,
         otpLength: 6,
+        storeOTP: 'hashed',
       }),
     );
     expect(phoneNumber).toHaveBeenCalledWith(
@@ -203,6 +204,7 @@ describe('AICO-102 authentication security controls', () => {
         allowedAttempts: 3,
         expiresIn: 300,
         otpLength: 6,
+        verifyOTP: expect.any(Function),
       }),
     );
   });

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -21,6 +21,7 @@ import {
   getVerificationOTPEmailTemplate,
 } from '@/libs/better-auth/email-templates';
 import { isValidIranianPhoneNumber, normalizeIranianPhoneNumber } from '@/libs/better-auth/phone';
+import { hashPhoneOtpVerificationValue, phoneOtpEquals } from '@/libs/better-auth/phoneOtpHash';
 import { aicoBanMessage } from '@/libs/better-auth/plugins/aico-ban-message';
 import { authAbuseSignal } from '@/libs/better-auth/plugins/auth-abuse-signal';
 import { emailWhitelist } from '@/libs/better-auth/plugins/email-whitelist';
@@ -238,6 +239,21 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
           },
         },
       },
+      /**
+       * DATA-001: Better Auth phone plugin stores OTP plaintext. Hash digit OTPs at insert
+       * so `verifications.value` is never a usable code. Email OTPs use `storeOTP: "hashed"`
+       * and do not match the plain-digit pattern.
+       */
+      verification: {
+        create: {
+          before: async (verification) => ({
+            data: {
+              ...verification,
+              value: hashPhoneOtpVerificationValue(String(verification.value ?? '')),
+            },
+          }),
+        },
+      },
       user: {
         create: {
           after: async (user) => {
@@ -326,6 +342,8 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
         expiresIn: OTP_EXPIRES_IN,
         otpLength: 6,
         allowedAttempts: 3,
+        // DATA-002: never persist usable OTP plaintext in `verifications`
+        storeOTP: 'hashed',
         // Don't automatically send OTP on sign up - let mobile client manually trigger it
         sendVerificationOnSignUp: false,
         async sendVerificationOTP({ email, otp }) {
@@ -373,6 +391,36 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
             console.error('[sms] failed to send OTP', { phone: phoneFingerprint, error });
             throw error;
           }
+        },
+        /**
+         * DATA-001: compare against hashed OTP (see verification.create before-hook).
+         * Replaces BA plaintext equality while preserving attempt limits.
+         */
+        verifyOTP: async ({ phoneNumber: rawPhone, code }, ctx) => {
+          if (!ctx) return false;
+          const phone = normalizeIranianPhoneNumber(rawPhone) ?? rawPhone;
+          const row = await ctx.context.internalAdapter.findVerificationValue(phone);
+          if (!row || row.expiresAt < new Date()) return false;
+
+          const colon = row.value.lastIndexOf(':');
+          const storedHash = colon === -1 ? row.value : row.value.slice(0, colon);
+          const attemptsRaw = colon === -1 ? '0' : row.value.slice(colon + 1);
+          const attempts = Number.parseInt(attemptsRaw || '0', 10);
+          const allowedAttempts = 3;
+
+          if (Number.isFinite(attempts) && attempts >= allowedAttempts) {
+            await ctx.context.internalAdapter.deleteVerificationByIdentifier(phone);
+            return false;
+          }
+
+          if (!phoneOtpEquals(code, storedHash)) {
+            await ctx.context.internalAdapter.updateVerificationByIdentifier(phone, {
+              value: `${storedHash}:${attempts + 1}`,
+            });
+            return false;
+          }
+
+          return true;
         },
       }),
       passkey({

--- a/src/libs/better-auth/phoneOtpHash.test.ts
+++ b/src/libs/better-auth/phoneOtpHash.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hashPhoneOtp,
+  hashPhoneOtpVerificationValue,
+  isPlainPhoneOtpValue,
+  phoneOtpEquals,
+} from './phoneOtpHash';
+
+describe('phoneOtpHash (DATA-001)', () => {
+  it('detects plain digit OTP values with optional attempts', () => {
+    expect(isPlainPhoneOtpValue('123456')).toBe(true);
+    expect(isPlainPhoneOtpValue('123456:0')).toBe(true);
+    expect(isPlainPhoneOtpValue('123456:2')).toBe(true);
+    expect(isPlainPhoneOtpValue('not-an-otp')).toBe(false);
+    expect(isPlainPhoneOtpValue(hashPhoneOtp('123456'))).toBe(false);
+  });
+
+  it('hashes OTP while preserving attempt counters', () => {
+    const hashed = hashPhoneOtpVerificationValue('654321:1');
+    expect(hashed.endsWith(':1')).toBe(true);
+    expect(hashed.startsWith('654321')).toBe(false);
+    expect(phoneOtpEquals('654321', hashed.slice(0, hashed.lastIndexOf(':')))).toBe(true);
+    expect(phoneOtpEquals('000000', hashed.slice(0, hashed.lastIndexOf(':')))).toBe(false);
+  });
+
+  it('is idempotent for already-hashed values', () => {
+    const once = hashPhoneOtpVerificationValue('111222:0');
+    expect(hashPhoneOtpVerificationValue(once)).toBe(once);
+  });
+});

--- a/src/libs/better-auth/phoneOtpHash.ts
+++ b/src/libs/better-auth/phoneOtpHash.ts
@@ -1,0 +1,31 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Hash a phone OTP the same way Better Auth hashes email OTPs (SHA-256 → base64url).
+ * Phone plugin has no `storeOTP` option, so we hash at rest ourselves (DATA-001).
+ */
+export const hashPhoneOtp = (otp: string): string =>
+  createHash('sha256').update(otp, 'utf8').digest('base64url');
+
+export const phoneOtpEquals = (plainOtp: string, storedHash: string): boolean => {
+  const hashed = Buffer.from(hashPhoneOtp(plainOtp), 'utf8');
+  const stored = Buffer.from(storedHash, 'utf8');
+  if (hashed.length !== stored.length) return false;
+  return timingSafeEqual(hashed, stored);
+};
+
+/** Plain digit OTP optionally followed by `:attempts` (Better Auth phone format). */
+export const isPlainPhoneOtpValue = (value: string): boolean => /^\d{4,10}(?::\d+)?$/.test(value);
+
+/**
+ * Rewrite a phone verification `value` so the OTP digits are hashed.
+ * Leaves already-hashed / non-OTP values unchanged.
+ */
+export const hashPhoneOtpVerificationValue = (value: string): string => {
+  if (!isPlainPhoneOtpValue(value)) return value;
+  const colon = value.lastIndexOf(':');
+  if (colon === -1) return hashPhoneOtp(value);
+  const otp = value.slice(0, colon);
+  const attempts = value.slice(colon + 1);
+  return `${hashPhoneOtp(otp)}:${attempts}`;
+};

--- a/src/routes/(main)/settings/apikey/features/ApiKey.test.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKey.test.tsx
@@ -111,7 +111,7 @@ const makeItem = (over: Partial<ApiKeyItem> = {}): ApiKeyItem => ({
   enabled: true,
   id: 'key-1',
   isMine: true,
-  key: 'lb-plain-secret',
+  key: 'sk-lh-****************',
   lastUsedAt: null,
   name: 'My Key',
   updatedAt: new Date('2026-01-01'),
@@ -169,7 +169,7 @@ describe('ApiKey', () => {
     renderPage();
 
     expect(await screen.findByText('My Key')).toBeInTheDocument();
-    expect(screen.getByText('lb-plain-secret')).toBeInTheDocument();
+    expect(screen.getByText('sk-lh-****************')).toBeInTheDocument();
     expect(screen.getByRole('switch')).toBeChecked();
   });
 
@@ -288,7 +288,7 @@ describe('ApiKey', () => {
     ).toBeEnabled();
 
     const mineRow = screen.getByText('My Key').closest('tr')!;
-    expect(within(mineRow).getByText('lb-plain-secret')).toBeInTheDocument();
+    expect(within(mineRow).getByText('sk-lh-****************')).toBeInTheDocument();
     expect(within(mineRow).getByRole('button', { name: 'edit-text' })).toBeEnabled();
     expect(within(mineRow).getByRole('switch')).toBeEnabled();
   });

--- a/src/routes/(main)/settings/apikey/features/ApiKey.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKey.tsx
@@ -98,7 +98,8 @@ const ApiKey: FC = () => {
     if (!canCreate) return;
     createApiKeyModal({
       onSubmit: async (values) => {
-        await createMutation.mutateAsync(values);
+        const created = await createMutation.mutateAsync(values);
+        return { key: created.key };
       },
     });
   };

--- a/src/routes/(main)/settings/apikey/features/ApiKeyModal/Content.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKeyModal/Content.tsx
@@ -10,13 +10,14 @@ import { useTranslation } from 'react-i18next';
 import { type CreateApiKeyParams } from '@/types/apiKey';
 
 import ApiKeyDatePicker from '../ApiKeyDatePicker';
+import ApiKeyDisplay from '../ApiKeyDisplay';
 
 type FormValues = Omit<CreateApiKeyParams, 'expiresAt'> & {
   expiresAt: Dayjs | null;
 };
 
 export interface ApiKeyModalContentProps {
-  onSubmit: (values: CreateApiKeyParams) => Promise<void>;
+  onSubmit: (values: CreateApiKeyParams) => Promise<{ key?: string } | void>;
 }
 
 const ApiKeyModalContent: FC<ApiKeyModalContentProps> = ({ onSubmit }) => {
@@ -24,14 +25,19 @@ const ApiKeyModalContent: FC<ApiKeyModalContentProps> = ({ onSubmit }) => {
   const { close } = useModalContext();
   const [form] = Form.useForm<FormValues>();
   const [loading, setLoading] = useState(false);
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
 
   const handleFinish = async (values: FormValues) => {
     setLoading(true);
     try {
-      await onSubmit({
+      const result = await onSubmit({
         ...values,
         expiresAt: values.expiresAt ? values.expiresAt.toDate() : null,
       } satisfies CreateApiKeyParams);
+      if (result?.key) {
+        setCreatedKey(result.key);
+        return;
+      }
       close();
     } finally {
       setLoading(false);
@@ -39,6 +45,24 @@ const ApiKeyModalContent: FC<ApiKeyModalContentProps> = ({ onSubmit }) => {
   };
 
   const itemStyle = { marginBottom: 0 };
+
+  if (createdKey) {
+    return (
+      <Flexbox gap={16}>
+        <div>{t('apikey.form.createdHint')}</div>
+        <ApiKeyDisplay apiKey={createdKey} />
+        <Button
+          block
+          type={'primary'}
+          onClick={() => {
+            close();
+          }}
+        >
+          {t('apikey.form.createdDone')}
+        </Button>
+      </Flexbox>
+    );
+  }
 
   return (
     <Form colon={false} form={form} layout={'vertical'} onFinish={handleFinish}>


### PR DESCRIPTION
<!-- Brief and heads-up -->

Hardens sensitive-data handling for AICO-108: hashed OTPs, production stack stripping, scrubbed committed vault secrets, sanitized error surfaces, and show-once API keys.

| Before | After |
| ------ | ----- |
| Plaintext OTPs in `verifications`; SSE/stream stacks to clients; sample KEY_VAULTS/AUTH in repo; raw OIDC/MCP/OR errors; API keys decryptable forever via list | Hashed OTPs; stacks only in development; placeholders/env for secrets; generic client errors; create-once plaintext + masked list |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --test` on OTP/hash, SSE, API key model/UI, auth security controls.

#### 🔗 Related Issue

Fixes #231

Plane: [AICO-108](https://plane.panafor.com/panaforai/browse/AICO-108/)