### PR TITLE
✨ feat(deploy): Panachat canary CI/CD with blue-green deploy

### DIFF
--- a/.agents/skills/self-host-deploy/SKILL.md
+++ b/.agents/skills/self-host-deploy/SKILL.md
@@ -94,7 +94,13 @@ docker build -t aico/lobehub:latest .
 
 Build pipeline inside Dockerfile runs: `build:spa` → `build:spa:mobile` → `build:spa:auth` → `build:spa:workbench` → `build:spa:copy` → `next build`. Never skip `build:spa:copy` — it publishes JS chunks to `public/_spa*`.
 
----
+### Path C: Canary CI/CD (production VPS)
+
+For a Linux server that must always match GitHub `canary` with no data loss and near-zero downtime, use the Panachat blue-green pipeline:
+
+→ **[canary-cicd.md](canary-cicd.md)** (`deploy-canary.yml` + `panachat-deploy-remote.sh` + `docker-compose.panachat.yml`)
+
+## Image: private `ghcr.io/<owner>/panachat:<sha>`. Volumes: `panachat_*` only.
 
 ## Reverse proxy / CDN
 
@@ -217,10 +223,12 @@ Full troubleshooting: [reference.md](reference.md)
 | **CDN**     | Pass `/_spa*` through unchanged; cache hashed assets, not HTML                                            |
 | **Deploy**  | Backup → pull/rebuild → `verify-deployment.sh` → rollback plan ready                                      |
 | **Updates** | Pin image tags; never `pull` without a DB backup                                                          |
+| **Canary**  | Server tracks GitHub `canary` via GHCR + blue-green — see [canary-cicd.md](canary-cicd.md)                |
 
 Templates:
 
 - [production.env.example](templates/production.env.example)
 - [docker-compose.production.override.yml](templates/docker-compose.production.override.yml)
+- [canary-cicd.md](canary-cicd.md) — Panachat CI/CD (private GHCR, `panachat-deploy-remote.sh`)
 
 Complete guide: [best-practices.md](best-practices.md)

