### PR TITLE
🔒 fix(aico): harden OpenRouter integration security (AICO-106)

### DIFF
--- a/apps/server/src/routers/lambda/organization.ts
+++ b/apps/server/src/routers/lambda/organization.ts
@@ -404,12 +404,23 @@ export const organizationRouter = router({
         });
       }
 
-      // Local access is already revocation_pending. Durable outbox handles OR
-      // disable + settlement — OpenRouter downtime must not block removal.
+      // OR-005: best-effort sync disable so the OR key stops spending immediately.
+      // Durable outbox still owns settlement + retry if OpenRouter is down.
       const budget = await ctx.organizationModel.getMemberBudgetForOrg({
         orgId: input.orgId,
         orgMemberId: input.memberId,
       });
+      if (budget?.openrouterKeyId) {
+        try {
+          const keyService = new AicoOpenRouterKeyService(ctx.serverDB);
+          await keyService.disableMemberKey(input.memberId);
+        } catch (error) {
+          console.warn(
+            '[aico] sync disableMemberKey on remove failed; outbox will retry reclaim',
+            error,
+          );
+        }
+      }
       await ctx.serverDB.insert(aicoKeyOutbox).values({
         action: 'reclaim_member',
         nextAttemptAt: new Date(),

--- a/apps/server/src/services/aico/keyOutbox.disableUserKey.test.ts
+++ b/apps/server/src/services/aico/keyOutbox.disableUserKey.test.ts
@@ -1,0 +1,85 @@
+/**
+ * OR-001 — soft-delete outbox action disable_user_key must disable the personal OR key.
+ */
+// @vitest-environment node
+import type { LobeChatDatabase } from '@lobechat/database';
+import { getTestDB } from '@lobechat/database/test-utils';
+import { and, eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AicoBillingModel } from '@/database/models/aicoBilling';
+import { users } from '@/database/schemas';
+import {
+  aicoAccountTombs,
+  aicoKeyOutbox,
+  userWallets,
+  walletTransactions,
+} from '@/database/schemas/aicoOrganization';
+import { processKeyOutbox } from '@/server/services/aico/renewalScheduler';
+import { AicoSoftDeleteService } from '@/server/services/aico/softDelete';
+import type { AicoOpenRouterKeyService } from '@/server/services/openrouter/keyService';
+
+const userId = 'or-001-soft-delete-user';
+
+describe('OR-001 processKeyOutbox disable_user_key', () => {
+  let db: LobeChatDatabase;
+
+  beforeEach(async () => {
+    db = await getTestDB();
+    await db.delete(aicoKeyOutbox);
+    await db.delete(aicoAccountTombs);
+    await db.delete(walletTransactions);
+    await db.delete(userWallets);
+    await db.delete(users);
+    await db.insert(users).values({ email: 'or001@example.com', id: userId });
+  });
+
+  afterEach(async () => {
+    await db.delete(aicoKeyOutbox);
+    await db.delete(aicoAccountTombs);
+    await db.delete(walletTransactions);
+    await db.delete(userWallets);
+    await db.delete(users);
+  });
+
+  it('soft-delete enqueues disable_user_key and outbox disables the personal key', async () => {
+    const billing = new AicoBillingModel(db);
+    await billing.manualCreditUser({
+      amountMicroUsd: 5_000_000,
+      amountToman: 25_000,
+      createdByUserId: userId,
+      fxRateTomanPerUsd: 5000,
+      userId,
+    });
+    await billing.updateUserOpenRouterKey({
+      ciphertext: 'cipher',
+      keyId: 'or-key-personal',
+      userId,
+    });
+
+    const softDelete = new AicoSoftDeleteService(db);
+    await softDelete.softDeleteUser({ deletedByUserId: userId, userId });
+
+    const pending = await db
+      .select()
+      .from(aicoKeyOutbox)
+      .where(and(eq(aicoKeyOutbox.userId, userId), eq(aicoKeyOutbox.action, 'disable_user_key')));
+    expect(pending).toHaveLength(1);
+    expect(pending[0].status).toBe('pending');
+
+    const disableUserKey = vi.fn(async () => ({ disabled: true, hash: 'or-key-personal' }));
+    const keyService = {
+      disableUserKey,
+    } as unknown as AicoOpenRouterKeyService;
+
+    const result = await processKeyOutbox(db, { keyService });
+    expect(result.succeeded).toBeGreaterThanOrEqual(1);
+    expect(disableUserKey).toHaveBeenCalledWith(userId);
+
+    const rows = await db
+      .select()
+      .from(aicoKeyOutbox)
+      .where(and(eq(aicoKeyOutbox.userId, userId), eq(aicoKeyOutbox.action, 'disable_user_key')));
+    expect(rows.every((r) => r.status === 'succeeded')).toBe(true);
+  });
+});

--- a/apps/server/src/services/aico/managedPolicy.test.ts
+++ b/apps/server/src/services/aico/managedPolicy.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  AicoManagedPolicy,
-  AicoManagedPolicyError,
-} from './managedPolicy';
 import { parseAicoBillingContext } from './billingContext';
+import { AicoManagedPolicy, AicoManagedPolicyError } from './managedPolicy';
 
 describe('explicit billing context + managed policy', () => {
   it('rejects missing / invalid billing context', () => {
@@ -17,9 +14,10 @@ describe('explicit billing context + managed policy', () => {
 
   it('accepts personal and organization shapes', () => {
     expect(parseAicoBillingContext({ source: 'personal' })).toEqual({ source: 'personal' });
-    expect(
-      parseAicoBillingContext({ source: 'organization', organizationId: 'org_1' }),
-    ).toEqual({ organizationId: 'org_1', source: 'organization' });
+    expect(parseAicoBillingContext({ source: 'organization', organizationId: 'org_1' })).toEqual({
+      organizationId: 'org_1',
+      source: 'organization',
+    });
   });
 
   it('treats aico and openrouter as managed', () => {
@@ -32,5 +30,15 @@ describe('explicit billing context + managed policy', () => {
     const err = new AicoManagedPolicyError('BILLING_CONTEXT_REQUIRED');
     expect(err.code).toBe('BILLING_CONTEXT_REQUIRED');
     expect(err.name).toBe('AicoManagedPolicyError');
+  });
+
+  it('OR-003: authorize requires modelId for managed providers', async () => {
+    const policy = new AicoManagedPolicy({} as any, async () => null);
+    await expect(
+      policy.authorize({ billing: { source: 'personal' }, userId: 'u1' }),
+    ).rejects.toMatchObject({ code: 'MODEL_ID_REQUIRED' });
+    await expect(
+      policy.authorize({ billing: { source: 'personal' }, modelId: '   ', userId: 'u1' }),
+    ).rejects.toMatchObject({ code: 'MODEL_ID_REQUIRED' });
   });
 });

--- a/apps/server/src/services/aico/managedPolicy.ts
+++ b/apps/server/src/services/aico/managedPolicy.ts
@@ -88,9 +88,12 @@ export class AicoManagedPolicy {
       throw new AicoManagedPolicyError(code, ChatErrorType.BadRequest);
     }
 
-    if (params.modelId) {
-      await this.assertModelAllowed(params.userId, billing, params.modelId);
+    // OR-003: managed keys must always bind to an explicit model — omitting modelId
+    // previously skipped the allow-list while still injecting the member/user key.
+    if (!params.modelId?.trim()) {
+      throw new AicoManagedPolicyError('MODEL_ID_REQUIRED', ChatErrorType.BadRequest);
     }
+    await this.assertModelAllowed(params.userId, billing, params.modelId);
 
     if (billing.source === 'personal') {
       // Trial uses personal wallet key path but product Trial is disabled in prod.

--- a/apps/server/src/services/aico/renewalScheduler.ts
+++ b/apps/server/src/services/aico/renewalScheduler.ts
@@ -10,7 +10,11 @@ import {
   walletTransactions,
 } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
-import { type BudgetPeriod, confirmedUnusedMicro, periodToOpenRouterLimitReset } from '@/database/utils/aicoMoney';
+import {
+  type BudgetPeriod,
+  confirmedUnusedMicro,
+  periodToOpenRouterLimitReset,
+} from '@/database/utils/aicoMoney';
 import { AicoOpenRouterKeyService } from '@/server/services/openrouter/keyService';
 
 import { computePeriodWindow } from './periodBoundaries';
@@ -100,9 +104,7 @@ export const processDueRenewals = async (
     const prepaidMicroUsd = Number(row.budget.pendingPeriodAmountMicroUsd ?? 0);
     const nextPeriod = (row.budget.pendingPeriod ?? row.budget.period) as BudgetPeriod;
     const nextPeriodAmountMicroUsd =
-      prepaidMicroUsd > 0
-        ? prepaidMicroUsd
-        : Number(row.budget.periodAmountMicroUsd ?? 0);
+      prepaidMicroUsd > 0 ? prepaidMicroUsd : Number(row.budget.periodAmountMicroUsd ?? 0);
     const due: DueBudget = {
       budgetId: row.budget.id,
       currentPeriod: row.budget.period as BudgetPeriod,
@@ -525,6 +527,13 @@ const runOutboxAction = async (params: {
     case 'disable_member_key': {
       if (!row.orgMemberId) throw new Error('ORG_MEMBER_ID_REQUIRED');
       await keyService.disableMemberKey(row.orgMemberId);
+      return;
+    }
+
+    // OR-001: soft-delete enqueues disable_user_key; must actually disable the personal OR key.
+    case 'disable_user_key': {
+      if (!row.userId) throw new Error('USER_ID_REQUIRED');
+      await keyService.disableUserKey(row.userId);
       return;
     }
 

--- a/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
+++ b/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
@@ -233,7 +233,7 @@ describe('Aico OpenRouter failure injection (Phase 2)', () => {
     expect(client.keys.size).toBe(0); // must not create key for zero budget
   });
 
-  it('OpenRouter succeeds then DB key update failure leaves orphan key', async () => {
+  it('OR-002: OpenRouter succeeds then DB key update failure retires orphan key', async () => {
     const billing = new AicoBillingModel(db);
     const client = new ControllableOpenRouterClient();
     const keys = new AicoOpenRouterKeyService(db, client);
@@ -252,7 +252,7 @@ describe('Aico OpenRouter failure injection (Phase 2)', () => {
     };
 
     await expect(keys.ensureUserKey(userId)).rejects.toThrow(/DB write failed/);
-    expect(client.keys.size).toBe(1); // orphan on OpenRouter side
+    expect(client.keys.size).toBe(0); // OR-002: orphan retired (disable+delete)
     const wallet = await billing.getUserWallet(userId);
     expect(wallet?.openrouterKeyId).toBeFalsy();
   });

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -136,18 +136,11 @@ export class AicoOpenRouterKeyService {
         return { created: false, keyId: null };
       }
 
-      const created = await this.client.createKey({
-        limitReset: null,
+      return this.createAndPersistUserKey({
         limitUsd,
         name: `aico-user-${userId}`,
-      });
-      const encrypted = await this.encryptKey(created.key);
-      await this.billingModel.updateUserOpenRouterKey({
-        ciphertext: encrypted,
-        keyId: created.hash,
         userId,
       });
-      return { created: true, keyId: created.hash };
     });
   };
 
@@ -165,18 +158,11 @@ export class AicoOpenRouterKeyService {
         return { created: false, keyId: wallet.openrouterKeyId };
       }
 
-      const created = await this.client.createKey({
-        limitReset: null,
+      return this.createAndPersistUserKey({
         limitUsd: microToOpenRouterLimitUsd(budgetMicro),
         name: `aico-trial-${userId}`,
-      });
-      const encrypted = await this.encryptKey(created.key);
-      await this.billingModel.updateUserOpenRouterKey({
-        ciphertext: encrypted,
-        keyId: created.hash,
         userId,
       });
-      return { created: true, keyId: created.hash };
     });
   };
 
@@ -230,15 +216,51 @@ export class AicoOpenRouterKeyService {
         limitUsd,
         name: `aico-member-${orgMemberId}`,
       });
-      const encrypted = await this.encryptKey(created.key);
-      await this.orgModel.updateMemberOpenRouterKey({
-        ciphertext: encrypted,
-        keyId: created.hash,
-        orgMemberId,
-      });
+      try {
+        const encrypted = await this.encryptKey(created.key);
+        await this.orgModel.updateMemberOpenRouterKey({
+          ciphertext: encrypted,
+          keyId: created.hash,
+          orgMemberId,
+        });
+      } catch (error) {
+        // OR-002: OR create succeeded but DB persist failed — retire orphan spendable key.
+        console.error('[aico] member OpenRouter key persist failed; retiring orphan key', error);
+        await this.retireManagedKey(created.hash);
+        throw error;
+      }
       return { created: true, keyId: created.hash };
     });
   };
+
+  /**
+   * OR-002: create on OpenRouter then persist ciphertext. If DB write fails after
+   * createKey, immediately retire the orphan so it cannot spend against the master account.
+   */
+  private async createAndPersistUserKey(params: {
+    limitUsd: number;
+    name: string;
+    userId: string;
+  }): Promise<{ created: true; keyId: string }> {
+    const created = await this.client.createKey({
+      limitReset: null,
+      limitUsd: params.limitUsd,
+      name: params.name,
+    });
+    try {
+      const encrypted = await this.encryptKey(created.key);
+      await this.billingModel.updateUserOpenRouterKey({
+        ciphertext: encrypted,
+        keyId: created.hash,
+        userId: params.userId,
+      });
+    } catch (error) {
+      console.error('[aico] user OpenRouter key persist failed; retiring orphan key', error);
+      await this.retireManagedKey(created.hash);
+      throw error;
+    }
+    return { created: true, keyId: created.hash };
+  }
 
   disableMemberKey = async (orgMemberId: string) => {
     const budget = await this.orgModel.getMemberBudget(orgMemberId);
@@ -324,9 +346,7 @@ export class AicoOpenRouterKeyService {
     const limitMicro =
       info.limit == null ? currentCycle : Number(openRouterUsdToMicroFloor(info.limit));
     const remainingFromOr =
-      info.limitRemaining == null
-        ? null
-        : Number(openRouterUsdToMicroFloor(info.limitRemaining));
+      info.limitRemaining == null ? null : Number(openRouterUsdToMicroFloor(info.limitRemaining));
 
     // Detect post-reset OR counters while Aico still holds closing-period spend.
     const looksReset =

--- a/apps/server/src/services/openrouter/management.ts
+++ b/apps/server/src/services/openrouter/management.ts
@@ -252,8 +252,8 @@ export const createOpenRouterManagementClient = (
   const isProduction = process.env.NODE_ENV === 'production';
   const isControlPlane = aicoEnv.AICO_IS_CONTROL_PLANE;
 
-  // Product servers must never hold the OpenRouter management key.
-  if (!isControlPlane && aicoEnv.OPENROUTER_MANAGEMENT_API_KEY && isProduction) {
+  // OR-008: product process must never hold the management key (any NODE_ENV).
+  if (!isControlPlane && aicoEnv.OPENROUTER_MANAGEMENT_API_KEY) {
     throw new Error(
       'OPENROUTER_MANAGEMENT_API_KEY must not be set on the product server — configure AICO_CONTROL_PLANE_URL + AICO_CONTROL_PLANE_SERVICE_TOKEN instead.',
     );
@@ -265,7 +265,7 @@ export const createOpenRouterManagementClient = (
     if (remote) return remote;
   }
 
-  // Control plane (or explicit local key in non-prod) talks to OpenRouter directly.
+  // Control plane talks to OpenRouter directly with the management key.
   if (aicoEnv.OPENROUTER_MANAGEMENT_API_KEY) {
     return new HttpOpenRouterManagementClient(aicoEnv.OPENROUTER_MANAGEMENT_API_KEY);
   }

--- a/apps/server/src/services/openrouter/remoteManagementClient.test.ts
+++ b/apps/server/src/services/openrouter/remoteManagementClient.test.ts
@@ -144,6 +144,19 @@ describe('createOpenRouterManagementClient product / control-plane rules', () =>
     }
   });
 
+  it('OR-008: non-production product server also rejects embedded management key', () => {
+    const prevNode = process.env.NODE_ENV;
+    try {
+      (process.env as { NODE_ENV?: string }).NODE_ENV = 'development';
+      aicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-should-not-be-here';
+      expect(() => createOpenRouterManagementClient({})).toThrow(
+        /must not be set on the product server/,
+      );
+    } finally {
+      (process.env as { NODE_ENV?: string }).NODE_ENV = prevNode;
+    }
+  });
+
   it('production product server requires control plane URL when no management key', () => {
     const prevNode = process.env.NODE_ENV;
     try {

--- a/security-audit-reports/phase-02-business-logic/05-openrouter-integration-security.md
+++ b/security-audit-reports/phase-02-business-logic/05-openrouter-integration-security.md
@@ -1,0 +1,230 @@
+# OpenRouter Integration Security Audit
+
+| Field              | Value                                                                                                   |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| **Plane**          | [AICO-106](https://plane.panafor.com/panaforai/browse/AICO-106/)                                        |
+| **Phase**          | Phase 2 — Business Logic & Multi-Tenancy Security                                                       |
+| **Finding prefix** | OR-001 …                                                                                                |
+| **Audit date**     | 2026-08-11                                                                                              |
+| **Method**         | Static review + key lifecycle / outbox / managed-policy regression tests                                |
+| **Scope**          | Master management key, per-member/user OpenRouter keys, model allow-list, param tamper, failure + retry |
+
+---
+
+## 1. Executive summary
+
+OpenRouter spend for Aico is gated by **per-user / per-member keys** with hard limits, while the **master management key** must live only on the control plane. Prior work (control-plane split, FIN-001/FIN-004, TENANT-001, managed chat policy) already closed most spend-bypass paths.
+
+This audit found remaining gaps: soft-delete never disabled personal keys (`disable_user_key` unsupported), create→DB failure left **orphan spendable keys**, managed authorize skipped the model allow-list when `modelId` was omitted, member remove waited on async outbox before OR disable, and non-prod product processes could still embed the management key.
+
+**Fixes shipped with this report** close OR-001 … OR-005 and OR-008.
+
+| Severity   | Open | Fixed | Accepted |
+| ---------- | ---: | ----: | -------: |
+| Critical   |    0 |     1 |        0 |
+| High       |    0 |     3 |        0 |
+| Medium     |    0 |     1 |        2 |
+| Low / Info |    0 |     1 |        1 |
+
+---
+
+## 2. Already well-protected (pre-existing / prior audits)
+
+| Area                                            | Evidence                                                                                       |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Master key not in SPA / `NEXT_PUBLIC_*`         | Server-only `packages/env/src/aico.ts`; wallet APIs expose `hasManagedKey` only                |
+| Master key product↔control-plane split          | `RemoteOpenRouterManagementClient` + service token; CP `openrouterInternal.ts`                 |
+| Chat managed providers fail closed              | `AicoManagedPolicy` + `DIRECT_PROVIDER_NOT_ALLOWED` for BYOK chat                              |
+| Org membership / foreign `organizationId`       | Authorize resolves **caller** membership; foreign org → `ORG_MEMBERSHIP_REQUIRED`              |
+| Client cannot set `memberId` / `budget` / `key` | Not in `AicoBillingContext`; keys decrypted server-side only                                   |
+| FIN-001 current-cycle OR limit                  | `currentCycleLimitMicro` / wallet-budget audit                                                 |
+| FIN-004 retire before recreate                  | `retireManagedKey`                                                                             |
+| TENANT-001 reclaim scoping                      | `reclaimMemberKey({ orgId, orgMemberId })`                                                     |
+| Org suspend / delete disables member keys       | `disableAllOrgMemberKeys`                                                                      |
+| Allocate / reclaim money races                  | FIN-002 / FIN-003 (wallet audit)                                                               |
+| Non-chat managed call without billing           | Fail closed (`BILLING_CONTEXT_REQUIRED`) — prevents spend bypass (OR-004 accepted product gap) |
+
+---
+
+## 3. Findings
+
+### OR-001 — Soft-delete outbox `disable_user_key` never ran
+
+| Field                  | Value                                                                                                                                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Severity**           | Critical                                                                                                                                                                                                                             |
+| **Status**             | Fixed                                                                                                                                                                                                                                |
+| **Affected component** | `AicoSoftDeleteService.softDeleteUser`, `processKeyOutbox` / `runOutboxAction`                                                                                                                                                       |
+| **Description**        | Soft-delete enqueued `disable_user_key`, but the outbox switch only handled `disable_member_key` / `reclaim_member` → `UNSUPPORTED_OUTBOX_ACTION`. Personal OR keys stayed enabled after account delete (wallet frozen in-app only). |
+| **Attack scenario**    | User soft-deletes account; previously issued personal key (or cached client) continues spending against the master OpenRouter account.                                                                                               |
+| **Impact**             | Unbounded spend after account deletion for B2C keys.                                                                                                                                                                                 |
+| **Recommendation**     | Handle `disable_user_key` → `keyService.disableUserKey(userId)`.                                                                                                                                                                     |
+| **Fix**                | Added `case 'disable_user_key'` in `runOutboxAction`.                                                                                                                                                                                |
+| **Retest result**      | Pass — `keyOutbox.disableUserKey.test.ts`                                                                                                                                                                                            |
+
+---
+
+### OR-002 — `createKey` then DB persist failure left orphan spendable key
+
+| Field                  | Value                                                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | High                                                                                                                                                    |
+| **Status**             | Fixed                                                                                                                                                   |
+| **Affected component** | `AicoOpenRouterKeyService.ensureUserKey` / `ensureTrialKey` / `ensureMemberKey`                                                                         |
+| **Description**        | OpenRouter `createKey` succeeded, then DB ciphertext write failed. The live key was untracked and remained spendable. Proven by failure-injection test. |
+| **Attack scenario**    | Transient DB error during provisioning → orphan key on master account; retries mint more orphans.                                                       |
+| **Impact**             | Master-account spend outside Aico ledger / hard-limit bookkeeping.                                                                                      |
+| **Recommendation**     | On persist failure, best-effort disable+delete (same as FIN-004 `retireManagedKey`).                                                                    |
+| **Fix**                | `createAndPersistUserKey` + member create path wrap persist in try/catch and `retireManagedKey`.                                                        |
+| **Retest result**      | Pass — `aico.keyFailureInjection.test.ts` OR-002                                                                                                        |
+
+---
+
+### OR-003 — Managed authorize skipped model allow-list when `modelId` omitted
+
+| Field                  | Value                                                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | High                                                                                                                                               |
+| **Status**             | Fixed                                                                                                                                              |
+| **Affected component** | `AicoManagedPolicy.authorize`                                                                                                                      |
+| **Description**        | `assertModelAllowed` ran only `if (params.modelId)`. Callers that injected a managed key without `modelId` bypassed team/trial model restrictions. |
+| **Attack scenario**    | Alternate / future runtime path with billing context but no model → forbidden model callable with member key.                                      |
+| **Impact**             | Model-restriction DoD bypass.                                                                                                                      |
+| **Recommendation**     | Require non-empty `modelId` for all managed authorize calls.                                                                                       |
+| **Fix**                | Throw `MODEL_ID_REQUIRED` before key decrypt / injection.                                                                                          |
+| **Retest result**      | Pass — `managedPolicy.test.ts` OR-003                                                                                                              |
+
+---
+
+### OR-004 — Non-chat LLM transports lack billing + model wiring
+
+| Field                  | Value                                                                                                                                                                            |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | Medium (product completeness)                                                                                                                                                    |
+| **Status**             | Accepted Risk (fail-closed)                                                                                                                                                      |
+| **Affected component** | e.g. `ServerLLMTransport.createModelRuntime` and other agent/system init sites without `billingContext`                                                                          |
+| **Description**        | Managed providers refuse to run without billing context (`BILLING_CONTEXT_REQUIRED`). This **blocks spend bypass** but also blocks funded agent use of managed keys until wired. |
+| **Impact**             | Agents cannot use org/personal managed OpenRouter keys yet; no silent fallthrough to env/BYOK for managed providers.                                                             |
+| **Recommendation**     | Follow-up product work: thread `AicoBillingContext` + `modelId` into agent transports.                                                                                           |
+| **Retest result**      | N/A — documented Accepted Risk for AICO-106 scope                                                                                                                                |
+
+---
+
+### OR-005 — Member remove only async-disabled OpenRouter key
+
+| Field                  | Value                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Severity**           | High                                                                                                                     |
+| **Status**             | Fixed                                                                                                                    |
+| **Affected component** | `organization.removeMember` router                                                                                       |
+| **Description**        | Removal set `revocation_pending` and enqueued `reclaim_member`, but OR key stayed enabled until cron drained the outbox. |
+| **Attack scenario**    | Remove member; until `process-key-outbox` runs, cached key can still spend.                                              |
+| **Impact**             | Delayed revoke window vs DoD “member delete revokes key”.                                                                |
+| **Recommendation**     | Best-effort sync `disableMemberKey` on remove; keep outbox for settlement retry.                                         |
+| **Fix**                | Sync disable before outbox insert; outbox still performs reclaim + finalize.                                             |
+| **Retest result**      | Pass (static + existing reclaim outbox path); sync call best-effort with warn log                                        |
+
+---
+
+### OR-006 — Multi-instance createKey races
+
+| Field                  | Value                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | Medium                                                                                                                    |
+| **Status**             | Accepted Risk                                                                                                             |
+| **Affected component** | `runExclusive` in-process lock in `keyService.ts`                                                                         |
+| **Description**        | Single-node mutex does not prevent two replicas from both calling `createKey`. OR-002 compensation reduces orphan damage. |
+| **Recommendation**     | DB advisory lock / unique claim on provisioning (follow-up).                                                              |
+| **Retest result**      | N/A — Accepted (aligned with FIN-010)                                                                                     |
+
+---
+
+### OR-007 — Master OpenRouter prepaid balance unknowable
+
+| Field                  | Value                                                                                                                                               |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | Medium (ops)                                                                                                                                        |
+| **Status**             | Accepted Risk                                                                                                                                       |
+| **Affected component** | `masterMonitor.ts` (`availableCreditMicroUsd: null`)                                                                                                |
+| **Description**        | OpenRouter does not expose a reliable remaining prepaid balance API used by Aico. Monitor heartbeats / staleness alerts exist; no invented balance. |
+| **Recommendation**     | Keep Accepted; rely on OR dashboard / billing webhook if available later.                                                                           |
+| **Retest result**      | N/A — Accepted                                                                                                                                      |
+
+---
+
+### OR-008 — Non-prod product could embed management key
+
+| Field                  | Value                                                                                                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Severity**           | Low                                                                                                                                                        |
+| **Status**             | Fixed                                                                                                                                                      |
+| **Affected component** | `createOpenRouterManagementClient`                                                                                                                         |
+| **Description**        | Management key rejection on product previously gated on `NODE_ENV === 'production'` only. Staging / misconfigured local product could hold the master key. |
+| **Impact**             | Key leakage surface on non-prod product processes.                                                                                                         |
+| **Fix**                | Reject `OPENROUTER_MANAGEMENT_API_KEY` on any process where `!AICO_IS_CONTROL_PLANE`.                                                                      |
+| **Retest result**      | Pass — `remoteManagementClient.test.ts` OR-008                                                                                                             |
+
+---
+
+## 4. Definition of Done checklist
+
+| Criterion                         | Status                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| Master Key leakage reviewed       | ✅ SPA / API / logs / env / CP split + OR-008                          |
+| Per-member Key lifecycle reviewed | ✅ create/budget/model/revoke; OR-001 soft-delete; OR-005 remove sync  |
+| Budget bypass tested              | ✅ Prior FIN-\* + managed policy; OR keys hard-limited                 |
+| Model bypass tested               | ✅ Chat path + OR-003 required `modelId`                               |
+| Failure Handling reviewed         | ✅ OR-002 orphan compensate; prior fail-closed mock refuse in prod     |
+| Retry behavior reviewed           | ✅ Outbox CAS; FIN-002/003 money idempotency; chat SoT = OR hard limit |
+
+---
+
+## 5. Parameter manipulation matrix
+
+| Parameter        | Client-controllable? | Server behavior                                          |
+| ---------------- | -------------------- | -------------------------------------------------------- |
+| `model`          | Yes (request)        | `assertModelAllowed` after OR-003 requires `modelId`     |
+| `provider`       | Yes (route)          | Non-managed chat rejected; managed forced through policy |
+| `memberId`       | No                   | Derived from caller membership                           |
+| `organizationId` | In billing context   | Must match **active** membership of caller               |
+| `budget`         | No                   | DB period/reserved amounts only                          |
+| `key`            | No                   | Ciphertext decrypt server-side; never returned to SPA    |
+
+---
+
+## 6. Failure / retry notes
+
+| Scenario                | Behavior                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| Timeout / network / 5xx | Management client throws; no silent mock in prod product                                      |
+| Invalid API key         | Chat fails closed (`MANAGED_KEY_*` / runtime error)                                           |
+| OR low / zero balance   | OR-007 Accepted — no invented balance; key hard limits still enforce member/user spend        |
+| Partial create+DB fail  | OR-002 retires orphan                                                                         |
+| Duplicate / retry money | FIN-002/003 reclaim + idempotency keys                                                        |
+| Chat retry              | Second successful completion is a second OR charge (expected); Aico wallet not double-debited |
+
+---
+
+## 7. Key files
+
+| Path                                                                   | Role                                         |
+| ---------------------------------------------------------------------- | -------------------------------------------- |
+| `apps/server/src/services/aico/renewalScheduler.ts`                    | Outbox `disable_user_key` (OR-001)           |
+| `apps/server/src/services/openrouter/keyService.ts`                    | Orphan retire on persist fail (OR-002)       |
+| `apps/server/src/services/aico/managedPolicy.ts`                       | Require `modelId` (OR-003)                   |
+| `apps/server/src/routers/lambda/organization.ts`                       | Sync disable on remove (OR-005)              |
+| `apps/server/src/services/openrouter/management.ts`                    | Product never embeds management key (OR-008) |
+| `apps/server/src/services/aico/keyOutbox.disableUserKey.test.ts`       | OR-001 regression                            |
+| `apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts` | OR-002 regression                            |
+| `apps/server/src/services/aico/managedPolicy.test.ts`                  | OR-003 regression                            |
+| `apps/server/src/services/openrouter/remoteManagementClient.test.ts`   | OR-008 regression                            |
+
+---
+
+## 8. Explicitly not re-opened
+
+Recorded as **Pass / prior** — do not reopen as new OR work: **FIN-001**, **FIN-004**, **TENANT-001**, control-plane master-key split, chat BYOK deny for managed providers.
+
+---
+
+_Retest file (if needed): `security-audit-reports/phase-02-business-logic/05-openrouter-integration-security-retest.md`_


### PR DESCRIPTION
#### 😜 Change Type

- [x] 🔒 security
- [x] 🐛 bug fix
- [ ] ✨ feature
- [ ] 💄 style
- [ ] 🔨 refactor
- [ ] 📝 docs
- [ ] 🔧 chore

#### 🔗 Related Issue

Fixes #237

Plane: [AICO-106](https://plane.panafor.com/panaforai/browse/AICO-106/)

#### 📝 Description of Change

Closes OpenRouter integration security gaps from the AICO-106 audit:

- **OR-001**: Soft-delete outbox handles `disable_user_key`
- **OR-002**: Retire orphan keys if OR create succeeds but DB persist fails
- **OR-003**: Managed authorize requires `modelId`
- **OR-005**: Best-effort sync disable on member remove
- **OR-008**: Product process never embeds the management API key

Adds audit report at `security-audit-reports/phase-02-business-logic/05-openrouter-integration-security.md`.

#### 🧪 How to Test

- [x] Unit regression tests (`keyOutbox.disableUserKey`, keyFailureInjection OR-002, managedPolicy OR-003, remoteManagement OR-008)
- [ ] Manual: soft-delete user with personal key → outbox disables OR key
- [ ] Manual: remove org member → OR key disabled immediately + reclaim outbox settles


Made with [Cursor](https://cursor.com)