### PR TITLE
🐛 fix(xai): prefer Live Search when chat search is enabled

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/searchDecision.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/searchDecision.test.ts
@@ -10,7 +10,7 @@ describe('resolveServerSearchDecision', () => {
           abilities: { search: true },
           id: 'grok-4.3',
           providerId: 'xai',
-          settings: { searchImpl: 'params' },
+          settings: { searchImpl: 'tool' },
         },
       ],
       chatConfig: { searchMode: 'on', useModelBuiltinSearch: true },
@@ -20,6 +20,38 @@ describe('resolveServerSearchDecision', () => {
 
     expect(result.useModelSearch).toBe(false);
     expect(result.useApplicationBuiltinSearchTool).toBe(true);
+  });
+
+  it('uses xAI Live Search for multi-agent Grok without the builtin toggle', () => {
+    const result = resolveServerSearchDecision({
+      builtinModels: [
+        {
+          abilities: { search: true },
+          id: 'grok-4.20-multi-agent-0309',
+          providerId: 'xai',
+          settings: { searchImpl: 'tool' },
+        },
+      ],
+      chatConfig: { searchMode: 'auto', useModelBuiltinSearch: false },
+      model: 'grok-4.20-multi-agent-0309',
+      provider: 'xai',
+    });
+
+    expect(result.useModelSearch).toBe(true);
+    expect(result.useApplicationBuiltinSearchTool).toBe(false);
+  });
+
+  it('infers tool search for a remotely discovered xAI model', () => {
+    const result = resolveServerSearchDecision({
+      builtinModels: [],
+      chatConfig: { searchMode: 'on', useModelBuiltinSearch: false },
+      model: 'grok-new-remote',
+      modelSearchAbility: true,
+      provider: 'xai',
+    });
+
+    expect(result.useModelSearch).toBe(true);
+    expect(result.useApplicationBuiltinSearchTool).toBe(false);
   });
 
   it('honors a stored abilities override that omits builtin search', () => {
@@ -46,7 +78,11 @@ describe('resolveServerSearchDecision', () => {
     (provider) => {
       const result = resolveServerSearchDecision({
         builtinModels: [],
-        chatConfig: { searchMode: 'on', useModelBuiltinSearch: true },
+        chatConfig: {
+          searchMode: 'on',
+          // SuperGrok uses tool search (no toggle); OpenRouter still needs params toggle.
+          useModelBuiltinSearch: provider === 'openrouter' ? true : false,
+        },
         model: 'new-remote-model',
         provider,
       });

--- a/packages/model-bank/src/aiModels/superGrok.ts
+++ b/packages/model-bank/src/aiModels/superGrok.ts
@@ -26,7 +26,7 @@ const superGrokChatModels: AIChatModelCard[] = [
     releasedAt: '2026-07-08',
     settings: {
       extendParams: ['grok4_5ReasoningEffort'],
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -28,7 +28,7 @@ const xaiChatModels: AIChatModelCard[] = [
     releasedAt: '2026-07-08',
     settings: {
       extendParams: ['grok4_5ReasoningEffort'],
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },
@@ -81,7 +81,7 @@ const xaiChatModels: AIChatModelCard[] = [
     releasedAt: '2026-05-01',
     settings: {
       extendParams: ['grok4_3ReasoningEffort'],
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },
@@ -132,7 +132,7 @@ const xaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-03-09',
     settings: {
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },
@@ -184,7 +184,7 @@ const xaiChatModels: AIChatModelCard[] = [
     },
     releasedAt: '2026-03-09',
     settings: {
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },
@@ -237,7 +237,7 @@ const xaiChatModels: AIChatModelCard[] = [
     releasedAt: '2026-03-09',
     settings: {
       extendParams: ['grok4_20ReasoningEffort'],
-      searchImpl: 'params',
+      searchImpl: 'tool',
     },
     type: 'chat',
   },

--- a/packages/model-bank/src/modelProviders/superGrok.ts
+++ b/packages/model-bank/src/modelProviders/superGrok.ts
@@ -32,7 +32,8 @@ const SuperGrok: ModelProviderCard = {
       tokenEndpoint: 'https://auth.x.ai/oauth2/token',
     },
     sdkType: 'openai',
-    searchMode: 'params',
+    // xAI Live Search is injected as server tools (web_search / x_search), not params.
+    searchMode: 'tool',
     showApiKey: false,
     showChecker: true,
   },

--- a/packages/model-bank/src/types/aiProvider.ts
+++ b/packages/model-bank/src/types/aiProvider.ts
@@ -251,7 +251,7 @@ const AiProviderSettingsSchema = z.object({
     .or(ResponseAnimationType)
     .optional(),
   sdkType: z.enum(AiProviderSdkTypes).optional(),
-  searchMode: z.enum(['params', 'internal']).optional(),
+  searchMode: z.enum(['params', 'internal', 'tool']).optional(),
   showAddNewModel: z.boolean().optional(),
   showApiKey: z.boolean().optional(),
   showChecker: z.boolean().optional(),

--- a/packages/model-bank/src/utils.test.ts
+++ b/packages/model-bank/src/utils.test.ts
@@ -39,6 +39,24 @@ describe('resolveSearchDecision', () => {
     },
     {
       expected: { application: false, model: true },
+      input: {
+        modelSearchImpl: 'tool' as const,
+        searchMode: 'on' as const,
+        useModelBuiltinSearch: false,
+      },
+      name: 'uses tool-based native search without requiring the builtin toggle',
+    },
+    {
+      expected: { application: false, model: true },
+      input: {
+        providerSearchMode: 'tool' as const,
+        searchMode: 'auto' as const,
+        useModelBuiltinSearch: false,
+      },
+      name: 'uses provider tool search (e.g. SuperGrok) without the builtin toggle',
+    },
+    {
+      expected: { application: false, model: true },
       input: { providerSearchMode: 'internal' as const, searchMode: 'on' as const },
       name: 'always uses internal provider search while search is enabled',
     },
@@ -61,6 +79,12 @@ describe('resolveModelSearchDefaultSettings', () => {
   it('falls back to params for unknown providers', () => {
     expect(resolveModelSearchDefaultSettings('custom-provider', 'remote-model')).toEqual({
       searchImpl: 'params',
+    });
+  });
+
+  it('defaults xAI remote models to tool-based Live Search', () => {
+    expect(resolveModelSearchDefaultSettings('xai', 'grok-remote')).toEqual({
+      searchImpl: 'tool',
     });
   });
 });

--- a/packages/model-bank/src/utils.ts
+++ b/packages/model-bank/src/utils.ts
@@ -22,6 +22,9 @@ export interface SearchDecision {
 
 /**
  * Resolves the mutually exclusive search route shared by client and server runtimes.
+ *
+ * `internal` and `tool` always prefer the model's native search while search is on
+ * (no second "use model builtin search" toggle). `params` still requires that toggle.
  */
 export const resolveSearchDecision = ({
   modelSearchImpl,
@@ -32,11 +35,17 @@ export const resolveSearchDecision = ({
   const enabledSearch = searchMode !== 'off';
   const isModelHasBuiltinSearch = !!modelSearchImpl;
   const isProviderHasBuiltinSearch = !!providerSearchMode;
-  const isBuiltinSearchInternal =
-    modelSearchImpl === 'internal' || providerSearchMode === 'internal';
+  // `internal` = always-on native search (Perplexity, Jina, …).
+  // `tool` = provider server tools (e.g. xAI web_search / x_search) — prefer native
+  // whenever search is enabled so Live Search is not skipped for the app helper.
+  const prefersNativeBuiltinSearch =
+    modelSearchImpl === 'internal' ||
+    modelSearchImpl === 'tool' ||
+    providerSearchMode === 'internal' ||
+    providerSearchMode === 'tool';
   const useModelSearch =
     enabledSearch &&
-    (isBuiltinSearchInternal ||
+    (prefersNativeBuiltinSearch ||
       ((isModelHasBuiltinSearch || isProviderHasBuiltinSearch) && !!useModelBuiltinSearch));
 
   return {
@@ -67,7 +76,7 @@ const PROVIDER_SEARCH_DEFAULTS: Record<string, ModelSearchSettings> = {
   stepfun: { searchImpl: 'params' },
   vertexai: { searchImpl: 'params', searchProvider: 'google' },
   wenxin: { searchImpl: 'params' },
-  xai: { searchImpl: 'params' },
+  xai: { searchImpl: 'tool' },
   zhipu: { searchImpl: 'params' },
 };
 

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.test.ts
@@ -684,6 +684,56 @@ describe('OpenAIResponsesStream', () => {
     expect(chunks.some((c) => c.includes('citations'))).toBe(true);
   });
 
+  it('should filter out empty url_citation annotations on the Responses path', async () => {
+    const mockOpenAIStream = createReadableStream([
+      {
+        type: 'response.created',
+        response: {
+          id: 'resp_empty_citation',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.output_text.annotation.added',
+        item_id: 'msg_empty',
+        annotation: {
+          type: 'url_citation',
+          title: 'Broken',
+          // empty / missing url must not reach grounding consumers
+        },
+      },
+      {
+        type: 'response.output_text.annotation.added',
+        item_id: 'msg_empty',
+        annotation: {
+          type: 'url_citation',
+          title: 'Valid',
+          url: 'https://valid.example',
+          start_index: 0,
+          end_index: 4,
+        },
+      },
+      {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: 'msg_empty',
+          type: 'message',
+          status: 'completed',
+        },
+      },
+    ]);
+
+    const protocolStream = OpenAIResponsesStream(mockOpenAIStream);
+    const chunks = await readStreamChunk(protocolStream);
+
+    const grounding = chunks.find((c) => c.includes('event: grounding'));
+    expect(grounding).toBeDefined();
+    expect(chunks.some((c) => c.includes('https://valid.example'))).toBe(true);
+    expect(chunks.some((c) => c.includes('"Broken"'))).toBe(false);
+    expect(chunks.filter((c) => c.includes('"url"')).length).toBeGreaterThan(0);
+  });
+
   it('should handle response.output_item.done without citations', async () => {
     const mockOpenAIStream = createReadableStream([
       {

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -22,6 +22,14 @@ import {
 } from '../protocol';
 import type { OpenAIStreamOptions } from './openai';
 
+/**
+ * Drop citations without a valid url. Some providers emit empty citation objects
+ * which would otherwise break downstream rendering and persistence.
+ * See https://github.com/lobehub/lobehub/issues/15043
+ */
+const filterValidCitations = (citations: ChatCitationItem[]): ChatCitationItem[] =>
+  citations.filter((citation) => !!citation?.url);
+
 const transformOpenAIStream = (
   chunk:
     | OpenAI.Responses.ResponseStreamEvent
@@ -136,11 +144,11 @@ const transformOpenAIStream = (
         // OpenAI SDK v6 types the annotation payload as `unknown`; narrow to the URL-citation shape we read.
         const citations = chunk.annotation as { title?: string; url?: string };
 
-        if (streamContext.returnedCitationArray) {
+        if (streamContext.returnedCitationArray && citations.url) {
           streamContext.returnedCitationArray.push({
             title: citations.title,
             url: citations.url,
-          } as ChatCitationItem);
+          });
         }
 
         return { data: null, id: chunk.item_id, type: 'text' };
@@ -188,9 +196,10 @@ const transformOpenAIStream = (
           return chunks;
         }
 
-        if (streamContext.returnedCitationArray?.length) {
+        const validCitations = filterValidCitations(streamContext.returnedCitationArray ?? []);
+        if (validCitations.length) {
           return {
-            data: { citations: streamContext.returnedCitationArray },
+            data: { citations: validCitations },
             id: chunk.item.id,
             type: 'grounding',
           };

--- a/packages/model-runtime/src/providers/xai/index.ts
+++ b/packages/model-runtime/src/providers/xai/index.ts
@@ -119,7 +119,8 @@ export const handleXAIResponsesPayload = (payload: ChatStreamPayload) => {
   const sanitizedTools = sanitizeXAITools(tools);
 
   const xaiTools = enabledSearch
-    ? [...(sanitizedTools || []), { type: 'web_search' }, { type: 'x_search' }]
+    ? // Live Search: inject xAI server-side web_search + x_search tools (Responses API).
+      [...(sanitizedTools || []), { type: 'web_search' }, { type: 'x_search' }]
     : sanitizedTools;
 
   return {

--- a/packages/types/src/search.ts
+++ b/packages/types/src/search.ts
@@ -13,7 +13,8 @@ export enum ModelSearchImplement {
    */
   Params = 'params',
   /**
-   * Uses tool calling approach
+   * Uses provider-native server tools (e.g. xAI Live Search via web_search / x_search).
+   * Prefer this path whenever search is enabled — no optional "use model builtin" toggle.
    */
   Tool = 'tool',
 }

--- a/src/features/ChatInput/ActionBar/Search/Controls.tsx
+++ b/src/features/ChatInput/ActionBar/Search/Controls.tsx
@@ -164,9 +164,14 @@ const Controls = memo(() => {
     !isModelBuiltinSearchInternal &&
     (isModelHasBuiltinSearchConfig || isProviderHasBuiltinSearchConfig);
 
+  // `tool` (e.g. xAI Live Search) always uses model-native search while search is on —
+  // same as `internal` for routing — so do not offer the app FC search-model picker.
+  const prefersNativeBuiltinSearch =
+    isModelBuiltinSearchInternal || modelBuiltinSearchImpl === 'tool';
+
   const showFCSearchModel =
     !supportFC &&
-    (!modelBuiltinSearchImpl || (!isModelBuiltinSearchInternal && !useModelBuiltinSearch));
+    (!modelBuiltinSearchImpl || (!prefersNativeBuiltinSearch && !useModelBuiltinSearch));
 
   const showDivider = showModelBuiltinSearch || showFCSearchModel;
 

--- a/src/features/ChatInput/hooks/useAgentEnableSearch.ts
+++ b/src/features/ChatInput/hooks/useAgentEnableSearch.ts
@@ -21,7 +21,7 @@ export const useAgentEnableSearch = () => {
   const searchImpl = useAiInfraStore(aiModelSelectors.modelBuiltinSearchImpl(model, provider));
 
   // If using a built-in search implementation, web search is always available
-  if (searchImpl === 'internal') return true;
+  if (searchImpl === 'internal' || searchImpl === 'tool') return true;
 
   // If the search mode is off, web search is never available
   return agentSearchMode !== 'off';

--- a/src/helpers/getSearchConfig.test.ts
+++ b/src/helpers/getSearchConfig.test.ts
@@ -174,4 +174,28 @@ describe('getSearchConfig', () => {
       useApplicationBuiltinSearchTool: false,
     });
   });
+
+  it('should use xAI tool Live Search without the builtin toggle', () => {
+    vi.mocked(chatConfigByIdSelectors.getChatConfigById).mockReturnValue(
+      () =>
+        ({
+          searchMode: 'auto',
+          useModelBuiltinSearch: false,
+        }) as any,
+    );
+
+    vi.mocked(aiInfraSelectors.aiModelSelectors.modelBuiltinSearchImpl).mockReturnValue(
+      () => 'tool',
+    );
+
+    const result = getSearchConfig('grok-4.20-multi-agent-0309', 'xai');
+
+    expect(result).toEqual({
+      enabledSearch: true,
+      isProviderHasBuiltinSearch: false,
+      isModelHasBuiltinSearch: true,
+      useModelSearch: true,
+      useApplicationBuiltinSearchTool: false,
+    });
+  });
 });

--- a/src/store/aiInfra/slices/aiModel/selectors.ts
+++ b/src/store/aiInfra/slices/aiModel/selectors.ts
@@ -139,16 +139,16 @@ const isModelBuiltinSearchInternal =
     return searchImpl === ModelSearchImplement.Internal;
   };
 
+/**
+ * True when the user can choose between app search and model-native search
+ * (`params` only). `internal` / `tool` always use native search while search is on,
+ * so they do not show the "use model builtin search" toggle.
+ */
 const isModelHasBuiltinSearchConfig =
   (id: string, provider: string) => (s: AIProviderStoreState) => {
     const searchImpl = modelBuiltinSearchImpl(id, provider)(s);
 
-    return (
-      !!searchImpl &&
-      [ModelSearchImplement.Tool, ModelSearchImplement.Params].includes(
-        searchImpl as ModelSearchImplement,
-      )
-    );
+    return searchImpl === ModelSearchImplement.Params;
   };
 
 export const aiModelSelectors = {

--- a/src/store/aiInfra/slices/aiProvider/__tests__/selectors.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/selectors.test.ts
@@ -276,6 +276,34 @@ describe('aiProviderSelectors', () => {
         false,
       );
     });
+
+    it('should return false if search mode is tool (no user toggle)', () => {
+      const state = {
+        ...mockState,
+        aiProviderRuntimeConfig: {
+          ...mockState.aiProviderRuntimeConfig,
+          xai: {
+            keyVaults: {},
+            settings: { searchMode: 'tool' },
+          },
+        },
+      };
+      expect(aiProviderSelectors.isProviderHasBuiltinSearchConfig('xai')(state)).toBe(false);
+    });
+
+    it('should return true if search mode is params', () => {
+      const state = {
+        ...mockState,
+        aiProviderRuntimeConfig: {
+          ...mockState.aiProviderRuntimeConfig,
+          openrouter: {
+            keyVaults: {},
+            settings: { searchMode: 'params' },
+          },
+        },
+      };
+      expect(aiProviderSelectors.isProviderHasBuiltinSearchConfig('openrouter')(state)).toBe(true);
+    });
   });
 
   describe('isProviderEnableResponseApi', () => {

--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -120,8 +120,11 @@ const isProviderHasBuiltinSearch = (provider: string) => (s: AIProviderStoreStat
 
 const isProviderHasBuiltinSearchConfig = (id: string) => (s: AIProviderStoreState) => {
   const providerCfg = providerConfigById(id)(s);
+  const searchMode = providerCfg?.settings.searchMode;
 
-  return !!providerCfg?.settings.searchMode && providerCfg?.settings.searchMode !== 'internal';
+  // Only `params` exposes a user toggle between app vs model-native search.
+  // `internal` / `tool` always prefer native search while search is enabled.
+  return searchMode === 'params';
 };
 
 const isProviderEnableResponseApi = (id: string) => (s: AIProviderStoreState) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [ ] ✨ feat
- [ ] 💄 style
- [ ] ♻️ refactor
- [ ] 📝 docs
- [ ] 🔧 chore

#### 📝 Description of Change

xAI/Grok Live Search was skipped whenever chat search was on but the optional “use model builtin search” switch stayed off (the default). The app helper was used instead — which breaks Multi-Agent Grok (no client tools).

This change:
- Marks xAI/SuperGrok search as `searchImpl: 'tool'` and prefers native `web_search` / `x_search` whenever search is enabled
- Filters empty/invalid citation URLs on the Responses stream (parity with Chat Completions)
- Hides the redundant builtin-search toggle for tool-based native search

#### 🔗 Related Issue

Fixes #245

Plane: [AICO-146](https://plane.panafor.com/panaforai/browse/AICO-146)

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression coverage for `resolveSearchDecision` / server search decision / `getSearchConfig`, Responses empty-citation filtering, and provider selector toggle visibility.

Made with [Cursor](https://cursor.com)