### PR TITLE
🐛 fix(aico): restore image/video gen via managed billing context

### DIFF
--- a/.cursor/plans/live_search_diagnosis_b642d2e3.plan.md
+++ b/.cursor/plans/live_search_diagnosis_b642d2e3.plan.md
@@ -1,0 +1,92 @@
+---
+name: Live search diagnosis
+overview: xAI/Grok “Live Search” often never actually runs because the app defaults to its own web-search helper, and citations on the current Responses path are under-filtered. This plan documents the user-facing problems and the concrete fixes.
+todos:
+  - id: route-xai-native
+    content: Force/prefer model-native Live Search for xAI when search is on (must for multi-agent Grok)
+    status: completed
+  - id: filter-responses-citations
+    content: Filter empty/invalid URL citations in responsesStream.ts + regression test
+    status: completed
+  - id: align-xai-metadata
+    content: Update xAI searchImpl/docs comments to match web_search/x_search tool injection
+    status: completed
+  - id: tests-search-decision
+    content: Extend resolveSearchDecision / getSearchConfig / server searchDecision tests for xAI routing
+    status: completed
+isProject: false
+---
+
+# Live search: what’s broken (plain language)
+
+**What “Live Search” is here:** Grok’s own built-in ability to look things up on the web and on X (Twitter), then show source links. It is not a separate feature named “live search” in the UI — it is the **model’s built-in search** path for xAI/Grok.
+
+Think of two different search helpers:
+
+1. **Grok’s own search** (Live Search) — Grok looks things up itself.
+2. **The app’s search helper** — the product sends search tools that Grok is supposed to call.
+
+Today, when someone turns search **on**, the product usually picks helper #2. Grok’s own Live Search (#1) only runs if the user also flips a second switch: **“use model built-in search.”** Most people never find that switch, so Live Search looks broken even when search is “on.”
+
+```mermaid
+flowchart TD
+  userTurnsSearchOn[User turns search on]
+  secondSwitch{Second switch: use model built-in search?}
+  grokLive[Grok Live Search: web_search + x_search]
+  appHelper[App web-browsing tools]
+  multiAgentBroken[Multi-agent Grok: cannot use app tools]
+
+  userTurnsSearchOn --> secondSwitch
+  secondSwitch -->|usually off by default| appHelper
+  secondSwitch -->|manually turned on| grokLive
+  appHelper --> multiAgentBroken
+```
+
+
+
+---
+
+## Problems (no programming jargon)
+
+### 1. Search is “on,” but Live Search is usually off
+
+- The product turns search mode on by default (`auto`), but **does not** turn on “use the model’s own search.”
+- Result: users believe web search is enabled; the app quietly uses its own helper instead of Grok’s Live Search.
+- Where this is decided: `[packages/const/src/settings/agent.ts](packages/const/src/settings/agent.ts)` (defaults) + `[packages/model-bank/src/utils.ts](packages/model-bank/src/utils.ts)` (`resolveSearchDecision`).
+
+### 2. Some Grok models cannot use the app’s helper at all
+
+- **Grok Multi-Agent** is documented as supporting only xAI’s own server tools (web/X search), not the app’s client tools.
+- With today’s defaults, search is routed to the app helper → that model gets tools it cannot use → research/search fails or appears useless.
+- Model note lives in `[packages/model-bank/src/aiModels/xai.ts](packages/model-bank/src/aiModels/xai.ts)` (`grok-4.20-multi-agent-0309`).
+
+### 3. Source links can be incomplete or messy
+
+- When search works, answers should show clickable sources.
+- An older path already drops empty/invalid links so the UI does not break.
+- Grok now uses the newer **Responses** stream path, which **does not** apply that same cleanup — empty or bad links can still slip through.
+- Files: filter exists in `[packages/model-runtime/src/core/streams/openai/openai.ts](packages/model-runtime/src/core/streams/openai/openai.ts)`; missing equivalent in `[packages/model-runtime/src/core/streams/openai/responsesStream.ts](packages/model-runtime/src/core/streams/openai/responsesStream.ts)`. The message UI already tries to be defensive (`[SearchGrounding.tsx](src/features/Conversation/Messages/components/SearchGrounding.tsx)`), but bad data should be filtered at the stream.
+
+### 4. Labels still describe an outdated system
+
+- Live Search used to be configured with old-style “search parameters.” That API is gone; the code now injects `web_search` / `x_search` tools (`[packages/model-runtime/src/providers/xai/index.ts](packages/model-runtime/src/providers/xai/index.ts)`).
+- Model cards still say `searchImpl: 'params'`, which matches the old mental model and makes routing easy to misconfigure.
+
+---
+
+## What needs to be fixed (engineering)
+
+Committed approach (no open options):
+
+1. **Route xAI search to model-native Live Search when search is on**
+  Prefer Grok’s `web_search` / `x_search` whenever search mode is not `off` for xAI models that advertise search — especially force this for multi-agent Grok (no client tools). Keep the existing “use model built-in search” toggle for other providers (Google, etc.) where choosing app vs model search is intentional.
+2. **Filter empty/invalid citations on the Responses stream**
+  Reuse the same `filterValidCitations` idea from the Chat Completions path inside `responsesStream.ts` before emitting `grounding` events; add a regression test with an empty `url_citation`.
+3. **Align model metadata with real behavior**
+  Update xAI model search settings / comments so they reflect tool injection (not the deprecated Live Search params API), so future routing does not reintroduce the wrong path.
+4. **Regression coverage**
+  - Decision tests: xAI + search on → `useModelSearch` / `enabledSearch` without requiring a manual second switch (and multi-agent specifically).
+  - Provider tests already cover tool injection when `enabledSearch` is true — keep those green.
+  - Stream test for empty citation filtering.
+
+Out of scope for this fix: redesigning the whole search UI, or changing non-xAI providers’ default between app search and model search.