--- a/.agents/skills/self-host-deploy/canary-cicd.md
+++ b/.agents/skills/self-host-deploy/canary-cicd.md
@@ -1,0 +1,109 @@
+# Panachat canary CI/CD (server)
+
+Keep a single Linux VPS in sync with GitHub `canary`: build in Actions → private GHCR image → SSH blue-green deploy. Data plane (Postgres / Redis / RustFS) is never recreated.
+
+## Architecture
+
+| Piece          | Name                                                                                                              |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Image          | `ghcr.io/<owner>/panachat:<sha>` and `:canary`                                                                    |
+| Compose        | [`docker-compose/deploy/docker-compose.panachat.yml`](../../../docker-compose/deploy/docker-compose.panachat.yml) |
+| Deploy         | [`scripts/panachat-deploy-remote.sh`](../../../scripts/panachat-deploy-remote.sh)                                 |
+| Workflow       | [`.github/workflows/deploy-canary.yml`](../../../.github/workflows/deploy-canary.yml)                             |
+| State          | `/var/lib/panachat/deploy.env`                                                                                    |
+| Nginx upstream | `panachat_backend` → `127.0.0.1:3210` (blue) or `:3211` (green)                                                   |
+| Volumes        | `panachat_postgres_data`, `panachat_redis_data`, `panachat_rustfs_data`                                           |
+
+**Hard bans:** `docker compose down -v`, `docker volume rm panachat_*`, wiping `PANACHAT_DATA_DIR` as if it were PGDATA.
+
+## One-time server bootstrap
+
+### 1. Prerequisites
+
+- Docker + Compose v2
+- nginx (or Caddy with equivalent upstream flip)
+- UFW: allow 22 / 80 / 443 only
+- Git clone of this repo (or deploy checkout) at e.g. `~/panachat`
+
+### 2. Env files
+
+```bash
+cp .env.example.panachat .env
+cp docker-compose/deploy/.env.example.panachat docker-compose/deploy/.env
+chmod 600 .env docker-compose/deploy/.env
+# Rotate AUTH_SECRET, KEY_VAULTS_SECRET, POSTGRES_PASSWORD, RUSTFS_SECRET_KEY, JWKS_KEY
+```
+
+Set `APP_URL`, `AUTH_TRUSTED_ORIGINS`, browser-reachable `S3_ENDPOINT`, and `PANACHAT_IMAGE` (filled by deploy script after first pull).
+
+### 3. Private GHCR login
+
+The repo may be public; the **`panachat` package must stay private**.
+
+```bash
+# PAT with read:packages (classic) or fine-grained Packages read
+echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
+```
+
+After the first Actions push, confirm Package settings → **Private** (workflow tries to set this via API).
+
+### 4. Nginx
+
+```bash
+sudo cp docker-compose/deploy/nginx/panachat-upstream.blue.conf \
+  /etc/nginx/conf.d/panachat-upstream.conf
+# Adapt and enable docker-compose/deploy/nginx/panachat-site.example.conf
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### 5. First start (blue slot)
+
+```bash
+export PANACHAT_IMAGE=ghcr.io/ < owner > /panachat:canary # or a SHA tag
+./scripts/panachat-deploy-remote.sh bootstrap "$PANACHAT_IMAGE"
+./scripts/panachat-backup.sh --install-cron
+```
+
+Optional control plane (requires built `apps/aico-control-plane` on the checkout):
+
+```bash
+export COMPOSE_PROFILES=control-plane
+# set AICO_CONTROL_PLANE_SERVICE_TOKEN in .env
+docker compose -f docker-compose/deploy/docker-compose.panachat.yml \
+  --env-file .env --env-file docker-compose/deploy/.env \
+  --profile control-plane up -d panachat-control-plane
+```
+
+### 6. GitHub Actions secrets
+
+| Secret            | Purpose                                               |
+| ----------------- | ----------------------------------------------------- |
+| `DEPLOY_HOST`     | Server hostname/IP                                    |
+| `DEPLOY_USER`     | SSH user                                              |
+| `DEPLOY_SSH_KEY`  | Private key                                           |
+| `DEPLOY_PATH`     | Optional repo root on server (default `~/panachat`)   |
+| `GHCR_READ_TOKEN` | PAT with `read:packages` for the server `docker pull` |
+
+Every push to `canary` builds, pushes GHCR, then runs:
+
+```bash
+./scripts/panachat-deploy-remote.sh deploy ghcr.io/<owner>/panachat:<sha>
+```
+
+Manual: Actions → **Deploy Panachat Canary** → `workflow_dispatch` (optional skip deploy).
+
+## Day-2 ops
+
+```bash
+./scripts/panachat-deploy-remote.sh status
+./scripts/panachat-deploy-remote.sh rollback # previous SHA, blue-green
+./scripts/panachat-backup.sh --reason manual
+bash .claude/skills/self-host-deploy/scripts/verify-deployment.sh https://chat.example.com
+```
+
+App updates only touch `panachat-blue` / `panachat-green`. Data services stay up. Failed health checks leave traffic on the old slot.
+
+## Near-zero downtime notes
+
+- Nginx reload flips `panachat_backend` in under a second for normal releases.
+- Breaking DB migrations can still require a careful window (old app + new schema). Prefer additive / expand-contract migrations.

--- a/.env.example.panachat
+++ b/.env.example.panachat
@@ -1,0 +1,61 @@
+# Panachat application environment (server / canary CI-CD)
+# Source of truth for app behavior, auth, branding, and public URLs.
+# Compose loads this first, then docker-compose/deploy/.env for infra.
+
+# Public URLs
+APP_URL=https://chat.example.com
+INTERNAL_APP_URL=http://localhost:3210
+AUTH_TRUSTED_ORIGINS=https://chat.example.com
+
+# Branding
+BRANDING_NAME=Panachat
+NEXT_PUBLIC_BRANDING_NAME=Panachat
+BRANDING_NAME_FA=پاناچت
+NEXT_PUBLIC_BRANDING_NAME_FA=پاناچت
+ORG_NAME=Panachat
+NEXT_PUBLIC_ORG_NAME=Panachat
+ORG_NAME_FA=پاناچت
+NEXT_PUBLIC_ORG_NAME_FA=پاناچت
+BRANDING_CLOUD_NAME=Panachat Cloud
+NEXT_PUBLIC_BRANDING_CLOUD_NAME=Panachat Cloud
+BRANDING_CLOUD_NAME_FA=ابر پاناچت
+NEXT_PUBLIC_BRANDING_CLOUD_NAME_FA=ابر پاناچت
+
+# Auth
+AUTH_EMAIL_VERIFICATION=1
+# AUTH_ALLOWED_EMAILS=admin@example.com
+# AUTH_DISABLE_EMAIL_PASSWORD=1
+
+# Secrets — rotate before going public (required)
+KEY_VAULTS_SECRET=change-me-key-vaults-secret
+AUTH_SECRET=change-me-auth-secret
+
+# Email (Resend)
+# EMAIL_SERVICE_PROVIDER=resend
+# RESEND_API_KEY=re_xxxx
+# RESEND_FROM=Panachat <noreply@chat.example.com>
+
+# SSO
+# AUTH_SSO_PROVIDERS=github,google
+# AUTH_GITHUB_ID=
+# AUTH_GITHUB_SECRET=
+# AUTH_GOOGLE_ID=
+# AUTH_GOOGLE_SECRET=
+
+SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
+
+# Product ↔ control-plane (required if profile control-plane is enabled)
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=
+# AICO_CONTROL_PLANE_PUBLIC_URL=https://admin.example.com
+# AICO_INSECURE_AUTH_COOKIES=0
+
+# Providers
+# OPENAI_API_KEY=
+# OPENROUTER_API_KEY=
+# OPENROUTER_MANAGEMENT_API_KEY=   # control-plane only
+
+# Browser-reachable S3 (not the docker service name)
+# S3_ENDPOINT=https://s3.example.com
+# S3_BUCKET=lobe
+# S3_ENABLE_PATH_STYLE=1
+# S3_SET_ACL=0

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -1,0 +1,138 @@
+name: Deploy Panachat Canary
+
+# Build ghcr.io/<owner>/panachat on every push to canary, then SSH-deploy
+# with blue-green swap (scripts/panachat-deploy-remote.sh).
+#
+# Required secrets:
+#   DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
+#   GHCR_READ_TOKEN — PAT with read:packages (server pulls private ghcr.io/.../panachat)
+# Optional secrets:
+#   DEPLOY_PATH (repo root on server; default ~/panachat)
+#
+# Package visibility: workflow attempts to set the GHCR package to private
+# after push (public GitHub repo does not mean a public image).
+on:
+  push:
+    branches: [canary]
+  workflow_dispatch:
+    inputs:
+      skip_deploy:
+        description: 'Build/push only (skip SSH deploy)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-canary
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build and push Panachat image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vars.outputs.image }}
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Image name (lowercase)
+        id: vars
+        run: |
+          owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image=${{ env.REGISTRY }}/${owner_lc}/panachat" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.vars.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.sha_short }}
+            type=raw,value=${{ steps.vars.outputs.sha }}
+            type=raw,value=canary
+          labels: |
+            org.opencontainers.image.title=panachat
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SHA=${{ steps.vars.outputs.sha_short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Ensure GHCR package is private
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner='${{ github.repository_owner }}'
+          # Package name for container API is the image name without registry
+          pkg='panachat'
+          # Org vs user package endpoints
+          if gh api "orgs/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "orgs/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+            echo "Set org package ${owner}/${pkg} visibility=private"
+          elif gh api "users/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "users/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+            echo "Set user package ${owner}/${pkg} visibility=private"
+          else
+            echo "Package not visible yet via API — set Private in GitHub Packages UI after first push."
+          fi
+
+  deploy:
+    name: SSH blue-green deploy
+    needs: build
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script_stop: true
+          envs: IMAGE,DEPLOY_PATH,GHCR_USER,GHCR_TOKEN
+          script: |
+            set -euo pipefail
+            DEPLOY_PATH="${DEPLOY_PATH:-$HOME/panachat}"
+            cd "$DEPLOY_PATH"
+            if [ -n "${GHCR_TOKEN:-}" ]; then
+              echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+            fi
+            ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}

--- a/docker-compose/deploy/.env.example.panachat
+++ b/docker-compose/deploy/.env.example.panachat
@@ -1,0 +1,40 @@
+# Panachat deploy infrastructure (server / canary CI-CD)
+# Keep infra-only. App config lives in ../../.env (from .env.example.panachat).
+
+# GHCR image pin — set by panachat-deploy-remote.sh / GitHub Actions
+# PANACHAT_IMAGE=ghcr.io/panafor-ai-team/panachat:canary
+
+# Blue-green host ports (loopback only; nginx fronts 80/443)
+PANACHAT_PORT_BLUE=3210
+PANACHAT_PORT_GREEN=3211
+
+# Database (also exported as LOBE_DB_NAME for panachat-backup.sh compatibility)
+PANACHAT_DB_NAME=lobechat
+LOBE_DB_NAME=lobechat
+POSTGRES_PASSWORD=change-me-strong-password
+POSTGRES_CONTAINER=panachat-postgres
+
+# Object storage
+RUSTFS_PORT=9000
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_SECRET_KEY=change-me-strong-password
+RUSTFS_LOBE_BUCKET=lobe
+# Browser-reachable HTTPS endpoint (reverse-proxy to 127.0.0.1:9000)
+S3_ENDPOINT=https://s3.example.com
+
+# Auth / JWT bootstrap
+JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me","use":"sig","alg":"RS256","n":"replace-me","e":"AQAB","d":"replace-me","p":"replace-me","q":"replace-me","dp":"replace-me","dq":"replace-me","qi":"replace-me"}]}
+
+# Named volumes: panachat_postgres_data, panachat_redis_data, panachat_rustfs_data
+# Fingerprint / metadata only (not live PGDATA):
+PANACHAT_DATA_DIR=/var/lib/panachat/data
+# PANACHAT_BACKUP_DIR=/var/lib/panachat/backups
+
+# Optional control-plane profile
+# PANACHAT_CONTROL_PLANE_PORT=3020
+# COMPOSE_PROFILES=control-plane
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=
+# AICO_CONTROL_PLANE_PUBLIC_URL=https://admin.example.com
+
+# Nginx include rewritten by panachat-deploy-remote.sh
+# PANACHAT_NGINX_UPSTREAM_FILE=/etc/nginx/conf.d/panachat-upstream.conf

--- a/docker-compose/deploy/docker-compose.panachat.yml
+++ b/docker-compose/deploy/docker-compose.panachat.yml
@@ -1,0 +1,242 @@
+# Panachat production / canary CI-CD stack (blue-green app + durable data plane).
+#
+# Usage (from docker-compose/deploy):
+#   export PANACHAT_IMAGE=ghcr.io/panafor-ai-team/panachat:<sha>
+#   docker compose -f docker-compose.panachat.yml --env-file ../../.env --env-file .env up -d
+#
+# Deploy script (scripts/panachat-deploy-remote.sh) starts only the inactive
+# app slot, verifies it, flips nginx, then stops the old slot.
+# Never run `docker compose down -v` — named volumes hold production data.
+
+name: panachat
+
+services:
+  # App slots are profile-gated so `compose up -d` (data plane) never
+  # accidentally restarts a stopped color. Deploy script starts one profile.
+  panachat-blue:
+    image: ${PANACHAT_IMAGE:?set PANACHAT_IMAGE to ghcr.io/<owner>/panachat:<sha>}
+    container_name: panachat-blue
+    pull_policy: always
+    profiles:
+      - slot-blue
+    ports:
+      - '127.0.0.1:${PANACHAT_PORT_BLUE:-3210}:3210'
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
+      rustfs-init:
+        condition: service_completed_successfully
+    environment:
+      - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}'
+      - 'INTERNAL_APP_URL=http://localhost:3210'
+      - 'S3_ENDPOINT=${S3_ENDPOINT}'
+      - 'S3_BUCKET=${RUSTFS_LOBE_BUCKET}'
+      - 'S3_ENABLE_PATH_STYLE=1'
+      - 'S3_ACCESS_KEY=${RUSTFS_ACCESS_KEY}'
+      - 'S3_ACCESS_KEY_ID=${RUSTFS_ACCESS_KEY}'
+      - 'S3_SECRET_ACCESS_KEY=${RUSTFS_SECRET_KEY}'
+      - 'LLM_VISION_IMAGE_USE_BASE64=1'
+      - 'S3_SET_ACL=0'
+      - 'SEARXNG_URL=http://searxng:8080'
+      - 'REDIS_URL=redis://redis:6379'
+      - 'REDIS_PREFIX=${REDIS_PREFIX:-panachat}'
+      - 'REDIS_TLS=0'
+      - 'AICO_CONTROL_PLANE_URL=${AICO_CONTROL_PLANE_URL:-http://panachat-control-plane:3020}'
+      - 'OPENROUTER_MANAGEMENT_API_KEY='
+    env_file:
+      - ../../.env
+      - .env
+    networks:
+      - panachat-network
+    restart: unless-stopped
+
+  panachat-green:
+    image: ${PANACHAT_IMAGE:?set PANACHAT_IMAGE to ghcr.io/<owner>/panachat:<sha>}
+    container_name: panachat-green
+    pull_policy: always
+    profiles:
+      - slot-green
+    ports:
+      - '127.0.0.1:${PANACHAT_PORT_GREEN:-3211}:3210'
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
+      rustfs-init:
+        condition: service_completed_successfully
+    environment:
+      - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}'
+      - 'INTERNAL_APP_URL=http://localhost:3210'
+      - 'S3_ENDPOINT=${S3_ENDPOINT}'
+      - 'S3_BUCKET=${RUSTFS_LOBE_BUCKET}'
+      - 'S3_ENABLE_PATH_STYLE=1'
+      - 'S3_ACCESS_KEY=${RUSTFS_ACCESS_KEY}'
+      - 'S3_ACCESS_KEY_ID=${RUSTFS_ACCESS_KEY}'
+      - 'S3_SECRET_ACCESS_KEY=${RUSTFS_SECRET_KEY}'
+      - 'LLM_VISION_IMAGE_USE_BASE64=1'
+      - 'S3_SET_ACL=0'
+      - 'SEARXNG_URL=http://searxng:8080'
+      - 'REDIS_URL=redis://redis:6379'
+      - 'REDIS_PREFIX=${REDIS_PREFIX:-panachat}'
+      - 'REDIS_TLS=0'
+      - 'AICO_CONTROL_PLANE_URL=${AICO_CONTROL_PLANE_URL:-http://panachat-control-plane:3020}'
+      - 'OPENROUTER_MANAGEMENT_API_KEY='
+    env_file:
+      - ../../.env
+      - .env
+    networks:
+      - panachat-network
+    restart: unless-stopped
+
+  panachat-control-plane:
+    image: ${PANACHAT_CONTROL_PLANE_IMAGE:-node:24-bookworm-slim}
+    container_name: panachat-control-plane
+    profiles:
+      - control-plane
+    working_dir: ${PANACHAT_CONTROL_PLANE_WORKDIR:-/repo/apps/aico-control-plane}
+    volumes:
+      - ${PANACHAT_REPO_ROOT:-../..}:/repo
+    command: ['node', 'dist/standalone.js']
+    env_file:
+      - ../../.env
+      - .env
+    environment:
+      AICO_IS_CONTROL_PLANE: '1'
+      AICO_CONTROL_PLANE_PORT: '3020'
+      HONO_HOST: '0.0.0.0'
+      AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:-}
+      OPENROUTER_MANAGEMENT_API_KEY: ${OPENROUTER_MANAGEMENT_API_KEY:-}
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}
+      REDIS_URL: redis://redis:6379
+      REDIS_PREFIX: ${REDIS_PREFIX:-panachat}
+      REDIS_TLS: '0'
+      APP_URL: ${AICO_CONTROL_PLANE_PUBLIC_URL:-http://127.0.0.1:${PANACHAT_CONTROL_PLANE_PORT:-3020}}
+      AICO_CONTROL_PLANE_UI_URL: ${AICO_CONTROL_PLANE_PUBLIC_URL:-http://127.0.0.1:${PANACHAT_CONTROL_PLANE_PORT:-3020}}
+      INTERNAL_APP_URL: http://panachat-app:3210
+      AICO_INSECURE_AUTH_COOKIES: ${AICO_INSECURE_AUTH_COOKIES:-0}
+      NODE_ENV: production
+      ENABLE_MOCK_DEV_USER: '0'
+      MOCK_DEV_USER_ID: ''
+      AICO_ALLOW_CONTROL_PLANE_MOCK_AUTH: '0'
+      AICO_OPENROUTER_MOCK: '0'
+      AICO_ALLOW_INSECURE_CONTROL_PLANE: '0'
+    ports:
+      - '127.0.0.1:${PANACHAT_CONTROL_PLANE_PORT:-3020}:3020'
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(\"http://127.0.0.1:3020/health\").then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped
+    networks:
+      - panachat-network
+
+  postgresql:
+    image: paradedb/paradedb:latest-pg17
+    container_name: panachat-postgres
+    volumes:
+      - panachat_postgres_data:/var/lib/postgresql/data
+    command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
+    environment:
+      - 'POSTGRES_DB=${PANACHAT_DB_NAME}'
+      - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: always
+    networks:
+      - panachat-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: panachat-redis
+    command: redis-server --save 60 1000 --appendonly yes
+    volumes:
+      - panachat_redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: always
+    networks:
+      - panachat-network
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: panachat-rustfs
+    ports:
+      - '127.0.0.1:${RUSTFS_PORT:-9000}:9000'
+    environment:
+      - RUSTFS_CONSOLE_ENABLE=true
+      - RUSTFS_ACCESS_KEY=${RUSTFS_ACCESS_KEY}
+      - RUSTFS_SECRET_KEY=${RUSTFS_SECRET_KEY}
+    volumes:
+      - panachat_rustfs_data:/data
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:9000/health >/dev/null 2>&1 || exit 1']
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    command:
+      ['--access-key', '${RUSTFS_ACCESS_KEY}', '--secret-key', '${RUSTFS_SECRET_KEY}', '/data']
+    restart: always
+    networks:
+      - panachat-network
+
+  rustfs-init:
+    image: minio/mc:latest
+    container_name: panachat-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    volumes:
+      - ./bucket.config.json:/bucket.config.json:ro
+    entrypoint: /bin/sh
+    command: -c ' set -eux; mc alias set rustfs "http://rustfs:9000" "${RUSTFS_ACCESS_KEY}" "${RUSTFS_SECRET_KEY}"; mc ls rustfs || true; mc mb "rustfs/lobe" --ignore-existing; mc admin info rustfs || true; mc anonymous set-json "/bucket.config.json" "rustfs/lobe"; '
+    restart: 'no'
+    networks:
+      - panachat-network
+
+  searxng:
+    image: searxng/searxng
+    container_name: panachat-searxng
+    volumes:
+      - './searxng-settings.yml:/etc/searxng/settings.yml'
+    environment:
+      - 'SEARXNG_SETTINGS_FILE=/etc/searxng/settings.yml'
+    restart: always
+    networks:
+      - panachat-network
+    env_file:
+      - .env
+
+networks:
+  panachat-network:
+    name: panachat-network
+    driver: bridge
+
+volumes:
+  panachat_postgres_data:
+    name: panachat_postgres_data
+  panachat_redis_data:
+    name: panachat_redis_data
+  panachat_rustfs_data:
+    name: panachat_rustfs_data

--- a/docker-compose/deploy/nginx/panachat-site.example.conf
+++ b/docker-compose/deploy/nginx/panachat-site.example.conf
@@ -1,0 +1,53 @@
+# Example HTTPS site for Panachat (place under /etc/nginx/sites-available/).
+# TLS paths are placeholders — use certbot or your own certs.
+#
+# Upstream file (auto-loaded from conf.d on most distros):
+#   cp docker-compose/deploy/nginx/panachat-upstream.blue.conf \
+#      /etc/nginx/conf.d/panachat-upstream.conf
+#   # panachat-deploy-remote.sh rewrites that file on each flip
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name chat.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name chat.example.com;
+
+    # ssl_certificate     /etc/letsencrypt/live/chat.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/chat.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://panachat_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    # Hashed SPA assets — safe to cache; never rewrite paths
+    location /_spa/assets/ {
+        proxy_pass http://panachat_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location /_spa-auth/assets/ {
+        proxy_pass http://panachat_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/docker-compose/deploy/nginx/panachat-upstream.blue.conf
+++ b/docker-compose/deploy/nginx/panachat-upstream.blue.conf
@@ -1,0 +1,4 @@
+upstream panachat_backend {
+    server 127.0.0.1:3210;
+    keepalive 32;
+}

--- a/docker-compose/deploy/nginx/panachat-upstream.conf
+++ b/docker-compose/deploy/nginx/panachat-upstream.conf
@@ -1,0 +1,10 @@
+# Active Panachat app upstream — rewritten by scripts/panachat-deploy-remote.sh
+# Include from the main site server block:
+#   include /etc/nginx/conf.d/panachat-upstream.conf;
+#
+# Bootstrap: copy panachat-upstream.blue.conf → panachat-upstream.conf
+
+upstream panachat_backend {
+    server 127.0.0.1:3210;
+    keepalive 32;
+}

--- a/docker-compose/deploy/nginx/panachat-upstream.green.conf
+++ b/docker-compose/deploy/nginx/panachat-upstream.green.conf
@@ -1,0 +1,4 @@
+upstream panachat_backend {
+    server 127.0.0.1:3211;
+    keepalive 32;
+}

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# Panachat blue-green remote deploy (canary CI-CD).
+#
+# Usage:
+#   ./scripts/panachat-deploy-remote.sh deploy <image-ref>   # e.g. ghcr.io/org/panachat:abc1234
+#   ./scripts/panachat-deploy-remote.sh rollback
+#   ./scripts/panachat-deploy-remote.sh bootstrap            # data plane + blue slot
+#   ./scripts/panachat-deploy-remote.sh status
+#
+# Safety:
+#   - Always runs panachat-backup.sh before deploy (unless PANACHAT_SKIP_BACKUP=1)
+#   - Never runs `docker compose down -v` or removes panachat_* volumes
+#   - Only starts/stops app slots; data plane stays up
+#   - On failure, traffic stays on the current slot
+#
+# Env (optional):
+#   PANACHAT_ROOT                 repo root (default: parent of scripts/)
+#   PANACHAT_STATE_DIR            default /var/lib/panachat
+#   PANACHAT_NGINX_UPSTREAM_FILE  default /etc/nginx/conf.d/panachat-upstream.conf
+#   PANACHAT_PUBLIC_URL           for post-flip verify (e.g. https://chat.example.com)
+#   PANACHAT_HEALTH_TIMEOUT_SEC   default 180
+#   PANACHAT_IMAGE_KEEP           keep last N SHA images (default 5)
+#   PANACHAT_SKIP_BACKUP=1
+#   PANACHAT_SKIP_NGINX=1         skip upstream rewrite (manual proxy)
+#   COMPOSE_PROFILES              e.g. control-plane
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="${PANACHAT_ROOT:-$ROOT}"
+DEPLOY_DIR="$ROOT/docker-compose/deploy"
+COMPOSE_FILE="$DEPLOY_DIR/docker-compose.panachat.yml"
+STATE_DIR="${PANACHAT_STATE_DIR:-/var/lib/panachat}"
+STATE_FILE="$STATE_DIR/deploy.env"
+NGINX_UPSTREAM="${PANACHAT_NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/panachat-upstream.conf}"
+HEALTH_TIMEOUT="${PANACHAT_HEALTH_TIMEOUT_SEC:-180}"
+IMAGE_KEEP="${PANACHAT_IMAGE_KEEP:-5}"
+NETWORK_NAME="panachat-network"
+APP_ALIAS="panachat-app"
+
+PORT_BLUE="${PANACHAT_PORT_BLUE:-3210}"
+PORT_GREEN="${PANACHAT_PORT_GREEN:-3211}"
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+log() { printf '==> %s\n' "$*"; }
+err() { printf 'Error: %s\n' "$*" >&2; }
+
+ensure_state_dir() {
+  mkdir -p "$STATE_DIR"
+}
+
+load_state() {
+  CURRENT_SLOT=blue
+  DEPLOYED_SHA=
+  PREVIOUS_SHA=
+  PREVIOUS_SLOT=
+  if [[ -f "$STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+  fi
+  CURRENT_SLOT="${CURRENT_SLOT:-blue}"
+}
+
+write_state() {
+  ensure_state_dir
+  cat >"$STATE_FILE" <<EOF
+CURRENT_SLOT=$1
+DEPLOYED_SHA=$2
+PREVIOUS_SLOT=${3:-}
+PREVIOUS_SHA=${4:-}
+UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+}
+
+slot_service() {
+  case "$1" in
+    blue) echo panachat-blue ;;
+    green) echo panachat-green ;;
+    *) err "unknown slot: $1"; return 1 ;;
+  esac
+}
+
+slot_profile() {
+  case "$1" in
+    blue) echo slot-blue ;;
+    green) echo slot-green ;;
+    *) return 1 ;;
+  esac
+}
+
+slot_port() {
+  case "$1" in
+    blue) echo "$PORT_BLUE" ;;
+    green) echo "$PORT_GREEN" ;;
+    *) return 1 ;;
+  esac
+}
+
+other_slot() {
+  case "$1" in
+    blue) echo green ;;
+    green) echo blue ;;
+    *) return 1 ;;
+  esac
+}
+
+compose() {
+  (
+    cd "$DEPLOY_DIR"
+    # shellcheck disable=SC2086
+    docker compose \
+      --env-file ../../.env \
+      --env-file .env \
+      -f docker-compose.panachat.yml \
+      "$@"
+  )
+}
+
+compose_with_profile() {
+  local profile="$1"
+  shift
+  (
+    cd "$DEPLOY_DIR"
+    docker compose \
+      --env-file ../../.env \
+      --env-file .env \
+      -f docker-compose.panachat.yml \
+      --profile "$profile" \
+      "$@"
+  )
+}
+
+set_image_env() {
+  local image="$1"
+  export PANACHAT_IMAGE="$image"
+  # Persist for subsequent compose calls on this host
+  local envf="$DEPLOY_DIR/.env"
+  if [[ -f "$envf" ]]; then
+    if grep -qE '^PANACHAT_IMAGE=' "$envf"; then
+      sed -i.bak "s|^PANACHAT_IMAGE=.*|PANACHAT_IMAGE=${image}|" "$envf"
+      rm -f "${envf}.bak"
+    else
+      printf '\nPANACHAT_IMAGE=%s\n' "$image" >>"$envf"
+    fi
+  else
+    printf 'PANACHAT_IMAGE=%s\n' "$image" >"$envf"
+  fi
+}
+
+run_backup() {
+  if [[ "${PANACHAT_SKIP_BACKUP:-0}" == "1" ]]; then
+    log "Skipping backup (PANACHAT_SKIP_BACKUP=1)"
+    return 0
+  fi
+  log "Pre-deploy backup"
+  export POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-panachat-postgres}"
+  export LOBE_DB_NAME="${LOBE_DB_NAME:-${PANACHAT_DB_NAME:-lobechat}}"
+  "$ROOT/scripts/panachat-backup.sh" --reason pre-deploy
+}
+
+wait_healthy() {
+  local slot="$1"
+  local port
+  port="$(slot_port "$slot")"
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local service
+  service="$(slot_service "$slot")"
+  log "Waiting for $service on 127.0.0.1:$port (timeout ${HEALTH_TIMEOUT}s)"
+
+  while ((SECONDS < deadline)); do
+    if ! docker inspect -f '{{.State.Running}}' "$service" 2>/dev/null | grep -q true; then
+      sleep 2
+      continue
+    fi
+    # Migration / ready signals in logs
+    if docker logs "$service" 2>&1 | tail -n 200 | grep -qE 'database migration pass|Ready in |started server'; then
+      local code
+      code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${port}/signin" || echo 000)
+      if [[ "$code" == "200" || "$code" == "302" || "$code" == "307" ]]; then
+        log "$service is healthy (HTTP $code)"
+        return 0
+      fi
+      code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${port}/" || echo 000)
+      if [[ "$code" == "200" || "$code" == "302" || "$code" == "307" ]]; then
+        log "$service is healthy (HTTP $code)"
+        return 0
+      fi
+    fi
+    sleep 3
+  done
+
+  err "$service did not become healthy within ${HEALTH_TIMEOUT}s"
+  docker logs "$service" 2>&1 | tail -n 80 || true
+  return 1
+}
+
+verify_slot_spa() {
+  local port="$1"
+  local code
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://127.0.0.1:${port}/_spa/icons/icon-192x192.png" || echo 000)
+  if [[ "$code" != "200" ]]; then
+    err "SPA icon check failed on :$port → HTTP $code"
+    return 1
+  fi
+  log "SPA icon OK on :$port"
+}
+
+set_network_alias() {
+  local service="$1"
+  # Reconnect with alias so control-plane INTERNAL_APP_URL=http://panachat-app:3210 works
+  docker network disconnect "$NETWORK_NAME" "$service" 2>/dev/null || true
+  docker network connect --alias "$APP_ALIAS" "$NETWORK_NAME" "$service"
+}
+
+clear_network_alias() {
+  local service="$1"
+  # Disconnect/reconnect without alias (best-effort)
+  if docker inspect "$service" >/dev/null 2>&1; then
+    docker network disconnect "$NETWORK_NAME" "$service" 2>/dev/null || true
+    docker network connect "$NETWORK_NAME" "$service" 2>/dev/null || true
+  fi
+}
+
+flip_nginx() {
+  local slot="$1"
+  if [[ "${PANACHAT_SKIP_NGINX:-0}" == "1" ]]; then
+    log "Skipping nginx flip (PANACHAT_SKIP_NGINX=1)"
+    return 0
+  fi
+  local src="$DEPLOY_DIR/nginx/panachat-upstream.${slot}.conf"
+  if [[ ! -f "$src" ]]; then
+    err "Missing nginx template: $src"
+    return 1
+  fi
+  if [[ ! -d "$(dirname "$NGINX_UPSTREAM")" ]]; then
+    err "Nginx upstream dir missing: $(dirname "$NGINX_UPSTREAM") — set PANACHAT_NGINX_UPSTREAM_FILE or PANACHAT_SKIP_NGINX=1"
+    return 1
+  fi
+  log "Flipping nginx upstream → $slot ($src → $NGINX_UPSTREAM)"
+  cp "$src" "$NGINX_UPSTREAM"
+  if command -v nginx >/dev/null 2>&1; then
+    nginx -t
+    nginx -s reload
+  elif [[ -x /usr/sbin/nginx ]]; then
+    /usr/sbin/nginx -t
+    /usr/sbin/nginx -s reload
+  else
+    err "nginx binary not found; upstream file updated but not reloaded"
+    return 1
+  fi
+}
+
+prune_old_images() {
+  local keep="$IMAGE_KEEP"
+  local repo
+  repo="$(echo "${PANACHAT_IMAGE:-}" | sed 's/:.*//')"
+  [[ -n "$repo" ]] || return 0
+  mapfile -t ids < <(docker images "$repo" --format '{{.ID}}' 2>/dev/null | awk -v k="$keep" 'NR>k')
+  if ((${#ids[@]} == 0)); then
+    return 0
+  fi
+  log "Pruning old $repo images (keep $keep)"
+  for id in "${ids[@]}"; do
+    [[ -n "$id" ]] || continue
+    docker rmi "$id" 2>/dev/null || true
+  done
+}
+
+image_sha_tag() {
+  local image="$1"
+  if [[ "$image" == *:* ]]; then
+    echo "${image##*:}"
+  else
+    echo "$image"
+  fi
+}
+
+cmd_status() {
+  load_state
+  echo "State file: $STATE_FILE"
+  echo "CURRENT_SLOT=${CURRENT_SLOT:-}"
+  echo "DEPLOYED_SHA=${DEPLOYED_SHA:-}"
+  echo "PREVIOUS_SLOT=${PREVIOUS_SLOT:-}"
+  echo "PREVIOUS_SHA=${PREVIOUS_SHA:-}"
+  echo "PANACHAT_IMAGE=${PANACHAT_IMAGE:-}"
+  docker ps --filter 'name=panachat-' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
+}
+
+cmd_bootstrap() {
+  local image="${1:-}"
+  if [[ -z "$image" ]]; then
+    image="${PANACHAT_IMAGE:-}"
+  fi
+  if [[ -z "$image" ]]; then
+    err "bootstrap requires image: $0 bootstrap ghcr.io/<owner>/panachat:<sha>"
+    exit 1
+  fi
+  ensure_state_dir
+  set_image_env "$image"
+  log "Starting data plane + panachat-blue"
+  compose up -d postgresql redis rustfs rustfs-init searxng
+  compose_with_profile slot-blue up -d --no-deps panachat-blue
+  set_network_alias panachat-blue
+  wait_healthy blue
+  verify_slot_spa "$PORT_BLUE"
+  flip_nginx blue || true
+  write_state blue "$(image_sha_tag "$image")" "" ""
+  log "Bootstrap complete — active slot=blue"
+}
+
+cmd_deploy() {
+  local image="${1:-}"
+  if [[ -z "$image" ]]; then
+    err "deploy requires image ref"
+    usage 1
+  fi
+
+  load_state
+  local active="$CURRENT_SLOT"
+  local inactive
+  inactive="$(other_slot "$active")"
+  local active_svc inactive_svc
+  active_svc="$(slot_service "$active")"
+  inactive_svc="$(slot_service "$inactive")"
+  local inactive_profile
+  inactive_profile="$(slot_profile "$inactive")"
+  local prev_sha="${DEPLOYED_SHA:-}"
+
+  log "Active=$active → deploying $image onto $inactive"
+
+  run_backup
+  set_image_env "$image"
+
+  log "Pulling $image"
+  docker pull "$image"
+
+  log "Starting inactive slot $inactive_svc"
+  compose_with_profile "$inactive_profile" up -d --no-deps --force-recreate "$inactive_svc"
+
+  if ! wait_healthy "$inactive"; then
+    err "New slot unhealthy — leaving traffic on $active; stopping $inactive_svc"
+    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    exit 1
+  fi
+
+  if ! verify_slot_spa "$(slot_port "$inactive")"; then
+    err "SPA verify failed — leaving traffic on $active; stopping $inactive_svc"
+    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    exit 1
+  fi
+
+  set_network_alias "$inactive_svc"
+  if ! flip_nginx "$inactive"; then
+    err "Nginx flip failed — leaving traffic on $active; clearing new alias"
+    clear_network_alias "$inactive_svc" || true
+    set_network_alias "$active_svc" || true
+    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    exit 1
+  fi
+
+  log "Stopping old slot $active_svc"
+  local active_profile
+  active_profile="$(slot_profile "$active")"
+  compose_with_profile "$active_profile" stop "$active_svc" || true
+  clear_network_alias "$active_svc" || true
+
+  write_state "$inactive" "$(image_sha_tag "$image")" "$active" "$prev_sha"
+  prune_old_images
+
+  if [[ -n "${PANACHAT_PUBLIC_URL:-}" ]]; then
+    local verify="$ROOT/.claude/skills/self-host-deploy/scripts/verify-deployment.sh"
+    if [[ -x "$verify" ]]; then
+      log "Verifying public URL ${PANACHAT_PUBLIC_URL}"
+      bash "$verify" "$PANACHAT_PUBLIC_URL" "$inactive_svc" || true
+    fi
+  fi
+
+  log "Deploy complete — active slot=$inactive image=$image"
+}
+
+cmd_rollback() {
+  load_state
+  if [[ -z "${PREVIOUS_SHA:-}" ]]; then
+    err "No PREVIOUS_SHA in $STATE_FILE — cannot rollback"
+    exit 1
+  fi
+
+  local image_repo
+  image_repo="$(grep -E '^PANACHAT_IMAGE=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | sed 's/:.*//' || true)"
+  if [[ -z "$image_repo" ]]; then
+    err "Cannot resolve image repository from deploy .env"
+    exit 1
+  fi
+  local image="${image_repo}:${PREVIOUS_SHA}"
+  log "Rolling back to $image"
+  cmd_deploy "$image"
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    deploy) cmd_deploy "${1:-}" ;;
+    rollback) cmd_rollback ;;
+    bootstrap) cmd_bootstrap "${1:-}" ;;
+    status) cmd_status ;;
+    -h|--help|help) usage 0 ;;
+    *) usage 1 ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #249

Plane: [AICO-148](https://plane.panafor.com/panaforai/browse/AICO-148)

#### Description of Change

Adds production canary CI/CD so a Linux VPS stays pinned to GitHub `canary` with near-zero downtime and no data-volume loss:

- GitHub Actions workflow builds and pushes private `ghcr.io/<owner>/panachat:<sha>` / `:canary`
- Panachat compose stack (`panachat-blue` / `panachat-green`) + nginx upstream flip
- `panachat-deploy-remote.sh` for backup → pull → health check → flip → stop old / rollback / bootstrap
- Env examples and self-host-deploy docs (`canary-cicd.md`)

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Validated `docker compose … config` for `docker-compose.panachat.yml`
- `bash -n` on `scripts/panachat-deploy-remote.sh`
- Server bootstrap + first Actions deploy still needs secrets (`DEPLOY_*`, `GHCR_READ_TOKEN`) on the VPS

#### Checklist

- [x] Docs / skill path for operators (`canary-cicd.md`)
- [x] Named volumes `panachat_*` only; no `down -v` in deploy path
- [x] GHCR package visibility set to private in workflow (best-effort API)


Made with [Cursor](https://cursor.com)