### PR TITLE
🔧 fix(aico): default Image Create to OpenRouter Nano Banana 2

### DIFF
--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.test.tsx
@@ -22,8 +22,8 @@ const testState = vi.hoisted(() => ({
     enabledVideoModelList: [] as TestProviderWithModels[],
     isInitAiProviderRuntimeState: false,
   },
-  // Mirrors the buggy default: falls back to the Google provider even when Google
-  // is disabled (lobehub/lobehub#17400).
+  // Mirrors a stale selection: falls back to Google even when Aico managed mode
+  // only exposes OpenRouter (lobehub/lobehub#17400 pattern).
   image: { model: 'gemini-3.1-flash-image-preview:image', provider: 'google' },
   video: { model: 'veo-3.1', provider: 'google' },
 }));

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationModelNotice/useGenerationModelNotice.ts
@@ -36,10 +36,11 @@ interface ResolveGenerationModelNoticeParams {
  * We gate on `isModelConfigReady` (aiProvider runtime state initialized) so we do
  * NOT flash a false warning while the provider runtime config is still loading and
  * the enabled model list is transiently empty. This matters for the default state
- * where the store falls back to `provider=google,
- * model='gemini-3.1-flash-image-preview:image'`: once config is ready and Google is
- * disabled, the notice reads as `providerDisabled` instead of silently generating
- * against a disabled provider (see lobehub/lobehub#17400).
+ * where the store falls back to `provider=openrouter`,
+ * model='google/gemini-3.1-flash-image-preview:image'`: once config is ready and that
+ * provider/model is unavailable, the notice reads as `providerDisabled` /
+ * `modelRemoved` instead of silently generating against a disabled provider
+ * (see lobehub/lobehub#17400).
  */
 export const resolveGenerationModelNotice = ({
   enabledModelList,

--- a/src/store/image/slices/generationConfig/initialState.ts
+++ b/src/store/image/slices/generationConfig/initialState.ts
@@ -4,8 +4,10 @@ import { nanoBanana2Parameters } from 'model-bank/imageParameters';
 
 import { DEFAULT_IMAGE_CONFIG } from '@/const/settings';
 
-export const DEFAULT_AI_IMAGE_PROVIDER = ModelProvider.Google;
-export const DEFAULT_AI_IMAGE_MODEL = 'gemini-3.1-flash-image-preview:image';
+/** Aico: Nano Banana runs on managed OpenRouter (not Google BYOK). */
+export const DEFAULT_AI_IMAGE_PROVIDER = ModelProvider.OpenRouter;
+/** OpenRouter id + Image-tab `:image` sibling (see postProcessModelList). */
+export const DEFAULT_AI_IMAGE_MODEL = 'google/gemini-3.1-flash-image-preview:image';
 
 export interface GenerationConfigState {
   parameters: RuntimeImageGenParams;


### PR DESCRIPTION
## Summary
- Point Image Create defaults at managed OpenRouter Nano Banana 2 (`openrouter` + `google/gemini-3.1-flash-image-preview:image`) instead of Google BYOK ids.
- Follow-up: this commit was pushed after #252 merged and never landed on `canary`.

#### 🔗 Related Issue

Fixes #253

Plane: [AICO-150](https://plane.panafor.com/panaforai/browse/AICO-150/)

## Test plan
- [ ] Fresh Image Create session (no lastSelected) selects OpenRouter Nano Banana 2
- [ ] Google is not the default provider under Aico managed mode


Made with [Cursor](https://cursor.com)