--- a/apps/server/src/routers/async/image.ts
+++ b/apps/server/src/routers/async/image.ts
@@ -21,6 +21,8 @@ import { GenerationModel } from '@/database/models/generation';
 import { GenerationBatchModel } from '@/database/models/generationBatch';
 import { asyncAuthedProcedure, asyncRouter as router } from '@/libs/trpc/async';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { parseAicoBillingContext } from '@/server/services/aico/billingContext';
+import { toManagedGenerationModelId } from '@/server/services/aico/generationBilling';
 import { GenerationService } from '@/server/services/generation';
 import { sanitizeFileName } from '@/utils/sanitizeFileName';
 
@@ -142,7 +144,13 @@ export const imageRouter = router({
         // billing. Loaded before the model mapping so the handle is available
         // for reconciliation even when mapping resolution throws.
         const asyncTask = await asyncTaskModel.findById(taskId);
-        prechargeResult = (asyncTask?.metadata as { precharge?: unknown } | undefined)?.precharge;
+        const taskMetadata = asyncTask?.metadata as
+          { aicoBilling?: unknown; precharge?: unknown } | undefined;
+        prechargeResult = taskMetadata?.precharge;
+        const billingContext =
+          taskMetadata?.aicoBilling !== undefined
+            ? parseAicoBillingContext(taskMetadata.aicoBilling)
+            : undefined;
 
         // Resolve model mapping up front so both the success and error billing
         // paths can reference the resolved model id.
@@ -160,6 +168,10 @@ export const imageRouter = router({
             ctx.userId,
             provider,
             workspaceId,
+            {
+              billingContext,
+              modelId: toManagedGenerationModelId(resolvedModelId),
+            },
           );
 
           // Check if operation has been cancelled

--- a/apps/server/src/routers/async/video.ts
+++ b/apps/server/src/routers/async/video.ts
@@ -19,6 +19,8 @@ import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
 import { asyncAuthedProcedure, asyncRouter as router } from '@/libs/trpc/async';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { parseAicoBillingContext } from '@/server/services/aico/billingContext';
+import { toManagedGenerationModelId } from '@/server/services/aico/generationBilling';
 import { VideoGenerationService } from '@/server/services/generation/video';
 import { buildVideoGenerationFilePayload } from '@/server/services/generation/videoFile';
 import { FileSource } from '@/types/files';
@@ -156,11 +158,23 @@ export const videoRouter = router({
     try {
       const pollingPromise = async (signal: AbortSignal) => {
         log('Initializing agent runtime for provider: %s', provider);
+
+        const asyncTask = await asyncTaskModel.findById(asyncTaskId);
+        const taskMetadata = asyncTask?.metadata as { aicoBilling?: unknown } | undefined;
+        const billingContext =
+          taskMetadata?.aicoBilling !== undefined
+            ? parseAicoBillingContext(taskMetadata.aicoBilling)
+            : undefined;
+
         const modelRuntime = await initModelRuntimeFromDB(
           ctx.serverDB,
           ctx.userId,
           provider,
           workspaceId,
+          {
+            billingContext,
+            modelId: toManagedGenerationModelId(resolvedModelId),
+          },
         );
 
         checkAbortSignal(signal);

--- a/apps/server/src/routers/lambda/image/index.test.ts
+++ b/apps/server/src/routers/lambda/image/index.test.ts
@@ -137,15 +137,16 @@ describe('imageRouter', () => {
   });
 
   const createDefaultInput = (overrides = {}) => ({
+    aicoBilling: { source: 'personal' as const },
     generationTopicId: 'topic-1',
     imageNum: 2,
-    model: 'stable-diffusion',
+    model: 'google/gemini-3.1-flash-image-preview:image',
     params: {
       prompt: 'a beautiful sunset',
       width: 512,
       height: 512,
     },
-    provider: 'test-provider',
+    provider: 'openrouter',
     ...overrides,
   });
 
@@ -170,8 +171,8 @@ describe('imageRouter', () => {
     const mockBatch = {
       id: 'batch-1',
       generationTopicId: 'topic-1',
-      model: 'stable-diffusion',
-      provider: 'test-provider',
+      model: 'google/gemini-3.1-flash-image-preview:image',
+      provider: 'openrouter',
       config: {},
       userId: mockUserId,
     };
@@ -237,31 +238,40 @@ describe('imageRouter', () => {
       expect(mockServerDB.transaction).toHaveBeenCalled();
     });
 
-    it('should validate mapped model id before rejecting deprecated lobehub image models', async () => {
-      mockResolveBusinessModelMapping.mockResolvedValue({
-        requestedModelId: 'onboarding-image',
-        resolvedModelId: 'gpt-image-1',
-      });
-
+    it('should reject direct (BYOK) image providers under Aico managed policy', async () => {
       const ctx = createMockCtx();
       const input = createDefaultInput({
-        model: 'onboarding-image',
-        provider: 'lobehub',
+        aicoBilling: undefined,
+        model: 'gemini-3.1-flash-image-preview:image',
+        provider: 'google',
       });
 
       const caller = imageRouter.createCaller(ctx);
-      const result = await caller.createImage(input);
 
-      expect(result.success).toBe(true);
-      expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-image');
-      expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('gpt-image-1', 'image', {
-        getUserEmail: expect.any(Function),
+      await expect(caller.createImage(input)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'DIRECT_PROVIDER_NOT_ALLOWED',
       });
-      const availabilityOptions = mockIsLobeHubModelAvailable.mock.calls.at(-1)?.[2];
-      expect(mockFindUserById).not.toHaveBeenCalled();
-      await expect(availabilityOptions!.getUserEmail!()).resolves.toBe('user@example.com');
-      expect(mockFindUserById).toHaveBeenCalledWith(mockServerDB, mockUserId);
-      expect(mockCreateAsyncCaller).toHaveBeenCalledWith({ userId: mockUserId });
+
+      expect(mockServerDB.transaction).not.toHaveBeenCalled();
+      expect(mockCreateAsyncCaller).not.toHaveBeenCalled();
+    });
+
+    it('should reject managed providers when billing context is missing', async () => {
+      const ctx = createMockCtx();
+      const input = createDefaultInput({
+        aicoBilling: undefined,
+      });
+
+      const caller = imageRouter.createCaller(ctx);
+
+      await expect(caller.createImage(input)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'BILLING_CONTEXT_REQUIRED',
+      });
+
+      expect(mockServerDB.transaction).not.toHaveBeenCalled();
+      expect(mockCreateAsyncCaller).not.toHaveBeenCalled();
     });
 
     it('should reject inaccessible generation topic before charging or creating records', async () => {
@@ -275,26 +285,6 @@ describe('imageRouter', () => {
       });
 
       expect(mockChargeBeforeGenerate).not.toHaveBeenCalled();
-      expect(mockServerDB.transaction).not.toHaveBeenCalled();
-      expect(mockCreateAsyncCaller).not.toHaveBeenCalled();
-    });
-
-    it('should reject unavailable lobehub image models before creating async tasks', async () => {
-      mockIsLobeHubModelAvailable.mockResolvedValue(false);
-
-      const ctx = createMockCtx();
-      const input = createDefaultInput({
-        model: 'restricted-image-model',
-        provider: 'lobehub',
-      });
-
-      const caller = imageRouter.createCaller(ctx);
-
-      await expect(caller.createImage(input)).rejects.toMatchObject({
-        code: 'BAD_REQUEST',
-        message: 'LobeHubModelDeprecated',
-      });
-
       expect(mockServerDB.transaction).not.toHaveBeenCalled();
       expect(mockCreateAsyncCaller).not.toHaveBeenCalled();
     });
@@ -436,8 +426,8 @@ describe('imageRouter', () => {
         expect.objectContaining({
           generationTopicId: 'topic-1',
           imageNum: 2,
-          model: 'stable-diffusion',
-          provider: 'test-provider',
+          model: 'google/gemini-3.1-flash-image-preview:image',
+          provider: 'openrouter',
           userId: mockUserId,
         }),
       );
@@ -456,14 +446,24 @@ describe('imageRouter', () => {
 
       // insertValues: [0] batch, [1] generations[], [2] task#1, [3] task#2
       expect(mockInsertValues[2]).toEqual(
-        expect.objectContaining({ metadata: { precharge: { reservationKey: 'k-1' } } }),
+        expect.objectContaining({
+          metadata: {
+            aicoBilling: { source: 'personal' },
+            precharge: { reservationKey: 'k-1' },
+          },
+        }),
       );
       expect(mockInsertValues[3]).toEqual(
-        expect.objectContaining({ metadata: { precharge: { reservationKey: 'k-2' } } }),
+        expect.objectContaining({
+          metadata: {
+            aicoBilling: { source: 'personal' },
+            precharge: { reservationKey: 'k-2' },
+          },
+        }),
       );
     });
 
-    it('leaves asyncTask metadata unset when there are no prechargeItems', async () => {
+    it('stores aicoBilling on asyncTask metadata when there are no prechargeItems', async () => {
       mockChargeBeforeGenerate.mockResolvedValue({ prechargeItems: undefined });
 
       const ctx = createMockCtx();
@@ -472,7 +472,11 @@ describe('imageRouter', () => {
       const caller = imageRouter.createCaller(ctx);
       await caller.createImage(input);
 
-      expect(mockInsertValues[2]).toEqual(expect.objectContaining({ metadata: undefined }));
+      expect(mockInsertValues[2]).toEqual(
+        expect.objectContaining({
+          metadata: { aicoBilling: { source: 'personal' } },
+        }),
+      );
     });
 
     it('should trigger async image generation tasks', async () => {

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -19,6 +19,11 @@ import { asyncTasks, generationBatches, generations } from '@/database/schemas';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { createAsyncCaller } from '@/server/routers/async/caller';
+import {
+  managedPolicyErrorToTrpc,
+  resolveManagedGenerationBilling,
+} from '@/server/services/aico/generationBilling';
+import { AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
 import { FileService } from '@/server/services/file';
 import {
   AsyncTaskError,
@@ -47,7 +52,13 @@ const imageProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) =>
 
 const imageCreateProcedure = imageProcedure.use(withScopedPermission('file:upload'));
 
+const aicoBillingSchema = z.union([
+  z.object({ source: z.literal('personal') }),
+  z.object({ organizationId: z.string().min(1), source: z.literal('organization') }),
+]);
+
 const createImageInputSchema = z.object({
+  aicoBilling: aicoBillingSchema.optional(),
   generationTopicId: z.string(),
   imageNum: z.number(),
   model: z.string(),
@@ -87,9 +98,19 @@ export const imageRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { userId, serverDB, asyncTaskModel, fileService, generationTopicModel } = ctx;
       const wsId = ctx.workspaceId ?? undefined;
-      const { generationTopicId, provider, model, imageNum, params } = input;
+      const { generationTopicId, provider, model, imageNum, params, aicoBilling } = input;
 
       log('Starting image creation process, input: %O', input);
+
+      let billingContext;
+      try {
+        billingContext = resolveManagedGenerationBilling({ aicoBilling, provider });
+      } catch (error) {
+        if (error instanceof AicoManagedPolicyError) {
+          throw new TRPCError(managedPolicyErrorToTrpc(error));
+        }
+        throw error;
+      }
 
       const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
 
@@ -268,7 +289,10 @@ export const imageRouter = router({
               const [createdAsyncTask] = await tx
                 .insert(asyncTasks)
                 .values({
-                  metadata: prechargeItem === undefined ? undefined : { precharge: prechargeItem },
+                  metadata: {
+                    aicoBilling: billingContext,
+                    ...(prechargeItem === undefined ? {} : { precharge: prechargeItem }),
+                  },
                   status: AsyncTaskStatus.Pending,
                   type: AsyncTaskType.ImageGeneration,
                   userId,

--- a/apps/server/src/routers/lambda/video/index.ts
+++ b/apps/server/src/routers/lambda/video/index.ts
@@ -33,6 +33,12 @@ import { appEnv } from '@/envs/app';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import {
+  managedPolicyErrorToTrpc,
+  resolveManagedGenerationBilling,
+  toManagedGenerationModelId,
+} from '@/server/services/aico/generationBilling';
+import { AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
 import { FileService } from '@/server/services/file';
 import { processBackgroundVideoPolling } from '@/server/services/generation/videoBackgroundPolling';
 import { after } from '@/server/utils/scheduleAfterResponse';
@@ -57,7 +63,13 @@ const videoProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) =>
 
 const videoCreateProcedure = videoProcedure.use(withScopedPermission('file:upload'));
 
+const aicoBillingSchema = z.union([
+  z.object({ source: z.literal('personal') }),
+  z.object({ organizationId: z.string().min(1), source: z.literal('organization') }),
+]);
+
 const createVideoInputSchema = z.object({
+  aicoBilling: aicoBillingSchema.optional(),
   generationTopicId: z.string(),
   model: z.string(),
   params: z
@@ -83,7 +95,17 @@ export const videoRouter = router({
     .mutation(async ({ input, ctx }) => {
       const { userId, serverDB, asyncTaskModel, fileService, generationTopicModel } = ctx;
       const wsId = ctx.workspaceId ?? undefined;
-      const { generationTopicId, provider, model, params } = input;
+      const { generationTopicId, provider, model, params, aicoBilling } = input;
+
+      let billingContext;
+      try {
+        billingContext = resolveManagedGenerationBilling({ aicoBilling, provider });
+      } catch (error) {
+        if (error instanceof AicoManagedPolicyError) {
+          throw new TRPCError(managedPolicyErrorToTrpc(error));
+        }
+        throw error;
+      }
 
       const { resolvedModelId } = await resolveBusinessModelMapping(provider, model);
 
@@ -221,6 +243,7 @@ export const videoRouter = router({
           .insert(asyncTasks)
           .values({
             metadata: {
+              aicoBilling: billingContext,
               ...(prechargeResult ? { precharge: prechargeResult } : {}),
               webhookToken,
             },
@@ -250,7 +273,10 @@ export const videoRouter = router({
 
       // Step 2: Call model runtime to submit video generation task
       try {
-        const modelRuntime = await initModelRuntimeFromDB(serverDB, userId, provider, wsId);
+        const modelRuntime = await initModelRuntimeFromDB(serverDB, userId, provider, wsId, {
+          billingContext,
+          modelId: toManagedGenerationModelId(resolvedModelId),
+        });
 
         const callbackBaseUrl = process.env.WEBHOOK_PROXY_URL || appEnv.APP_URL;
         const callbackUrl = `${callbackBaseUrl}/api/webhooks/video/${provider}?token=${webhookToken}`;
@@ -296,6 +322,7 @@ export const videoRouter = router({
               const db = await getServerDB();
 
               await processBackgroundVideoPolling(db, {
+                aicoBilling: billingContext,
                 asyncTaskCreatedAt,
                 asyncTaskId,
                 generationBatchId: createdBatch.id,

--- a/apps/server/src/services/aico/generationBilling.test.ts
+++ b/apps/server/src/services/aico/generationBilling.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveManagedGenerationBilling, toManagedGenerationModelId } from './generationBilling';
+import { AicoManagedPolicyError } from './managedPolicy';
+
+describe('toManagedGenerationModelId', () => {
+  it('strips the synthesized :image suffix', () => {
+    expect(toManagedGenerationModelId('google/gemini-3.1-flash-image-preview:image')).toBe(
+      'google/gemini-3.1-flash-image-preview',
+    );
+  });
+
+  it('leaves chat model ids unchanged', () => {
+    expect(toManagedGenerationModelId('google/gemini-3.1-flash-image-preview')).toBe(
+      'google/gemini-3.1-flash-image-preview',
+    );
+  });
+});
+
+describe('resolveManagedGenerationBilling', () => {
+  it('rejects direct (BYOK) providers', () => {
+    expect(() =>
+      resolveManagedGenerationBilling({ aicoBilling: { source: 'personal' }, provider: 'google' }),
+    ).toThrow(AicoManagedPolicyError);
+    try {
+      resolveManagedGenerationBilling({ aicoBilling: { source: 'personal' }, provider: 'google' });
+    } catch (error) {
+      expect(error).toBeInstanceOf(AicoManagedPolicyError);
+      expect((error as AicoManagedPolicyError).code).toBe('DIRECT_PROVIDER_NOT_ALLOWED');
+    }
+  });
+
+  it('requires an explicit billing context for managed providers', () => {
+    expect(() =>
+      resolveManagedGenerationBilling({ aicoBilling: undefined, provider: 'openrouter' }),
+    ).toThrow(/BILLING_CONTEXT_REQUIRED/);
+  });
+
+  it('accepts personal billing on openrouter/aico', () => {
+    expect(
+      resolveManagedGenerationBilling({ aicoBilling: { source: 'personal' }, provider: 'aico' }),
+    ).toEqual({ source: 'personal' });
+    expect(
+      resolveManagedGenerationBilling({
+        aicoBilling: { organizationId: 'org_1', source: 'organization' },
+        provider: 'openrouter',
+      }),
+    ).toEqual({ organizationId: 'org_1', source: 'organization' });
+  });
+});

--- a/apps/server/src/services/aico/generationBilling.ts
+++ b/apps/server/src/services/aico/generationBilling.ts
@@ -1,0 +1,42 @@
+import { ChatErrorType } from '@lobechat/types';
+
+import {
+  type AicoBillingContext,
+  parseAicoBillingContext,
+} from '@/server/services/aico/billingContext';
+import { AicoManagedPolicy, AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
+
+/**
+ * Image-tab clones use `{baseId}:image`. Org/trial allow-lists store the chat
+ * model id without that suffix — normalize before authorize().
+ */
+export const toManagedGenerationModelId = (modelId: string): string =>
+  modelId.endsWith(':image') ? modelId.slice(0, -':image'.length) : modelId;
+
+/**
+ * Aico generation (image/video) must use wallet-backed OpenRouter/`aico` and an
+ * explicit billing context — same contract as chat webapi.
+ */
+export const resolveManagedGenerationBilling = (params: {
+  aicoBilling: unknown;
+  provider: string;
+}): AicoBillingContext => {
+  if (!AicoManagedPolicy.isManagedProvider(params.provider)) {
+    throw new AicoManagedPolicyError('DIRECT_PROVIDER_NOT_ALLOWED', ChatErrorType.BadRequest);
+  }
+
+  try {
+    return parseAicoBillingContext(params.aicoBilling);
+  } catch (error) {
+    const code =
+      error instanceof Error && error.message.startsWith('BILLING_CONTEXT_')
+        ? error.message
+        : 'BILLING_CONTEXT_INVALID';
+    throw new AicoManagedPolicyError(code, ChatErrorType.BadRequest);
+  }
+};
+
+export const managedPolicyErrorToTrpc = (error: AicoManagedPolicyError) => ({
+  code: 'BAD_REQUEST' as const,
+  message: error.code || error.message,
+});

--- a/apps/server/src/services/generation/videoBackgroundPolling.ts
+++ b/apps/server/src/services/generation/videoBackgroundPolling.ts
@@ -7,6 +7,8 @@ import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { GenerationModel } from '@/database/models/generation';
 import type { LobeChatDatabase } from '@/database/type';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import type { AicoBillingContext } from '@/server/services/aico/billingContext';
+import { toManagedGenerationModelId } from '@/server/services/aico/generationBilling';
 import { VideoGenerationService } from '@/server/services/generation/video';
 import { buildVideoGenerationFilePayload } from '@/server/services/generation/videoFile';
 import { AsyncTaskError, AsyncTaskErrorType, AsyncTaskStatus } from '@/types/asyncTask';
@@ -16,6 +18,7 @@ import type { VideoGenerationAsset } from '@/types/generation';
 const log = debug('lobe-video:background-polling');
 
 interface BackgroundPollingParams {
+  aicoBilling?: AicoBillingContext;
   asyncTaskCreatedAt: Date;
   asyncTaskId: string;
   generationBatchId: string;
@@ -34,6 +37,7 @@ export async function processBackgroundVideoPolling(
   params: BackgroundPollingParams,
 ): Promise<void> {
   const {
+    aicoBilling,
     asyncTaskCreatedAt,
     asyncTaskId,
     generationBatchId,
@@ -57,7 +61,10 @@ export async function processBackgroundVideoPolling(
     const videoService = new VideoGenerationService(db, userId, workspaceId);
     const generationModel = new GenerationModel(db, userId, workspaceId);
 
-    const modelRuntime = await initModelRuntimeFromDB(db, userId, provider, workspaceId);
+    const modelRuntime = await initModelRuntimeFromDB(db, userId, provider, workspaceId, {
+      billingContext: aicoBilling,
+      modelId: toManagedGenerationModelId(model),
+    });
     const pollResult = await pollUntilCompletion(modelRuntime, inferenceId);
 
     if (!pollResult) {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
@@ -87,7 +87,12 @@ describe('createOpenAICompatibleImage', () => {
         const result = await createOpenAICompatibleImage(mockClient, payload, 'openrouter');
 
         expect(result.imageUrl).toBe('data:image/png;base64,generatedImageData');
-        expect(mockClient.chat.completions.create).toHaveBeenCalled();
+        expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modalities: ['image', 'text'],
+            model: 'gemini-2.0-flash-exp',
+          }),
+        );
       });
 
       it('should process base64 data URI without mimeType', async () => {
@@ -267,6 +272,7 @@ describe('createOpenAICompatibleImage', () => {
               role: 'user',
             },
           ],
+          modalities: ['image', 'text'],
           model: 'gemini-2.0-flash',
           stream: false,
         });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -211,7 +211,6 @@ async function generateByChatModel(
     }
   }
 
-  // Call chat completion API
   const response = await client.chat.completions.create({
     messages: [
       {
@@ -220,8 +219,12 @@ async function generateByChatModel(
       },
     ],
     model: actualModel,
+    // OpenRouter (and similar) require modalities so the model returns an image
+    // rather than text. The provider chat() path injects this via handlePayload;
+    // createImage uses the raw OpenAI client, so set it here explicitly.
+    modalities: ['image', 'text'],
     stream: false,
-  });
+  } as Parameters<typeof client.chat.completions.create>[0]);
 
   log('Chat API response: %O', response);
 

--- a/src/hooks/useEnabledImageModels.ts
+++ b/src/hooks/useEnabledImageModels.ts
@@ -1,0 +1,38 @@
+import isEqual from 'fast-deep-equal';
+import { useMemo } from 'react';
+
+import { filterAicoManagedProviders } from '@/features/AicoBilling/isManagedRuntimeProvider';
+import { isAicoManagedProviderMode } from '@/features/Conversation/Error/isAicoManagedProviderMode';
+import { useClientDataSWR } from '@/libs/swr';
+import { lambdaClient } from '@/libs/trpc/client';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { type EnabledProviderWithModels } from '@/types/aiProvider';
+
+/**
+ * Enabled image models for the Image Create picker.
+ * In Aico managed mode, only wallet-backed OpenRouter/`aico` providers are shown
+ * (same product rule as chat — never BYOK Google/OpenAI keys).
+ */
+export const useEnabledImageModels = (): {
+  isManagedStatusLoading: boolean;
+  list: EnabledProviderWithModels[];
+} => {
+  const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList, isEqual);
+  const { data: managedStatus, isLoading } = useClientDataSWR('aico-provider-status', () =>
+    lambdaClient.aicoBilling.getManagedProviderStatus.query(),
+  );
+
+  const list = useMemo(() => {
+    const raw = enabledImageModelList || [];
+    // While status loads, expose an empty list so config init waits (avoids
+    // locking onto Google defaults before we know Aico is managed-only).
+    if (managedStatus === undefined && isLoading) return [];
+    if (!isAicoManagedProviderMode(managedStatus?.managed)) return raw;
+    return filterAicoManagedProviders(raw);
+  }, [enabledImageModelList, isLoading, managedStatus]);
+
+  return {
+    isManagedStatusLoading: managedStatus === undefined && Boolean(isLoading),
+    list,
+  };
+};

--- a/src/hooks/useEnabledVideoModels.ts
+++ b/src/hooks/useEnabledVideoModels.ts
@@ -1,0 +1,35 @@
+import isEqual from 'fast-deep-equal';
+import { useMemo } from 'react';
+
+import { filterAicoManagedProviders } from '@/features/AicoBilling/isManagedRuntimeProvider';
+import { isAicoManagedProviderMode } from '@/features/Conversation/Error/isAicoManagedProviderMode';
+import { useClientDataSWR } from '@/libs/swr';
+import { lambdaClient } from '@/libs/trpc/client';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { type EnabledProviderWithModels } from '@/types/aiProvider';
+
+/**
+ * Enabled video models for the Video Create picker.
+ * Aico managed mode: wallet-backed providers only (match chat / image).
+ */
+export const useEnabledVideoModels = (): {
+  isManagedStatusLoading: boolean;
+  list: EnabledProviderWithModels[];
+} => {
+  const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList, isEqual);
+  const { data: managedStatus, isLoading } = useClientDataSWR('aico-provider-status', () =>
+    lambdaClient.aicoBilling.getManagedProviderStatus.query(),
+  );
+
+  const list = useMemo(() => {
+    const raw = enabledVideoModelList || [];
+    if (managedStatus === undefined && isLoading) return [];
+    if (!isAicoManagedProviderMode(managedStatus?.managed)) return raw;
+    return filterAicoManagedProviders(raw);
+  }, [enabledVideoModelList, isLoading, managedStatus]);
+
+  return {
+    isManagedStatusLoading: managedStatus === undefined && Boolean(isLoading),
+    list,
+  };
+};

--- a/src/hooks/useFetchAiImageConfig.ts
+++ b/src/hooks/useFetchAiImageConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
+import { useEnabledImageModels } from '@/hooks/useEnabledImageModels';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -10,9 +11,10 @@ import {
 } from '@/store/image/slices/generationConfig/initialState';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
+import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
 const checkModelEnabled = (
-  enabledImageModelList: ReturnType<typeof aiProviderSelectors.enabledImageModelList>,
+  enabledImageModelList: EnabledProviderWithModels[],
   provider: string,
   model: string,
 ) => {
@@ -34,7 +36,10 @@ export const useFetchAiImageConfig = () => {
   const isUserStateInit = useUserStore((s) => s.isUserStateInit);
   const isUserStateReady = isUserStateInit || isActualLogout;
 
-  const isReadyForInit = isStatusInit && isInitAiProviderRuntimeState && isUserStateReady;
+  const { list: enabledImageModelList, isManagedStatusLoading } = useEnabledImageModels();
+
+  const isReadyForInit =
+    isStatusInit && isInitAiProviderRuntimeState && isUserStateReady && !isManagedStatusLoading;
 
   const { lastSelectedImageModel, lastSelectedImageProvider } = useGlobalStore((s) => ({
     lastSelectedImageModel: s.status.lastSelectedImageModel,
@@ -42,8 +47,6 @@ export const useFetchAiImageConfig = () => {
   }));
   const isInitializedImageConfig = useImageStore((s) => s.isInit);
   const initializeImageConfig = useImageStore((s) => s.initializeImageConfig);
-
-  const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
 
   // Determine which model/provider to use for initialization
   const initParams = useMemo(() => {
@@ -69,7 +72,7 @@ export const useFetchAiImageConfig = () => {
       return { model: DEFAULT_AI_IMAGE_MODEL, provider: providerWithDefaultModel.id };
     }
 
-    // 3. Fallback to first enabled model
+    // 3. Fallback to first enabled model (OpenRouter under Aico managed mode)
     const firstProvider = enabledImageModelList[0];
     const firstModel = firstProvider?.children[0];
     if (firstProvider && firstModel) {

--- a/src/hooks/useFetchAiVideoConfig.ts
+++ b/src/hooks/useFetchAiVideoConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
+import { useEnabledVideoModels } from '@/hooks/useEnabledVideoModels';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -10,9 +11,10 @@ import {
   DEFAULT_AI_VIDEO_MODEL,
   DEFAULT_AI_VIDEO_PROVIDER,
 } from '@/store/video/slices/generationConfig/initialState';
+import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
 const checkModelEnabled = (
-  enabledVideoModelList: ReturnType<typeof aiProviderSelectors.enabledVideoModelList>,
+  enabledVideoModelList: EnabledProviderWithModels[],
   provider: string,
   model: string,
 ) => {
@@ -34,7 +36,10 @@ export const useFetchAiVideoConfig = () => {
   const isUserStateInit = useUserStore((s) => s.isUserStateInit);
   const isUserStateReady = isUserStateInit || isActualLogout;
 
-  const isReadyForInit = isStatusInit && isInitAiProviderRuntimeState && isUserStateReady;
+  const { list: enabledVideoModelList, isManagedStatusLoading } = useEnabledVideoModels();
+
+  const isReadyForInit =
+    isStatusInit && isInitAiProviderRuntimeState && isUserStateReady && !isManagedStatusLoading;
 
   const { lastSelectedVideoModel, lastSelectedVideoProvider } = useGlobalStore((s) => ({
     lastSelectedVideoModel: s.status.lastSelectedVideoModel,
@@ -42,8 +47,6 @@ export const useFetchAiVideoConfig = () => {
   }));
   const isInitializedVideoConfig = useVideoStore((s) => s.isInit);
   const initializeVideoConfig = useVideoStore((s) => s.initializeVideoConfig);
-
-  const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
 
   // Determine which model/provider to use for initialization
   const initParams = useMemo(() => {

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
@@ -64,6 +64,20 @@ vi.mock('@/store/aiInfra', () => ({
     selector(testState.aiInfra),
 }));
 
+vi.mock('@/hooks/useEnabledImageModels', () => ({
+  useEnabledImageModels: () => ({
+    isManagedStatusLoading: false,
+    list: testState.aiInfra.enabledImageModelList,
+  }),
+}));
+
+vi.mock('@/hooks/useEnabledVideoModels', () => ({
+  useEnabledVideoModels: () => ({
+    isManagedStatusLoading: false,
+    list: testState.aiInfra.enabledVideoModelList,
+  }),
+}));
+
 describe('resolveGenerationModelNotice', () => {
   it('does not return a notice before the model runtime config is ready', () => {
     expect(

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
@@ -1,3 +1,5 @@
+import { useEnabledImageModels } from '@/hooks/useEnabledImageModels';
+import { useEnabledVideoModels } from '@/hooks/useEnabledVideoModels';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useImageStore } from '@/store/image';
 import { imageGenerationConfigSelectors } from '@/store/image/selectors';
@@ -69,7 +71,7 @@ export interface UseGenerationModelNoticeResult {
 export const useImageGenerationModelNotice = (): UseGenerationModelNoticeResult => {
   const model = useImageStore(imageGenerationConfigSelectors.model);
   const provider = useImageStore(imageGenerationConfigSelectors.provider);
-  const enabledModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  const enabledModelList = useEnabledImageModels().list;
   const isModelConfigReady = useAiInfraStore((s) =>
     aiProviderSelectors.isInitAiProviderRuntimeState(s),
   );
@@ -87,7 +89,7 @@ export const useImageGenerationModelNotice = (): UseGenerationModelNoticeResult 
 export const useVideoGenerationModelNotice = (): UseGenerationModelNoticeResult => {
   const model = useVideoStore(videoGenerationConfigSelectors.model);
   const provider = useVideoStore(videoGenerationConfigSelectors.provider);
-  const enabledModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  const enabledModelList = useEnabledVideoModels().list;
   const isModelConfigReady = useAiInfraStore((s) =>
     aiProviderSelectors.isInitAiProviderRuntimeState(s),
   );

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -12,6 +12,7 @@ import { loginRequired } from '@/components/Error/loginRequiredNotification';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import PromptTransformAction from '@/features/PromptTransform/PromptTransformAction';
+import { useEnabledImageModels } from '@/hooks/useEnabledImageModels';
 import { useFetchAiImageConfig } from '@/hooks/useFetchAiImageConfig';
 import { useIsDark } from '@/hooks/useIsDark';
 import { usePermission } from '@/hooks/usePermission';
@@ -175,7 +176,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const isSupportWatermark = useImageStore(isSupportedParamSelector('watermark'));
   const isSupportWebSearch = useImageStore(isSupportedParamSelector('webSearch'));
   const isLogin = useUserStore(authSelectors.isLogin);
-  const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  const enabledImageModelList = useEnabledImageModels().list;
   const isModelConfigReady = useAiInfraStore((s) =>
     aiProviderSelectors.isInitAiProviderRuntimeState(s),
   );

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -13,6 +13,7 @@ import { loginRequired } from '@/components/Error/loginRequiredNotification';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import PromptTransformAction from '@/features/PromptTransform/PromptTransformAction';
+import { useEnabledVideoModels } from '@/hooks/useEnabledVideoModels';
 import { useFetchAiVideoConfig } from '@/hooks/useFetchAiVideoConfig';
 import { useIsDark } from '@/hooks/useIsDark';
 import { usePermission } from '@/hooks/usePermission';
@@ -320,7 +321,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const setNewGenerationTopicVisibility = useVideoStore((s) => s.setNewGenerationTopicVisibility);
   const currentModel = useVideoStore(videoGenerationConfigSelectors.model);
   const currentProvider = useVideoStore(videoGenerationConfigSelectors.provider);
-  const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  const enabledVideoModelList = useEnabledVideoModels().list;
   const isModelConfigReady = useAiInfraStore((s) =>
     aiProviderSelectors.isInitAiProviderRuntimeState(s),
   );

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -11,12 +11,24 @@ export class AiImageService {
     log('Creating image with payload: %O', payload);
 
     try {
-      const result = await lambdaClient.image.createImage.mutate(payload);
+      // Managed OpenRouter/Aico must send explicit billing — same contract as chat.
+      const { AICO_BILLING_SOURCES_SWR_KEY, assertAicoBillingAllowsChat } =
+        await import('@/features/AicoBilling');
+      const aicoBilling = await assertAicoBillingAllowsChat(payload.provider);
+      const requestPayload = aicoBilling ? { ...payload, aicoBilling } : payload;
+
+      const result = await lambdaClient.image.createImage.mutate(requestPayload);
       log('Image creation service call completed successfully: %O', {
         batchId: result.data?.batch?.id,
         generationCount: result.data?.generations?.length,
         success: result.success,
       });
+
+      if (aicoBilling) {
+        const { mutate: globalMutate } = await import('@/libs/swr');
+        void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
+        void globalMutate('aico-my-wallet');
+      }
 
       return result;
     } catch (error) {

--- a/src/services/video.ts
+++ b/src/services/video.ts
@@ -10,12 +10,23 @@ export class AiVideoService {
     log('Creating video with payload: %O', payload);
 
     try {
-      const result = await lambdaClient.video.createVideo.mutate(payload);
+      const { AICO_BILLING_SOURCES_SWR_KEY, assertAicoBillingAllowsChat } =
+        await import('@/features/AicoBilling');
+      const aicoBilling = await assertAicoBillingAllowsChat(payload.provider);
+      const requestPayload = aicoBilling ? { ...payload, aicoBilling } : payload;
+
+      const result = await lambdaClient.video.createVideo.mutate(requestPayload);
       log('Video creation service call completed: %O', {
         batchId: result.data?.batch?.id,
         generationCount: result.data?.generations?.length,
         success: result.success,
       });
+
+      if (aicoBilling) {
+        const { mutate: globalMutate } = await import('@/libs/swr');
+        void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
+        void globalMutate('aico-my-wallet');
+      }
 
       return result;
     } catch (error) {


### PR DESCRIPTION
## Summary
- Thread explicit `aicoBilling` from Image/Video create through async task metadata into `initModelRuntimeFromDB` (fixes `BILLING_CONTEXT_REQUIRED` on managed OpenRouter/`aico`).
- Scope Image/Video model pickers to wallet-backed providers (same product rule as chat); reject BYOK providers on the server.
- Request `modalities: ['image','text']` in chat-based `:image` createImage so OpenRouter returns images.

Fixes #251

Plane: [AICO-149](https://plane.panafor.com/panaforai/browse/AICO-149/)

## Test plan
- [ ] Open Image Create with a funded personal/org wallet; select an OpenRouter image model; generate — asset appears (not stuck Pending/Error)
- [ ] Confirm Google/BYOK providers are not offered in the Image model picker under Aico managed mode
- [ ] Missing billing / wrong provider returns a clear BAD_REQUEST (not a silent async failure)
- [ ] Video create on a managed provider also submits with billing context (no `BILLING_CONTEXT_REQUIRED`)


Made with [Cursor](https://cursor.com)