### PR TITLE
🐛 fix(aico): org wallet billing gate remaining + error copy

### DIFF
--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -502,9 +502,17 @@ export const initModelRuntimeFromDB = async (
     if (options?.billingContext === undefined) {
       throw new AicoManagedPolicyError('BILLING_CONTEXT_REQUIRED');
     }
-    // Decrypt-only: chat path must not construct the OpenRouter management client.
-    const keyService = new AicoOpenRouterKeyService(db, null);
-    const policy = new AicoManagedPolicy(db, (ciphertext) => keyService.decryptKey(ciphertext));
+    // Decrypt-only by default. Management client is created only if authorize
+    // needs to repair a funded member budget that is missing a managed key.
+    const decryptKeyService = new AicoOpenRouterKeyService(db, null);
+    const policy = new AicoManagedPolicy(
+      db,
+      (ciphertext) => decryptKeyService.decryptKey(ciphertext),
+      {
+        ensureMemberKey: (orgMemberId) =>
+          new AicoOpenRouterKeyService(db).ensureMemberKey(orgMemberId),
+      },
+    );
     const authorized = await policy.authorize({
       billing: options.billingContext,
       modelId: options.modelId,

--- a/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
@@ -34,20 +34,30 @@ vi.mock('@/server/services/sms', () => ({
   },
 }));
 
-const { disableAllOrgMemberKeysMock, reclaimMemberKeyMock } = vi.hoisted(() => ({
+const {
+  disableAllOrgMemberKeysMock,
+  ensureMemberKeyMock,
+  getUserRemainingMock,
+  reclaimMemberKeyMock,
+  syncMemberCycleUsageMock,
+} = vi.hoisted(() => ({
   disableAllOrgMemberKeysMock: vi.fn().mockResolvedValue([]),
+  ensureMemberKeyMock: vi.fn().mockResolvedValue({ created: false, keyId: null }),
+  getUserRemainingMock: vi.fn().mockResolvedValue({ remainingMicroUsd: 0, usageMicroUsd: null }),
   reclaimMemberKeyMock: vi.fn().mockResolvedValue(null),
+  syncMemberCycleUsageMock: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/server/services/openrouter/keyService', () => ({
   AicoOpenRouterKeyService: class {
     ensureUserKey = vi.fn().mockResolvedValue({ created: false, keyId: null });
-    ensureMemberKey = vi.fn().mockResolvedValue({ created: false, keyId: null });
+    ensureMemberKey = ensureMemberKeyMock;
     disableMemberKey = vi.fn().mockResolvedValue(null);
     disableAllOrgMemberKeys = disableAllOrgMemberKeysMock;
-    getUserRemaining = vi.fn().mockRejectedValue(new Error('not mocked'));
+    getUserRemaining = getUserRemainingMock;
     reclaimMemberKey = reclaimMemberKeyMock;
-    syncMemberUsage = vi.fn().mockResolvedValue(null);
+    syncMemberCycleUsage = syncMemberCycleUsageMock;
+    syncMemberUsage = syncMemberCycleUsageMock;
   },
 }));
 
@@ -477,6 +487,11 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
       })
       .where(eq(userWallets.userId, ownerId));
 
+    getUserRemainingMock.mockResolvedValue({
+      remainingMicroUsd: 1_500_000,
+      usageMicroUsd: null,
+    });
+
     const org = await ownerCaller.create({ name: 'Billing Sources Co' });
     await orgModel.addManualCredit({
       amountMicroUsd: 10_000_000,
@@ -518,6 +533,94 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     const preferred = await billingCaller.getMyBillingSources();
     expect(preferred.preferredBillingSource).toBe('organization');
     expect(preferred.preferredOrganizationId).toBe(org.id);
+  });
+
+  it('getMyBillingSources org remaining uses periodAmount not reserved when pending hold exists', async () => {
+    const { eq } = await import('drizzle-orm');
+    const { OrganizationModel } = await import('@/database/models/organization');
+    const { memberBudgets } = await import('@/database/schemas/aicoOrganization');
+
+    const ownerCaller = organizationRouter.createCaller(createTestContext(ownerId));
+    const billingCaller = aicoBillingRouter.createCaller(createTestContext(ownerId));
+    const orgModel = new OrganizationModel(testDB);
+
+    const org = await ownerCaller.create({ name: 'Pending Hold Co' });
+    await orgModel.addManualCredit({
+      amountMicroUsd: 50_000_000,
+      amountToman: 500_000,
+      createdByUserId: ownerId,
+      description: 'fund',
+      fxRateTomanPerUsd: 50_000,
+      orgId: org.id,
+      type: 'topup',
+    });
+
+    const members = await orgModel.listMembers(org.id);
+    const me = members.find((m) => m.userId === ownerId);
+    expect(me).toBeTruthy();
+
+    await orgModel.allocateMemberCredit({
+      createdByUserId: ownerId,
+      orgId: org.id,
+      orgMemberId: me!.id,
+      period: 'daily',
+      periodAmountMicroUsd: 10_000_000,
+    });
+
+    await testDB
+      .update(memberBudgets)
+      .set({
+        openrouterKeyId: 'ctrl_pending_hold',
+        pendingPeriod: 'monthly',
+        pendingPeriodAmountMicroUsd: 20_000_000,
+        reservedMicroUsd: 30_000_000,
+        settledUsageMicroUsd: 2_000_000,
+      })
+      .where(eq(memberBudgets.orgMemberId, me!.id));
+
+    const sources = await billingCaller.getMyBillingSources();
+    const orgSource = sources.sources.find(
+      (s) => s.source === 'organization' && s.organizationId === org.id,
+    );
+    expect(orgSource).toBeTruthy();
+    // $10 period cap − $2 settled = $8 (not $30 reserved − $2 = $28)
+    expect(orgSource!.remainingUsd).toBe('8.000000');
+    expect(orgSource!.hasManagedKey).toBe(true);
+  });
+
+  it('getMyBillingSources calls ensureMemberKey when funded but key is missing', async () => {
+    ensureMemberKeyMock.mockClear();
+
+    const { OrganizationModel } = await import('@/database/models/organization');
+    const ownerCaller = organizationRouter.createCaller(createTestContext(ownerId));
+    const billingCaller = aicoBillingRouter.createCaller(createTestContext(ownerId));
+    const orgModel = new OrganizationModel(testDB);
+
+    const org = await ownerCaller.create({ name: 'Lazy Key Repair Co' });
+    await orgModel.addManualCredit({
+      amountMicroUsd: 10_000_000,
+      amountToman: 500_000,
+      createdByUserId: ownerId,
+      description: 'fund',
+      fxRateTomanPerUsd: 50_000,
+      orgId: org.id,
+      type: 'topup',
+    });
+
+    const members = await orgModel.listMembers(org.id);
+    const me = members.find((m) => m.userId === ownerId);
+    expect(me).toBeTruthy();
+
+    await orgModel.allocateMemberCredit({
+      createdByUserId: ownerId,
+      orgId: org.id,
+      orgMemberId: me!.id,
+      period: 'daily',
+      periodAmountMicroUsd: 5_000_000,
+    });
+
+    await billingCaller.getMyBillingSources();
+    expect(ensureMemberKeyMock).toHaveBeenCalledWith(me!.id);
   });
 
   it('convertToManagement requires a verified phone and rejects a second organization', async () => {

--- a/apps/server/src/routers/lambda/aicoBilling.ts
+++ b/apps/server/src/routers/lambda/aicoBilling.ts
@@ -6,7 +6,11 @@ import { z } from 'zod';
 import { AicoBillingModel } from '@/database/models/aicoBilling';
 import { OrganizationModel } from '@/database/models/organization';
 import { users } from '@/database/schemas';
-import { microUsdToDecimalString } from '@/database/utils/aicoMoney';
+import {
+  cycleRemainingMicroUsd,
+  hasValidManagedKeyId,
+  microUsdToDecimalString,
+} from '@/database/utils/aicoMoney';
 import { aicoEnv } from '@/envs/aico';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
@@ -107,7 +111,7 @@ export const aicoBillingRouter = router({
     ).remainingMicroUsd;
 
     const personal = {
-      hasManagedKey: Boolean(wallet.openrouterKeyId),
+      hasManagedKey: hasValidManagedKeyId(wallet.openrouterKeyId),
       isActive: Boolean(wallet.isActive),
       remainingMicroUsd: String(personalRemaining),
       remainingUsd: microUsdToDecimalString(personalRemaining),
@@ -121,23 +125,45 @@ export const aicoBillingRouter = router({
           const me = members.find((m) => m.userId === ctx.userId && m.status === 'active');
           if (!me) return null;
 
-          await keyService.syncMemberUsage(me.id).catch(() => null);
+          let budget = await ctx.organizationModel.getMemberBudget(me.id);
 
-          const budget = await ctx.organizationModel.getMemberBudget(me.id);
-          const reservedMicroUsd = Number(budget?.reservedMicroUsd ?? 0);
-          const settledUsageMicroUsd = Number(budget?.settledUsageMicroUsd ?? 0);
-          const remainingMicroUsd = Math.max(0, reservedMicroUsd - settledUsageMicroUsd);
+          if (budget && hasValidManagedKeyId(budget.openrouterKeyId)) {
+            await keyService.syncMemberCycleUsage(me.id).catch(() => null);
+            budget = await ctx.organizationModel.getMemberBudget(me.id);
+          }
+
           const renewalStatus = budget?.renewalStatus ?? null;
+          const renewalBlocked =
+            renewalStatus === 'renewal_pending' || renewalStatus === 'renewal_failed';
+
+          let remainingMicroUsd = cycleRemainingMicroUsd(budget ?? {});
+
+          if (
+            budget?.isActive &&
+            !renewalBlocked &&
+            remainingMicroUsd > 0 &&
+            !hasValidManagedKeyId(budget.openrouterKeyId)
+          ) {
+            await keyService.ensureMemberKey(me.id).catch((error) => {
+              console.warn('[aicoBilling] lazy member key repair failed', {
+                orgId: org.id,
+                orgMemberId: me.id,
+                error,
+              });
+              return null;
+            });
+            budget = await ctx.organizationModel.getMemberBudget(me.id);
+            remainingMicroUsd = cycleRemainingMicroUsd(budget ?? {});
+          }
 
           return {
-            hasManagedKey: Boolean(budget?.openrouterKeyId),
+            hasManagedKey: hasValidManagedKeyId(budget?.openrouterKeyId),
             isActive: Boolean(budget?.isActive),
             organizationId: org.id,
             organizationName: org.name,
             remainingMicroUsd: String(remainingMicroUsd),
             remainingUsd: microUsdToDecimalString(remainingMicroUsd),
-            renewalBlocked:
-              renewalStatus === 'renewal_pending' || renewalStatus === 'renewal_failed',
+            renewalBlocked,
             source: 'organization' as const,
           };
         }),
@@ -333,7 +359,7 @@ export const aicoBillingRouter = router({
           const me = members.find((m) => m.userId === ctx.userId && m.status === 'active');
           if (!me) return false;
           const budget = await ctx.organizationModel.getMemberBudget(me.id);
-          return Boolean(budget?.isActive && (budget.reservedMicroUsd ?? 0) > 0);
+          return Boolean(budget?.isActive && cycleRemainingMicroUsd(budget) > 0);
         }),
       )
     ).some(Boolean);

--- a/apps/server/src/services/aico/managedPolicy.ts
+++ b/apps/server/src/services/aico/managedPolicy.ts
@@ -3,10 +3,19 @@ import { ChatErrorType, type ErrorType } from '@lobechat/types';
 import { AicoBillingModel } from '@/database/models/aicoBilling';
 import { OrganizationModel } from '@/database/models/organization';
 import type { LobeChatDatabase } from '@/database/type';
-import { microUsdToDecimalString } from '@/database/utils/aicoMoney';
+import {
+  cycleRemainingMicroUsd,
+  hasValidManagedKeyId,
+  microUsdToDecimalString,
+} from '@/database/utils/aicoMoney';
 import { aicoEnv } from '@/envs/aico';
 
 import { type AicoBillingContext, parseAicoBillingContext } from './billingContext';
+
+/** Optional repair hook — chat path may lazy-provision a missing member key. */
+export type AicoManagedKeyRepair = {
+  ensureMemberKey: (orgMemberId: string) => Promise<unknown>;
+};
 
 export class AicoManagedPolicyError extends Error {
   errorType: ErrorType;
@@ -42,6 +51,7 @@ export class AicoManagedPolicy {
   constructor(
     private readonly db: LobeChatDatabase,
     private readonly decryptKey: (ciphertext: string) => Promise<string | null>,
+    private readonly keyRepair?: AicoManagedKeyRepair,
   ) {
     this.orgModel = new OrganizationModel(db);
     this.billingModel = new AicoBillingModel(db);
@@ -150,7 +160,7 @@ export class AicoManagedPolicy {
       throw new AicoManagedPolicyError('ORG_MEMBERSHIP_REQUIRED', ChatErrorType.Forbidden);
     }
 
-    const budget = await this.orgModel.getMemberBudget(me.id);
+    let budget = await this.orgModel.getMemberBudget(me.id);
     if (!budget?.isActive) {
       throw new AicoManagedPolicyError('MEMBER_BUDGET_INACTIVE', ChatErrorType.InvalidUserKey);
     }
@@ -160,10 +170,23 @@ export class AicoManagedPolicy {
         ChatErrorType.InvalidUserKey,
       );
     }
-    if ((budget.reservedMicroUsd ?? 0) <= 0) {
+    if (cycleRemainingMicroUsd(budget) <= 0) {
       throw new AicoManagedPolicyError('MEMBER_BUDGET_UNFUNDED', ChatErrorType.InvalidUserKey);
     }
-    if (!budget.openrouterKeyCiphertext || !budget.openrouterKeyId) {
+
+    if (
+      (!hasValidManagedKeyId(budget.openrouterKeyId) || !budget.openrouterKeyCiphertext) &&
+      this.keyRepair
+    ) {
+      try {
+        await this.keyRepair.ensureMemberKey(me.id);
+        budget = (await this.orgModel.getMemberBudget(me.id)) ?? budget;
+      } catch (error) {
+        console.warn('[aico] managed policy failed to repair member OpenRouter key', error);
+      }
+    }
+
+    if (!hasValidManagedKeyId(budget.openrouterKeyId) || !budget.openrouterKeyCiphertext) {
       throw new AicoManagedPolicyError('MANAGED_KEY_UNAVAILABLE', ChatErrorType.InvalidUserKey);
     }
 

--- a/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
+++ b/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
@@ -414,6 +414,49 @@ describe('Aico OpenRouter failure injection (Phase 2)', () => {
     expect(key.limit).toBe(10);
   });
 
+  it('syncMemberCycleUsage writes period usage, not lifetime OpenRouter usage', async () => {
+    const { OrganizationModel } = await import('@/database/models/organization');
+    const orgModel = new OrganizationModel(db);
+    const org = await orgModel.createOrganization({
+      name: 'Cycle Sync Org',
+      ownerUserId: userId,
+    });
+    const members = await orgModel.listMembers(org.id);
+    const ownerMember = members[0];
+
+    const client = new ControllableOpenRouterClient();
+    const keys = new AicoOpenRouterKeyService(db, client);
+
+    await db.insert(memberBudgets).values({
+      isActive: true,
+      openrouterKeyCiphertext: 'enc',
+      openrouterKeyId: 'ctrl_cycle_sync',
+      orgId: org.id,
+      orgMemberId: ownerMember.id,
+      period: 'daily',
+      periodAmountMicroUsd: 10_000_000,
+      reservedMicroUsd: 10_000_000,
+      settledUsageMicroUsd: 0,
+    });
+
+    client.keys.set('ctrl_cycle_sync', {
+      disabled: false,
+      hash: 'ctrl_cycle_sync',
+      key: `${FAKE_SECRET}-ctrl_cycle_sync`,
+      limit: 10,
+      limitRemaining: 8,
+      name: 'test',
+      usage: 50,
+      usageDaily: 2,
+      usageMonthly: 50,
+      usageWeekly: 50,
+    });
+
+    await keys.syncMemberCycleUsage(ownerMember.id);
+    const budget = await orgModel.getMemberBudget(ownerMember.id);
+    expect(budget!.settledUsageMicroUsd).toBe(2_000_000);
+  });
+
   it('FIN-004: recreate after 404 disables/deletes the stale key hash', async () => {
     const billing = new AicoBillingModel(db);
     const client = new ControllableOpenRouterClient();

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -3,6 +3,8 @@ import { OrganizationModel } from '@/database/models/organization';
 import type { LobeChatDatabase } from '@/database/type';
 import {
   type BudgetPeriod,
+  currentCycleLimitMicroUsd,
+  isStaleManagedKeyId,
   microUsdToDecimalString,
   openRouterUsdToMicroFloor,
   periodToOpenRouterLimitReset,
@@ -73,24 +75,6 @@ export class AicoOpenRouterKeyService {
     return wasAuthentic ? plaintext : null;
   }
 
-  private isStaleManagedKeyId(keyId: string | null | undefined): boolean {
-    return !keyId || keyId.startsWith('mock_');
-  }
-
-  /**
-   * Current-cycle spendable limit for OpenRouter (FIN-001).
-   * Pending next-period reservations inflate `reservedMicroUsd` but must not
-   * raise the live key limit until renewal applies them.
-   */
-  private currentCycleLimitMicro(budget: {
-    periodAmountMicroUsd?: number | null;
-    reservedMicroUsd?: number | null;
-  }): number {
-    const periodAmount = Number(budget.periodAmountMicroUsd ?? 0);
-    if (periodAmount > 0) return periodAmount;
-    return Number(budget.reservedMicroUsd ?? 0);
-  }
-
   /** Best-effort retire a managed key before recreating (FIN-004). */
   private async retireManagedKey(hash: string): Promise<void> {
     try {
@@ -114,7 +98,7 @@ export class AicoOpenRouterKeyService {
       if (
         wallet.openrouterKeyId &&
         wallet.openrouterKeyCiphertext &&
-        !this.isStaleManagedKeyId(wallet.openrouterKeyId)
+        !isStaleManagedKeyId(wallet.openrouterKeyId)
       ) {
         try {
           await this.client.updateKey({
@@ -178,7 +162,7 @@ export class AicoOpenRouterKeyService {
       const period = (budget.period || 'total') as BudgetPeriod;
       const limitReset: OpenRouterKeyLimitReset = periodToOpenRouterLimitReset(period);
       // FIN-001: never use reservedMicroUsd here — it may include pending next-period funds.
-      const limitMicro = this.currentCycleLimitMicro(budget);
+      const limitMicro = currentCycleLimitMicroUsd(budget);
       const limitUsd = microToOpenRouterLimitUsd(limitMicro);
       const shouldDisable =
         !budget.isActive ||
@@ -189,7 +173,7 @@ export class AicoOpenRouterKeyService {
       if (
         budget.openrouterKeyId &&
         budget.openrouterKeyCiphertext &&
-        !this.isStaleManagedKeyId(budget.openrouterKeyId)
+        !isStaleManagedKeyId(budget.openrouterKeyId)
       ) {
         try {
           await this.client.updateKey({
@@ -293,7 +277,7 @@ export class AicoOpenRouterKeyService {
 
     const info = await this.client.getKey(budget.openrouterKeyId);
     const usageMicro = Number(openRouterUsdToMicroFloor(info.usage));
-    const currentCycle = this.currentCycleLimitMicro(budget);
+    const currentCycle = currentCycleLimitMicroUsd(budget);
     const pendingHeld = Math.max(0, Number(budget.pendingPeriodAmountMicroUsd ?? 0));
     const remainingFromOr =
       info.limitRemaining == null
@@ -311,24 +295,24 @@ export class AicoOpenRouterKeyService {
   };
 
   /**
-   * Authoritative period settlement read for renewal.
-   * Does not itself enable/disable the OpenRouter key — renewal already
-   * disables keys at the start of `renewal_pending` and re-enables only after
-   * the next period is funded.
-   *
-   * Boundary safety (AICO-140): prefer `limit_remaining` and period usage
-   * counters. If OpenRouter has already reset for the new cycle (period usage
-   * near 0 / remaining ≈ full limit while Aico still has closing-cycle
-   * settledUsage), use Aico's last settled usage so we do not over-refund.
+   * Period-aware usage read for dashboards / billing sources.
+   * Never writes lifetime `info.usage` into `settledUsageMicroUsd`.
    */
-  settleMemberPeriod = async (
-    orgMemberId: string,
-  ): Promise<{ remainingMicroUsd: number; usageMicroUsd: number } | null> => {
-    const budget = await this.orgModel.getMemberBudget(orgMemberId);
-    if (!budget?.openrouterKeyId) return null;
-
-    const info = await this.client.getKey(budget.openrouterKeyId);
-    const currentCycle = this.currentCycleLimitMicro(budget);
+  private computeCycleUsageFromKeyInfo = (
+    budget: {
+      period?: string | null;
+      settledUsageMicroUsd?: number | null;
+    },
+    info: {
+      limit?: number | null;
+      limitRemaining?: number | null;
+      usage?: number | null;
+      usageDaily?: number | null;
+      usageMonthly?: number | null;
+      usageWeekly?: number | null;
+    },
+  ): { remainingMicroUsd: number; usageMicroUsd: number } => {
+    const currentCycle = currentCycleLimitMicroUsd(budget);
     const priorSettled = Math.max(0, Number(budget.settledUsageMicroUsd ?? 0));
 
     const periodUsageUsd =
@@ -348,7 +332,6 @@ export class AicoOpenRouterKeyService {
     const remainingFromOr =
       info.limitRemaining == null ? null : Number(openRouterUsdToMicroFloor(info.limitRemaining));
 
-    // Detect post-reset OR counters while Aico still holds closing-period spend.
     const looksReset =
       priorSettled > 0 &&
       ((periodUsageMicro != null && periodUsageMicro < priorSettled / 2) ||
@@ -374,18 +357,40 @@ export class AicoOpenRouterKeyService {
       usageMicro = Math.min(currentCycle, Math.max(0, periodUsageMicro));
       remainingMicro = Math.max(0, currentCycle - usageMicro);
     } else {
-      usageMicro = Number(openRouterUsdToMicroFloor(info.usage));
-      // Lifetime `usage` can exceed one cycle — clamp to current cycle.
+      usageMicro = Number(openRouterUsdToMicroFloor(info.usage ?? 0));
       usageMicro = Math.min(currentCycle, Math.max(0, usageMicro));
       remainingMicro = Math.max(0, currentCycle - usageMicro);
     }
 
+    return { remainingMicroUsd: remainingMicro, usageMicroUsd: usageMicro };
+  };
+
+  /**
+   * Authoritative period settlement read for renewal.
+   * Does not itself enable/disable the OpenRouter key — renewal already
+   * disables keys at the start of `renewal_pending` and re-enables only after
+   * the next period is funded.
+   *
+   * Boundary safety (AICO-140): prefer `limit_remaining` and period usage
+   * counters. If OpenRouter has already reset for the new cycle (period usage
+   * near 0 / remaining ≈ full limit while Aico still has closing-cycle
+   * settledUsage), use Aico's last settled usage so we do not over-refund.
+   */
+  settleMemberPeriod = async (
+    orgMemberId: string,
+  ): Promise<{ remainingMicroUsd: number; usageMicroUsd: number } | null> => {
+    const budget = await this.orgModel.getMemberBudget(orgMemberId);
+    if (!budget?.openrouterKeyId) return null;
+
+    const info = await this.client.getKey(budget.openrouterKeyId);
+    const { remainingMicroUsd, usageMicroUsd } = this.computeCycleUsageFromKeyInfo(budget, info);
+
     await this.orgModel.syncMemberBudgetUsage({
       orgMemberId,
-      settledUsageMicroUsd: usageMicro,
+      settledUsageMicroUsd: usageMicroUsd,
     });
 
-    return { remainingMicroUsd: remainingMicro, usageMicroUsd: usageMicro };
+    return { remainingMicroUsd, usageMicroUsd };
   };
 
   /**
@@ -406,7 +411,7 @@ export class AicoOpenRouterKeyService {
     const wallet = await this.billingModel.getOrCreateUserWallet(userId);
     const balanceMicroUsd = Number(wallet.balanceMicroUsd ?? 0);
 
-    if (!wallet.openrouterKeyId || this.isStaleManagedKeyId(wallet.openrouterKeyId)) {
+    if (!wallet.openrouterKeyId || isStaleManagedKeyId(wallet.openrouterKeyId)) {
       return { remainingMicroUsd: Math.max(0, balanceMicroUsd), usageMicroUsd: null };
     }
 
@@ -423,13 +428,22 @@ export class AicoOpenRouterKeyService {
     }
   };
 
-  syncMemberUsage = async (orgMemberId: string) => {
+  /**
+   * Period-aware sync for billing dashboards — prefers cycle counters over
+   * lifetime OpenRouter usage so remaining balance stays accurate.
+   */
+  syncMemberCycleUsage = async (orgMemberId: string) => {
     const budget = await this.orgModel.getMemberBudget(orgMemberId);
-    if (!budget?.openrouterKeyId) return null;
+    if (!budget?.openrouterKeyId || isStaleManagedKeyId(budget.openrouterKeyId)) return null;
+
     const info = await this.client.getKey(budget.openrouterKeyId);
+    const { usageMicroUsd } = this.computeCycleUsageFromKeyInfo(budget, info);
     return this.orgModel.syncMemberBudgetUsage({
       orgMemberId,
-      settledUsageMicroUsd: Number(openRouterUsdToMicroFloor(info.usage)),
+      settledUsageMicroUsd: usageMicroUsd,
     });
   };
+
+  /** @deprecated Prefer `syncMemberCycleUsage`. */
+  syncMemberUsage = async (orgMemberId: string) => this.syncMemberCycleUsage(orgMemberId);
 }

--- a/packages/database/src/models/organization.ts
+++ b/packages/database/src/models/organization.ts
@@ -24,6 +24,7 @@ import { users } from '../schemas/user';
 import type { LobeChatDatabase } from '../type';
 import {
   type BudgetPeriod,
+  cycleRemainingMicroUsd,
   isBudgetPeriod,
   isProductBudgetPeriod,
   periodToOpenRouterLimitReset,
@@ -1691,7 +1692,11 @@ export class OrganizationModel {
           periodAmountMicroUsd,
           publicCode: m.publicCode,
           // Spendable remaining for the active cycle (excludes pending next-period hold).
-          remainingMicroUsd: Math.max(0, periodAmountMicroUsd - settledUsageMicroUsd),
+          remainingMicroUsd: cycleRemainingMicroUsd({
+            periodAmountMicroUsd,
+            reservedMicroUsd,
+            settledUsageMicroUsd,
+          }),
           pendingPeriod: budget?.pendingPeriod ?? null,
           pendingPeriodAmountMicroUsd: Number(budget?.pendingPeriodAmountMicroUsd ?? 0),
           renewalStatus: budget?.renewalStatus ?? null,

--- a/packages/database/src/utils/__tests__/aicoMoney.test.ts
+++ b/packages/database/src/utils/__tests__/aicoMoney.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   confirmedUnusedMicro,
+  currentCycleLimitMicroUsd,
+  cycleRemainingMicroUsd,
   isProductBudgetPeriod,
+  isStaleManagedKeyId,
   microUsdToDecimalString,
   openRouterUsdToMicroFloor,
   periodToOpenRouterLimitReset,
@@ -60,5 +63,21 @@ describe('aicoMoney (final remediation)', () => {
     expect(() => usdDecimalStringToMicro('1.2.3')).toThrow();
     expect(() => tomanToMicroUsd(-1, 50_000)).toThrow();
     expect(() => openRouterUsdToMicroFloor(Number.NaN)).toThrow();
+  });
+
+  it('cycle remaining uses periodAmount and ignores pending reserved hold (FIN-001)', () => {
+    const budget = {
+      periodAmountMicroUsd: 10_000_000,
+      reservedMicroUsd: 30_000_000,
+      settledUsageMicroUsd: 2_000_000,
+    };
+    expect(currentCycleLimitMicroUsd(budget)).toBe(10_000_000);
+    expect(cycleRemainingMicroUsd(budget)).toBe(8_000_000);
+  });
+
+  it('isStaleManagedKeyId treats mock_ hashes as invalid', () => {
+    expect(isStaleManagedKeyId(null)).toBe(true);
+    expect(isStaleManagedKeyId('mock_abc')).toBe(true);
+    expect(isStaleManagedKeyId('ctrl_realhash')).toBe(false);
   });
 });

--- a/packages/database/src/utils/aicoMoney.ts
+++ b/packages/database/src/utils/aicoMoney.ts
@@ -146,3 +146,34 @@ export const tomanString = (toman: bigint | number | string): string => {
   const value = typeof toman === 'bigint' ? toman : BigInt(toman);
   return value.toString();
 };
+
+/** Member budget fields needed for current-cycle spend math (FIN-001). */
+export type MemberBudgetCycleFields = {
+  periodAmountMicroUsd?: number | null;
+  reservedMicroUsd?: number | null;
+  settledUsageMicroUsd?: number | null;
+};
+
+/**
+ * Current-cycle spendable cap for a member budget.
+ * Pending next-period holds inflate `reservedMicroUsd` but must not raise the
+ * live OpenRouter limit until renewal applies them.
+ */
+export const currentCycleLimitMicroUsd = (budget: MemberBudgetCycleFields): number => {
+  const periodAmount = Number(budget.periodAmountMicroUsd ?? 0);
+  if (periodAmount > 0) return periodAmount;
+  return Number(budget.reservedMicroUsd ?? 0);
+};
+
+/** Spendable remaining in the active billing cycle (excludes pending next-period hold). */
+export const cycleRemainingMicroUsd = (budget: MemberBudgetCycleFields): number => {
+  const limit = currentCycleLimitMicroUsd(budget);
+  const settled = Math.max(0, Number(budget.settledUsageMicroUsd ?? 0));
+  return Math.max(0, limit - settled);
+};
+
+export const isStaleManagedKeyId = (keyId: string | null | undefined): boolean =>
+  !keyId || keyId.startsWith('mock_');
+
+export const hasValidManagedKeyId = (keyId: string | null | undefined): boolean =>
+  Boolean(keyId) && !isStaleManagedKeyId(keyId);

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -58,7 +58,7 @@ const recordManagedUsage = async (params: {
     const me = members.find((m) => m.userId === userId && m.status === 'active');
     if (me) {
       orgMemberId = me.id;
-      await keyService.syncMemberUsage(me.id).catch(() => null);
+      await keyService.syncMemberCycleUsage(me.id).catch(() => null);
     }
   } else {
     // Warm personal remaining from OpenRouter so the next sources fetch is current.

--- a/src/business/client/resolveAicoErrorMessage.test.ts
+++ b/src/business/client/resolveAicoErrorMessage.test.ts
@@ -89,6 +89,18 @@ describe('resolveAicoErrorMessage', () => {
       'برای ادامه، ابتدا شماره موبایل خود را تأیید کنید.',
     );
   });
+
+  it('prefers ChatMessageError body.error over generic InvalidUserKey message', async () => {
+    const { extractErrorCodeCandidate, resolveAicoErrorMessage } =
+      await import('./resolveAicoErrorMessage');
+    const chatError = {
+      body: { error: 'MEMBER_BUDGET_UNFUNDED', provider: 'aico' },
+      message: 'translated_response.InvalidUserKey',
+      type: 'InvalidUserKey',
+    };
+    expect(extractErrorCodeCandidate(chatError)).toBe('MEMBER_BUDGET_UNFUNDED');
+    expect(resolveAicoErrorMessage(chatError)).toBe('سهمیه سازمانی انتخاب‌شده موجودی ندارد.');
+  });
 });
 
 describe('toastAicoError', () => {

--- a/src/business/client/resolveAicoErrorMessage.ts
+++ b/src/business/client/resolveAicoErrorMessage.ts
@@ -9,18 +9,27 @@ import { buildPhoneVerifyRedirectUrl } from '@/libs/better-auth/phone';
 
 type LooseT = (key: string, options?: { defaultValue?: string }) => string;
 
-/** Pull a likely error-code string out of TRPC / Error / plain shapes. */
+/** Pull a likely error-code string out of TRPC / Error / ChatMessageError shapes. */
 export const extractErrorCodeCandidate = (error: unknown): string => {
   if (!error) return '';
   if (typeof error === 'string') return error;
   if (typeof error !== 'object') return '';
 
   const candidate = error as {
+    body?: { error?: unknown; message?: unknown };
     data?: { message?: unknown };
     message?: unknown;
     shape?: { message?: unknown };
   };
 
+  // Chat SSE: createErrorResponse puts Aico codes in `body.error` while
+  // `message` is a generic localized InvalidUserKey string — prefer body.
+  if (typeof candidate.body?.error === 'string' && candidate.body.error.trim()) {
+    return candidate.body.error;
+  }
+  if (typeof candidate.body?.message === 'string' && candidate.body.message.trim()) {
+    return candidate.body.message;
+  }
   if (typeof candidate.message === 'string' && candidate.message.trim()) {
     return candidate.message;
   }

--- a/src/features/AicoBilling/useAicoBillingChatGate.test.ts
+++ b/src/features/AicoBilling/useAicoBillingChatGate.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAicoBillingChatGate } from './useAicoBillingChatGate';
+
+const useAicoBillingSources = vi.fn();
+
+vi.mock('./useAicoBillingSources', () => ({
+  useAicoBillingSources: () => useAicoBillingSources(),
+}));
+
+describe('useAicoBillingChatGate', () => {
+  beforeEach(() => {
+    useAicoBillingSources.mockReset();
+  });
+
+  it('fail-closed while billing sources are loading', () => {
+    useAicoBillingSources.mockReturnValue({
+      activeSource: undefined,
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useAicoBillingChatGate());
+    expect(result.current.blocked).toBe(true);
+    expect(result.current.blockReason).toBeNull();
+  });
+
+  it('fail-closed when active source is not resolved yet', () => {
+    useAicoBillingSources.mockReturnValue({
+      activeSource: undefined,
+      data: { sources: [], trialActive: false, trialAvailable: false },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useAicoBillingChatGate());
+    expect(result.current.blocked).toBe(true);
+  });
+});

--- a/src/features/AicoBilling/useAicoBillingChatGate.ts
+++ b/src/features/AicoBilling/useAicoBillingChatGate.ts
@@ -20,7 +20,7 @@ export const useAicoBillingChatGate = (): AicoBillingChatGate => {
 
   if (isLoading || !data || !activeSource) {
     return {
-      blocked: false,
+      blocked: true,
       blockReason: null,
       showTrialCta: false,
       trialActive: Boolean(data?.trialActive),

--- a/src/features/Conversation/Error/ChatInvalidApiKey.tsx
+++ b/src/features/Conversation/Error/ChatInvalidApiKey.tsx
@@ -5,6 +5,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { extractErrorCodeCandidate } from '@/business/client/resolveAicoErrorMessage';
 import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
@@ -12,7 +13,7 @@ import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
 import { type GlobalLLMProviderKey } from '@/types/user/settings/modelProvider';
 
-import { useConversationStore } from '../store';
+import { dataSelectors, useConversationStore } from '../store';
 import BaseErrorForm from './BaseErrorForm';
 import { isAicoManagedProviderMode } from './isAicoManagedProviderMode';
 import ManagedKeyError from './ManagedKeyError';
@@ -25,6 +26,8 @@ const ChatInvalidAPIKey = memo<ChatInvalidAPIKeyProps>(({ id, provider }) => {
   const { t } = useTranslation(['modelProvider', 'error']);
   const navigate = useWorkspaceAwareNavigate();
   const [deleteMessage] = useConversationStore((s) => [s.deleteMessage]);
+  const messageError = useConversationStore(dataSelectors.getDisplayMessageById(id))?.error;
+  const serverErrorCode = extractErrorCodeCandidate(messageError);
   const providerName = useProviderName(provider as GlobalLLMProviderKey);
 
   const { data: managedStatus } = useClientDataSWR('aico-provider-status', () =>
@@ -34,7 +37,13 @@ const ChatInvalidAPIKey = memo<ChatInvalidAPIKeyProps>(({ id, provider }) => {
     // Native openai/google/… selections do not use the wallet key — prompt a
     // model switch instead of the misleading “top up wallet” card.
     const reason = provider && !isAicoManagedRuntimeProvider(provider) ? 'wrongProvider' : 'funds';
-    return <ManagedKeyError reason={reason} onNavigate={() => deleteMessage(id)} />;
+    return (
+      <ManagedKeyError
+        reason={reason}
+        serverErrorCode={serverErrorCode || undefined}
+        onNavigate={() => deleteMessage(id)}
+      />
+    );
   }
 
   return (

--- a/src/features/Conversation/Error/ManagedKeyError.tsx
+++ b/src/features/Conversation/Error/ManagedKeyError.tsx
@@ -7,10 +7,14 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ProductLogo } from '@/components/Branding/ProductLogo';
-import { useAicoBillingChatGate } from '@/features/AicoBilling';
+import { useAicoBillingChatGate, useAicoBillingSources } from '@/features/AicoBilling';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 
 import BaseErrorForm from './BaseErrorForm';
+import {
+  resolveManagedKeyErrorDescription,
+  shouldShowManagedKeyTrialActions,
+} from './resolveManagedKeyErrorDescription';
 
 interface ManagedKeyErrorProps {
   onNavigate?: () => void;
@@ -20,58 +24,71 @@ interface ManagedKeyErrorProps {
    * is in managed OpenRouter mode.
    */
   reason?: 'funds' | 'wrongProvider';
+  /** Aico error code from the failed chat response (e.g. MEMBER_BUDGET_UNFUNDED). */
+  serverErrorCode?: string;
 }
 
-const ManagedKeyError = memo<ManagedKeyErrorProps>(({ onNavigate, reason = 'funds' }) => {
-  const { t } = useTranslation('aico');
-  const navigate = useWorkspaceAwareNavigate();
-  const { blockReason, showTrialCta } = useAicoBillingChatGate();
+const ManagedKeyError = memo<ManagedKeyErrorProps>(
+  ({ onNavigate, reason = 'funds', serverErrorCode }) => {
+    const { t } = useTranslation('aico');
+    const navigate = useWorkspaceAwareNavigate();
+    const { blockReason, showTrialCta } = useAicoBillingChatGate();
+    const { activeSource } = useAicoBillingSources();
 
-  const goWallet = () => {
-    navigate('/wallet');
-    onNavigate?.();
-  };
+    const goWallet = () => {
+      navigate('/wallet');
+      onNavigate?.();
+    };
 
-  if (reason === 'wrongProvider') {
+    if (reason === 'wrongProvider') {
+      return (
+        <BaseErrorForm
+          avatar={<ProductLogo size={40} type={'flat'} />}
+          desc={t('errors.managedKey.wrongProviderDescription', { brandName: BRANDING_NAME })}
+          title={t('errors.managedKey.wrongProviderTitle', { brandName: BRANDING_NAME })}
+          action={
+            <Button type={'primary'} onClick={() => onNavigate?.()}>
+              {t('errors.managedKey.wrongProviderAction')}
+            </Button>
+          }
+        />
+      );
+    }
+
+    const description = resolveManagedKeyErrorDescription({
+      activeSource,
+      blockReason,
+      serverErrorCode,
+      showTrialCta,
+      t,
+    });
+
+    const showTrialActions = shouldShowManagedKeyTrialActions({
+      activeSource,
+      blockReason,
+      serverErrorCode,
+      showTrialCta,
+    });
+
     return (
       <BaseErrorForm
         avatar={<ProductLogo size={40} type={'flat'} />}
-        desc={t('errors.managedKey.wrongProviderDescription', { brandName: BRANDING_NAME })}
-        title={t('errors.managedKey.wrongProviderTitle', { brandName: BRANDING_NAME })}
+        desc={description}
+        title={t('errors.managedKey.title', { brandName: BRANDING_NAME })}
         action={
-          <Button type={'primary'} onClick={() => onNavigate?.()}>
-            {t('errors.managedKey.wrongProviderAction')}
-          </Button>
+          <Flexbox horizontal gap={8} wrap="wrap">
+            <Button type={'primary'} onClick={goWallet}>
+              {t('billing.fundsBlocked.goWallet')}
+            </Button>
+            {showTrialActions ? (
+              <Button onClick={goWallet}>{t('billing.fundsBlocked.startTrial')}</Button>
+            ) : null}
+          </Flexbox>
         }
       />
     );
-  }
-
-  const description =
-    blockReason === 'PERSONAL_FUNDS_UNAVAILABLE' && showTrialCta
-      ? t('billing.fundsBlocked.descWithTrial')
-      : blockReason
-        ? t(`errors.${blockReason}`)
-        : t('errors.managedKey.description');
-
-  return (
-    <BaseErrorForm
-      avatar={<ProductLogo size={40} type={'flat'} />}
-      desc={description}
-      title={t('errors.managedKey.title', { brandName: BRANDING_NAME })}
-      action={
-        <Flexbox horizontal gap={8} wrap="wrap">
-          <Button type={'primary'} onClick={goWallet}>
-            {t('billing.fundsBlocked.goWallet')}
-          </Button>
-          {showTrialCta ? (
-            <Button onClick={goWallet}>{t('billing.fundsBlocked.startTrial')}</Button>
-          ) : null}
-        </Flexbox>
-      }
-    />
-  );
-});
+  },
+);
 
 ManagedKeyError.displayName = 'ManagedKeyError';
 

--- a/src/features/Conversation/Error/resolveManagedKeyErrorDescription.test.ts
+++ b/src/features/Conversation/Error/resolveManagedKeyErrorDescription.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AicoBillingSource } from '@/features/AicoBilling/types';
+
+import {
+  resolveManagedKeyErrorDescription,
+  shouldShowManagedKeyTrialActions,
+} from './resolveManagedKeyErrorDescription';
+
+const orgSource: AicoBillingSource = {
+  hasManagedKey: true,
+  isActive: true,
+  organizationId: 'org-1',
+  organizationName: 'Acme',
+  remainingMicroUsd: '5000000',
+  remainingUsd: '5.000000',
+  renewalBlocked: false,
+  source: 'organization',
+};
+
+const t = vi.fn((key: string) => key);
+
+describe('resolveManagedKeyErrorDescription', () => {
+  it('prefers server Aico error code over gate fallback', () => {
+    expect(
+      resolveManagedKeyErrorDescription({
+        activeSource: orgSource,
+        blockReason: null,
+        serverErrorCode: 'MEMBER_BUDGET_UNFUNDED',
+        showTrialCta: false,
+        t,
+      }),
+    ).toBe('errors.MEMBER_BUDGET_UNFUNDED');
+  });
+
+  it('uses org unfunded copy when org is active and gate is open', () => {
+    expect(
+      resolveManagedKeyErrorDescription({
+        activeSource: orgSource,
+        blockReason: null,
+        showTrialCta: false,
+        t,
+      }),
+    ).toBe('errors.MEMBER_BUDGET_UNFUNDED');
+  });
+
+  it('uses personal trial copy only for personal source', () => {
+    expect(
+      resolveManagedKeyErrorDescription({
+        activeSource: {
+          hasManagedKey: false,
+          isActive: true,
+          remainingMicroUsd: '0',
+          remainingUsd: '0.000000',
+          source: 'personal',
+        },
+        blockReason: 'PERSONAL_FUNDS_UNAVAILABLE',
+        showTrialCta: true,
+        t,
+      }),
+    ).toBe('billing.fundsBlocked.descWithTrial');
+  });
+});
+
+describe('shouldShowManagedKeyTrialActions', () => {
+  it('hides trial actions on org billing source', () => {
+    expect(
+      shouldShowManagedKeyTrialActions({
+        activeSource: orgSource,
+        blockReason: 'PERSONAL_FUNDS_UNAVAILABLE',
+        showTrialCta: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/Conversation/Error/resolveManagedKeyErrorDescription.ts
+++ b/src/features/Conversation/Error/resolveManagedKeyErrorDescription.ts
@@ -1,0 +1,55 @@
+import { resolveAicoErrorCode } from '@lobechat/business-const';
+import type { TFunction } from 'i18next';
+
+import { resolveAicoErrorMessage } from '@/business/client/resolveAicoErrorMessage';
+import type { AicoBillingChatBlockReason, AicoBillingSource } from '@/features/AicoBilling/types';
+
+export const resolveManagedKeyErrorDescription = (params: {
+  activeSource: AicoBillingSource | undefined;
+  blockReason: AicoBillingChatBlockReason | null;
+  serverErrorCode?: string;
+  showTrialCta: boolean;
+  t: TFunction<'aico'>;
+}): string => {
+  const { activeSource, blockReason, serverErrorCode, showTrialCta, t } = params;
+
+  const resolvedServerMessage = serverErrorCode
+    ? resolveAicoErrorMessage(serverErrorCode, t)
+    : undefined;
+
+  if (resolvedServerMessage) return resolvedServerMessage;
+
+  if (
+    blockReason === 'PERSONAL_FUNDS_UNAVAILABLE' &&
+    showTrialCta &&
+    activeSource?.source === 'personal'
+  ) {
+    return t('billing.fundsBlocked.descWithTrial');
+  }
+
+  if (blockReason) return t(`errors.${blockReason}`);
+
+  if (activeSource?.source === 'organization') {
+    return t('errors.MEMBER_BUDGET_UNFUNDED');
+  }
+
+  return t('errors.managedKey.description');
+};
+
+export const shouldShowManagedKeyTrialActions = (params: {
+  activeSource: AicoBillingSource | undefined;
+  blockReason: AicoBillingChatBlockReason | null;
+  serverErrorCode?: string;
+  showTrialCta: boolean;
+}): boolean => {
+  const { activeSource, blockReason, serverErrorCode, showTrialCta } = params;
+  const resolvedServerCode = serverErrorCode ? resolveAicoErrorCode(serverErrorCode) : undefined;
+
+  return (
+    showTrialCta &&
+    activeSource?.source === 'personal' &&
+    (resolvedServerCode === 'PERSONAL_FUNDS_UNAVAILABLE' ||
+      blockReason === 'PERSONAL_FUNDS_UNAVAILABLE' ||
+      blockReason === 'MANAGED_KEY_UNAVAILABLE')
+  );
+};


### PR DESCRIPTION
#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression coverage: cycle remaining helpers, period-aware OR sync, lazy `ensureMemberKey` on sources fetch, ChatMessageError `body.error` extraction, fail-closed chat gate while loading.

#### 🔗 Related Issue

Fixes #241

Plane: [AICO-145](https://plane.panafor.com/panaforai/browse/AICO-145)

#### Description of Change

Org members with allocated credit could select the org wallet (remaining > $0) and still hit the generic “charge personal wallet / use org credit” error.

- Align org remaining with current-cycle `periodAmount − settled` (FIN-001; ignore pending reserved hold)
- Replace lifetime OpenRouter usage sync with period-aware `syncMemberCycleUsage`
- Lazy-repair missing/stale member keys on `getMyBillingSources` / authorize
- Surface Aico codes from `error.body.error` in ManagedKeyError; fail-closed while billing hydrates


Made with [Cursor](https://cursor.com)