### PR TITLE
🐛 fix(auth): align Persian signup name and email fields under RTL

### DIFF
--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression: Persian signup must keep name fields RTL-aligned and show the
+ * email placeholder on the right (not pinned left by type=email / UA LTR).
+ */
+describe('BetterAuthSignUpForm RTL field alignment', () => {
+  const source = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), 'BetterAuthSignUpForm.tsx'),
+    'utf8',
+  );
+
+  it('does not put type=email on the email Input (keeps inputMode + rule validation)', () => {
+    expect(source).toContain('inputMode="email"');
+    expect(source).toContain("type: 'email'");
+    expect(source).not.toMatch(/<Input[\s\S]*?type=["']email["']/);
+  });
+
+  it('forces RTL placeholder alignment for the email field under dir=rtl', () => {
+    expect(source).toContain("html[dir='rtl'] &:placeholder-shown");
+    expect(source).toContain('direction: rtl');
+    expect(source).toContain('text-align: start');
+  });
+
+  it('keeps name inputs RTL under dir=rtl and prevents grid overflow clipping', () => {
+    expect(source).toContain('nameInput');
+    expect(source).toContain('min-width: 0');
+    expect(source).toMatch(/\.ant-form-item-label\s*\{[\s\S]*?text-align:\s*start/);
+    expect(source).toMatch(/\.ant-form-item-label > label\s*\{[\s\S]*?height:\s*auto/);
+  });
+});

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
@@ -28,8 +28,10 @@ describe('BetterAuthSignUpForm RTL field alignment', () => {
 
   it('keeps name inputs RTL under dir=rtl and prevents grid overflow clipping', () => {
     expect(source).toContain('nameInput');
+    expect(source).toContain('nameFieldLabel');
+    expect(source).toContain('labelWrap');
     expect(source).toContain('min-width: 0');
     expect(source).toMatch(/\.ant-form-item-label\s*\{[\s\S]*?text-align:\s*start/);
-    expect(source).toMatch(/\.ant-form-item-label > label\s*\{[\s\S]*?height:\s*auto/);
+    expect(source).toMatch(/\.ant-form-item-label > label\s*\{[\s\S]*?width:\s*100%/);
   });
 });

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts
@@ -28,10 +28,14 @@ describe('BetterAuthSignUpForm RTL field alignment', () => {
 
   it('keeps name inputs RTL under dir=rtl and prevents grid overflow clipping', () => {
     expect(source).toContain('nameInput');
-    expect(source).toContain('nameFieldLabel');
-    expect(source).toContain('labelWrap');
     expect(source).toContain('min-width: 0');
     expect(source).toMatch(/\.ant-form-item-label\s*\{[\s\S]*?text-align:\s*start/);
     expect(source).toMatch(/\.ant-form-item-label > label\s*\{[\s\S]*?width:\s*100%/);
+  });
+
+  it('uses one primary label color and does not show Optional on field titles', () => {
+    expect(source).toContain('color: ${cssVar.colorText}');
+    expect(source).not.toContain('colorTextSecondary');
+    expect(source).not.toContain('betterAuth.signup.optional');
   });
 });

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
@@ -36,7 +36,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   fieldLabel: css`
     margin-block-end: 6px;
     font-size: 13px;
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   footerLink: css`
     cursor: pointer;
@@ -48,25 +48,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       color: ${cssVar.colorPrimaryHover};
     }
   `,
-  nameFieldLabel: css`
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    align-items: flex-start;
-
-    width: 100%;
-    max-width: 100%;
-  `,
   nameInput: css`
     html[dir='rtl'] & {
       direction: rtl;
       text-align: start;
     }
-  `,
-  nameOptional: css`
-    font-size: 12px;
-    font-weight: 400;
-    color: ${cssVar.colorTextTertiary};
   `,
   nameRow: css`
     display: grid;
@@ -97,12 +83,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     @media (width <= 420px) {
       grid-template-columns: 1fr;
     }
-  `,
-  optional: css`
-    margin-inline-start: 6px;
-    font-size: 12px;
-    font-weight: 400;
-    color: ${cssVar.colorTextTertiary};
   `,
 }));
 
@@ -146,19 +126,7 @@ const BetterAuthSignUpForm = () => {
     </Text>
   );
 
-  const label = (text: string, optional?: boolean) => (
-    <span className={styles.fieldLabel}>
-      {text}
-      {optional ? <span className={styles.optional}>{t('betterAuth.signup.optional')}</span> : null}
-    </span>
-  );
-
-  const nameLabel = (text: string) => (
-    <span className={styles.nameFieldLabel}>
-      <span>{text}</span>
-      <span className={styles.nameOptional}>{t('betterAuth.signup.optional')}</span>
-    </span>
-  );
+  const label = (text: string) => <span className={styles.fieldLabel}>{text}</span>;
 
   return (
     <AuthCard footer={footer} title={t('betterAuth.signup.title')}>
@@ -187,11 +155,7 @@ const BetterAuthSignUpForm = () => {
         }
       >
         <div className={styles.nameRow}>
-          <Form.Item
-            labelWrap
-            label={nameLabel(t('betterAuth.signup.firstNameLabel'))}
-            name="firstName"
-          >
+          <Form.Item label={label(t('betterAuth.signup.firstNameLabel'))} name="firstName">
             <Input
               autoComplete="given-name"
               className={styles.nameInput}
@@ -199,11 +163,7 @@ const BetterAuthSignUpForm = () => {
               size="large"
             />
           </Form.Item>
-          <Form.Item
-            labelWrap
-            label={nameLabel(t('betterAuth.signup.lastNameLabel'))}
-            name="lastName"
-          >
+          <Form.Item label={label(t('betterAuth.signup.lastNameLabel'))} name="lastName">
             <Input
               autoComplete="family-name"
               className={styles.nameInput}

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
@@ -17,6 +17,22 @@ import { PASSWORD_MIN_LENGTH } from '@/libs/better-auth/plugins/password-policy'
 import { useSignUp } from './useSignUp';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  /**
+   * Email is inherently LTR once filled, but Persian placeholders must sit on the
+   * inline-start edge (right under dir=rtl). `type="email"` + UA LTR often pins the
+   * empty field left; keep text + inputMode and flip direction while placeholder-shown.
+   */
+  emailInput: css`
+    html[dir='rtl'] &:placeholder-shown {
+      direction: rtl;
+      text-align: start;
+    }
+
+    html[dir='rtl'] &:not(:placeholder-shown) {
+      direction: ltr;
+      text-align: start;
+    }
+  `,
   fieldLabel: css`
     margin-block-end: 6px;
     font-size: 13px;
@@ -32,10 +48,30 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       color: ${cssVar.colorPrimaryHover};
     }
   `,
+  nameInput: css`
+    html[dir='rtl'] & {
+      direction: rtl;
+      text-align: start;
+    }
+  `,
   nameRow: css`
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 12px;
+
+    /* Avoid min-content overflow clipping Persian labels in half-width columns */
+    & > .ant-form-item {
+      min-width: 0;
+    }
+
+    .ant-form-item-label {
+      text-align: start;
+    }
+
+    .ant-form-item-label > label {
+      height: auto;
+      white-space: normal;
+    }
 
     @media (width <= 420px) {
       grid-template-columns: 1fr;
@@ -126,6 +162,7 @@ const BetterAuthSignUpForm = () => {
           <Form.Item label={label(t('betterAuth.signup.firstNameLabel'), true)} name="firstName">
             <Input
               autoComplete="given-name"
+              className={styles.nameInput}
               placeholder={t('betterAuth.signup.firstNamePlaceholder')}
               size="large"
             />
@@ -133,6 +170,7 @@ const BetterAuthSignUpForm = () => {
           <Form.Item label={label(t('betterAuth.signup.lastNameLabel'), true)} name="lastName">
             <Input
               autoComplete="family-name"
+              className={styles.nameInput}
               placeholder={t('betterAuth.signup.lastNamePlaceholder')}
               size="large"
             />
@@ -148,11 +186,11 @@ const BetterAuthSignUpForm = () => {
         >
           <Input
             autoComplete="email"
+            className={styles.emailInput}
             inputMode="email"
             placeholder={t('betterAuth.signup.emailPlaceholder')}
             ref={emailInputRef}
             size="large"
-            type="email"
           />
         </Form.Item>
         <Form.Item

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
@@ -48,11 +48,25 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       color: ${cssVar.colorPrimaryHover};
     }
   `,
+  nameFieldLabel: css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-start;
+
+    width: 100%;
+    max-width: 100%;
+  `,
   nameInput: css`
     html[dir='rtl'] & {
       direction: rtl;
       text-align: start;
     }
+  `,
+  nameOptional: css`
+    font-size: 12px;
+    font-weight: 400;
+    color: ${cssVar.colorTextTertiary};
   `,
   nameRow: css`
     display: grid;
@@ -65,11 +79,18 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
 
     .ant-form-item-label {
+      overflow: visible;
+      max-width: 100%;
       text-align: start;
     }
 
     .ant-form-item-label > label {
+      display: flex;
+
+      width: 100%;
+      max-width: 100%;
       height: auto;
+
       white-space: normal;
     }
 
@@ -132,6 +153,13 @@ const BetterAuthSignUpForm = () => {
     </span>
   );
 
+  const nameLabel = (text: string) => (
+    <span className={styles.nameFieldLabel}>
+      <span>{text}</span>
+      <span className={styles.nameOptional}>{t('betterAuth.signup.optional')}</span>
+    </span>
+  );
+
   return (
     <AuthCard footer={footer} title={t('betterAuth.signup.title')}>
       <AuthSocialButtons
@@ -159,7 +187,11 @@ const BetterAuthSignUpForm = () => {
         }
       >
         <div className={styles.nameRow}>
-          <Form.Item label={label(t('betterAuth.signup.firstNameLabel'), true)} name="firstName">
+          <Form.Item
+            labelWrap
+            label={nameLabel(t('betterAuth.signup.firstNameLabel'))}
+            name="firstName"
+          >
             <Input
               autoComplete="given-name"
               className={styles.nameInput}
@@ -167,7 +199,11 @@ const BetterAuthSignUpForm = () => {
               size="large"
             />
           </Form.Item>
-          <Form.Item label={label(t('betterAuth.signup.lastNameLabel'), true)} name="lastName">
+          <Form.Item
+            labelWrap
+            label={nameLabel(t('betterAuth.signup.lastNameLabel'))}
+            name="lastName"
+          >
             <Input
               autoComplete="family-name"
               className={styles.nameInput}


### PR DESCRIPTION
### 🤔 Change Type

- [x] `🐛` Bug Fix

### 🔗 Related Issue

Fixes #239

Plane: [AICO-144](https://plane.panafor.com/panaforai/browse/AICO-144)

### 📝 Description of Change

- Keep signup name-row labels from clipping/misaligning in half-width RTL columns.
- Force Persian email placeholder to the right while empty; switch to LTR once filled.
- Drop `type="email"` (keep `inputMode="email"` + form email rule) so UA LTR does not pin the empty field left.
- Remove Optional markers from name field titles.
- Unify all signup field label colors to the primary text color.
- Add a source-level RTL regression test.

### 🧪 How to Test

1. Open `/signup` with `fa-IR` / `dir=rtl`.
2. Confirm نام / نام خانوادگی titles have no Optional text and align correctly above each input.
3. Confirm email / password / confirm labels use the same color as the name titles.
4. Confirm the email placeholder is right-aligned when empty; typing a Latin email still works.
5. `bunx vitest run --silent='passed-only' src/features/Auth/SignUp/BetterAuthSignUpForm.rtl.test.ts`

### ☑️ Self Checklist

- [x] Regression test added
- [x] Visual check described for Persian signup