### PR TITLE
✨ feat(deploy): Panachat preview stack with isolated DB

### DIFF
--- a/.agents/skills/self-host-deploy/SKILL.md
+++ b/.agents/skills/self-host-deploy/SKILL.md
@@ -100,7 +100,13 @@ For a Linux server that must always match GitHub `canary` with no data loss and 
 
 → **[canary-cicd.md](canary-cicd.md)** (`deploy-canary.yml` + `panachat-deploy-remote.sh` + `docker-compose.panachat.yml`)
 
-## Image: private `ghcr.io/<owner>/panachat:<sha>`. Volumes: `panachat_*` only.
+Image: private `ghcr.io/<owner>/panachat:<sha>`. Volumes: `panachat_*` only.
+
+### Path D: Preview branch (staging on same VPS)
+
+Long-lived `preview` branch deploys to an isolated stack with its **own** Postgres/Redis/RustFS volumes (`panachat_preview_*`). Promote with a PR `preview` → `canary`.
+
+→ **[preview-cicd.md](preview-cicd.md)** (`deploy-preview.yml` + `PANACHAT_ENV=preview`)
 
 ## Reverse proxy / CDN
 
@@ -224,11 +230,13 @@ Full troubleshooting: [reference.md](reference.md)
 | **Deploy**  | Backup → pull/rebuild → `verify-deployment.sh` → rollback plan ready                                      |
 | **Updates** | Pin image tags; never `pull` without a DB backup                                                          |
 | **Canary**  | Server tracks GitHub `canary` via GHCR + blue-green — see [canary-cicd.md](canary-cicd.md)                |
+| **Preview** | Same VPS staging on `preview` with own DB — see [preview-cicd.md](preview-cicd.md)                        |
 
 Templates:
 
 - [production.env.example](templates/production.env.example)
 - [docker-compose.production.override.yml](templates/docker-compose.production.override.yml)
-- [canary-cicd.md](canary-cicd.md) — Panachat CI/CD (private GHCR, `panachat-deploy-remote.sh`)
+- [canary-cicd.md](canary-cicd.md) — Panachat prod CI/CD (private GHCR, `panachat-deploy-remote.sh`)
+- [preview-cicd.md](preview-cicd.md) — Panachat preview stack (`panachat_preview_*` volumes)
 
 Complete guide: [best-practices.md](best-practices.md)

--- a/.agents/skills/self-host-deploy/canary-cicd.md
+++ b/.agents/skills/self-host-deploy/canary-cicd.md
@@ -87,21 +87,23 @@ docker compose -f docker-compose/deploy/docker-compose.panachat.yml \
 Every push to `canary` builds, pushes GHCR, then runs:
 
 ```bash
-./scripts/panachat-deploy-remote.sh deploy ghcr.io/<owner>/panachat:<sha>
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy ghcr.io/<owner>/panachat:<sha>
 ```
 
 Manual: Actions → **Deploy Panachat Canary** → `workflow_dispatch` (optional skip deploy).
 
+For staging before prod, use the **`preview`** branch and [preview-cicd.md](preview-cicd.md) (own database on the same VPS).
+
 ## Day-2 ops
 
 ```bash
-./scripts/panachat-deploy-remote.sh status
-./scripts/panachat-deploy-remote.sh rollback # previous SHA, blue-green
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh rollback # previous SHA, blue-green
 ./scripts/panachat-backup.sh --reason manual
 bash .claude/skills/self-host-deploy/scripts/verify-deployment.sh https://chat.example.com
 ```
 
-App updates only touch `panachat-blue` / `panachat-green`. Data services stay up. Failed health checks leave traffic on the old slot.
+App updates only touch `${PANACHAT_STACK}-blue` / `-green` (default `panachat-blue` / `panachat-green`). Data services stay up. Failed health checks leave traffic on the old slot.
 
 ## Near-zero downtime notes
 

--- a/.agents/skills/self-host-deploy/preview-cicd.md
+++ b/.agents/skills/self-host-deploy/preview-cicd.md
@@ -1,0 +1,88 @@
+# Panachat preview branch CI/CD
+
+Staging stack on the **same VPS** as production, with its **own database** (and Redis / RustFS). Promote to prod by merging `preview` → `canary`.
+
+## Why a separate DB
+
+Preview runs real migrations and test traffic. Sharing prod Postgres/Redis/RustFS risks data loss and downtime. Preview volumes are always `panachat_preview_*` — never `panachat_*`.
+
+## Git flow
+
+```text
+feature/*  →  preview  →  (smoke test)  →  canary  →  production VPS
+                 │                              │
+                 └─ deploy-preview.yml          └─ deploy-canary.yml
+                    PANACHAT_ENV=preview           PANACHAT_ENV=canary
+```
+
+| Branch    | Workflow                                                              | Image tags       | Stack                                             |
+| --------- | --------------------------------------------------------------------- | ---------------- | ------------------------------------------------- |
+| `preview` | [`deploy-preview.yml`](../../../.github/workflows/deploy-preview.yml) | `:preview` + SHA | `panachat-preview` + `panachat_preview_*` volumes |
+| `canary`  | [`deploy-canary.yml`](../../../.github/workflows/deploy-canary.yml)   | `:canary` + SHA  | `panachat` + `panachat_*` volumes                 |
+
+## Isolation map
+
+| Setting          | Preview                                                                 | Prod (canary)                   |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------- |
+| Compose project  | `panachat-preview`                                                      | `panachat`                      |
+| Volumes          | `panachat_preview_postgres_data` (etc.)                                 | `panachat_postgres_data` (etc.) |
+| App ports        | `3220` / `3221`                                                         | `3210` / `3211`                 |
+| RustFS host port | `9010` (example)                                                        | `9000`                          |
+| App env          | `.env.preview`                                                          | `.env`                          |
+| Infra env        | `docker-compose/deploy/.env.preview`                                    | `docker-compose/deploy/.env`    |
+| State            | `/var/lib/panachat-preview/deploy.env`                                  | `/var/lib/panachat/deploy.env`  |
+| Nginx upstream   | `panachat_preview_backend`                                              | `panachat_backend`              |
+| Backup dir       | `~/…/panachat-preview-backups` (or `/var/lib/panachat-preview/backups`) | prod backup dir                 |
+
+**Hard bans:** `docker compose down -v`, deleting `panachat_*` or `panachat_preview_*` volumes casually, pointing preview `DATABASE_URL` at prod.
+
+## One-time server bootstrap (preview)
+
+Assumes prod canary stack is already running on the same host and repo checkout (e.g. `~/panachat`).
+
+```bash
+cd ~/panachat # same checkout as prod
+
+cp .env.example.preview .env.preview
+cp docker-compose/deploy/.env.example.preview docker-compose/deploy/.env.preview
+chmod 600 .env.preview docker-compose/deploy/.env.preview
+# Use DISTINCT secrets, APP_URL=https://preview.…, ports 3220/3221, RUSTFS_PORT=9010
+
+sudo cp docker-compose/deploy/nginx/panachat-preview-upstream.blue.conf \
+  /etc/nginx/conf.d/panachat-preview-upstream.conf
+# Enable docker-compose/deploy/nginx/panachat-preview-site.example.conf + TLS
+
+export PANACHAT_IMAGE=ghcr.io/ < owner > /panachat:preview
+PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh bootstrap "$PANACHAT_IMAGE"
+```
+
+Create the long-lived GitHub branch once (from a good `canary`):
+
+```bash
+git fetch origin
+git checkout canary
+git pull --rebase origin canary
+git checkout -b preview
+git push -u origin preview
+```
+
+## Day-2 ops
+
+```bash
+PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh status
+PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh rollback
+PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy ghcr.io/<owner>/panachat:<sha>
+```
+
+Promote to production after smoke tests:
+
+```bash
+# Open PR preview → canary (or merge locally) so deploy-canary.yml runs
+gh pr create --base canary --head preview --title "Promote preview to canary"
+```
+
+## Related
+
+- Prod canary docs: [canary-cicd.md](canary-cicd.md)
+- Deploy script: [`scripts/panachat-deploy-remote.sh`](../../../scripts/panachat-deploy-remote.sh)
+- Compose: [`docker-compose.panachat.yml`](../../../docker-compose/deploy/docker-compose.panachat.yml)

--- a/.env.example.preview
+++ b/.env.example.preview
@@ -1,0 +1,38 @@
+# Panachat PREVIEW application environment (staging on same VPS).
+# Own database / Redis / RustFS — never point at prod volumes.
+# Compose loads this via PANACHAT_ENV=preview → .env.preview
+
+# Public URLs (preview host)
+APP_URL=https://preview.chat.example.com
+INTERNAL_APP_URL=http://localhost:3210
+AUTH_TRUSTED_ORIGINS=https://preview.chat.example.com
+
+# Branding
+BRANDING_NAME=Panachat
+NEXT_PUBLIC_BRANDING_NAME=Panachat
+BRANDING_NAME_FA=پاناچت
+NEXT_PUBLIC_BRANDING_NAME_FA=پاناچت
+ORG_NAME=Panachat
+NEXT_PUBLIC_ORG_NAME=Panachat
+ORG_NAME_FA=پاناچت
+NEXT_PUBLIC_ORG_NAME_FA=پاناچت
+BRANDING_CLOUD_NAME=Panachat Cloud
+NEXT_PUBLIC_BRANDING_CLOUD_NAME=Panachat Cloud
+BRANDING_CLOUD_NAME_FA=ابر پاناچت
+NEXT_PUBLIC_BRANDING_CLOUD_NAME_FA=ابر پاناچت
+
+# Auth
+AUTH_EMAIL_VERIFICATION=1
+# AUTH_ALLOWED_EMAILS=admin@example.com
+
+# Secrets — use DIFFERENT values from production .env
+KEY_VAULTS_SECRET=change-me-preview-key-vaults-secret
+AUTH_SECRET=change-me-preview-auth-secret
+
+SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
+
+# Browser-reachable S3 for preview (separate bucket or path recommended)
+# S3_ENDPOINT=https://s3-preview.example.com
+# S3_BUCKET=lobe
+# S3_ENABLE_PATH_STYLE=1
+# S3_SET_ACL=0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,19 +1,20 @@
-name: Deploy Panachat Canary
+name: Deploy Panachat Preview
 
-# Build ghcr.io/<owner>/panachat on every push to canary, then SSH-deploy
-# with blue-green swap (scripts/panachat-deploy-remote.sh).
+# Build ghcr.io/<owner>/panachat on every push to preview, then SSH-deploy
+# the isolated preview stack (own DB volumes) with PANACHAT_ENV=preview.
 #
-# Required secrets:
+# Required secrets (same as canary deploy):
 #   DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
-#   GHCR_READ_TOKEN — PAT with read:packages (server pulls private ghcr.io/.../panachat)
-# Optional secrets:
+#   GHCR_READ_TOKEN — PAT with read:packages
+# Optional:
 #   DEPLOY_PATH (repo root on server; default ~/panachat)
 #
-# Package visibility: workflow attempts to set the GHCR package to private
-# after push (public GitHub repo does not mean a public image).
+# Preview must use .env.preview + docker-compose/deploy/.env.preview on the server
+# and panachat_preview_* volumes — never prod panachat_* volumes.
+
 on:
   push:
-    branches: [canary]
+    branches: [preview]
   workflow_dispatch:
     inputs:
       skip_deploy:
@@ -22,7 +23,7 @@ on:
         default: false
 
 concurrency:
-  group: deploy-canary
+  group: deploy-preview
   cancel-in-progress: false
 
 permissions:
@@ -34,7 +35,7 @@ env:
 
 jobs:
   build:
-    name: Build and push Panachat image
+    name: Build and push Panachat preview image
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.vars.outputs.image }}
@@ -69,7 +70,7 @@ jobs:
           tags: |
             type=raw,value=${{ steps.vars.outputs.sha_short }}
             type=raw,value=${{ steps.vars.outputs.sha }}
-            type=raw,value=canary
+            type=raw,value=preview
           labels: |
             org.opencontainers.image.title=panachat
             org.opencontainers.image.source=${{ github.repositoryUrl }}
@@ -94,28 +95,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           owner='${{ github.repository_owner }}'
-          # Package name for container API is the image name without registry
           pkg='panachat'
-          # Org vs user package endpoints
           if gh api "orgs/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
             gh api --method PATCH "orgs/${owner}/packages/container/${pkg}" \
               -f visibility=private || true
-            echo "Set org package ${owner}/${pkg} visibility=private"
           elif gh api "users/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
             gh api --method PATCH "users/${owner}/packages/container/${pkg}" \
               -f visibility=private || true
-            echo "Set user package ${owner}/${pkg} visibility=private"
           else
             echo "Package not visible yet via API — set Private in GitHub Packages UI after first push."
           fi
 
   deploy:
-    name: SSH blue-green deploy
+    name: SSH preview blue-green deploy
     needs: build
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy over SSH
+      - name: Deploy preview over SSH
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.DEPLOY_HOST }}
@@ -130,7 +127,7 @@ jobs:
             if [ -n "${GHCR_TOKEN:-}" ]; then
               echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
             fi
-            PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
+            PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
         env:
           IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}

--- a/docker-compose/deploy/.env.example.panachat
+++ b/docker-compose/deploy/.env.example.panachat
@@ -1,6 +1,10 @@
 # Panachat deploy infrastructure (server / canary CI-CD)
 # Keep infra-only. App config lives in ../../.env (from .env.example.panachat).
 
+# Stack identity (default prod/canary)
+PANACHAT_STACK=panachat
+PANACHAT_VOLUME_PREFIX=panachat
+
 # GHCR image pin — set by panachat-deploy-remote.sh / GitHub Actions
 # PANACHAT_IMAGE=ghcr.io/panafor-ai-team/panachat:canary
 

--- a/docker-compose/deploy/.env.example.preview
+++ b/docker-compose/deploy/.env.example.preview
@@ -1,0 +1,42 @@
+# Panachat PREVIEW deploy infrastructure (same VPS, isolated data plane)
+# App config: ../../.env.preview
+# Never reuse prod PANACHAT_* volume names or POSTGRES_PASSWORD from prod.
+
+# Stack identity (filled/updated by panachat-deploy-remote.sh when PANACHAT_ENV=preview)
+PANACHAT_STACK=panachat-preview
+PANACHAT_VOLUME_PREFIX=panachat_preview
+# PANACHAT_APP_ENV_FILE / PANACHAT_INFRA_ENV_FILE are set by the deploy script
+
+# GHCR image pin — set by deploy script / Actions
+# PANACHAT_IMAGE=ghcr.io/panafor-ai-team/panachat:preview
+
+# Blue-green ports (must not collide with prod 3210/3211)
+PANACHAT_PORT_BLUE=3220
+PANACHAT_PORT_GREEN=3221
+
+# Database (own volume: panachat_preview_postgres_data)
+PANACHAT_DB_NAME=lobechat
+LOBE_DB_NAME=lobechat
+POSTGRES_PASSWORD=change-me-preview-db-password
+POSTGRES_CONTAINER=panachat-preview-postgres
+
+# Object storage (own volume: panachat_preview_rustfs_data)
+# Use a different host port than prod RustFS (9000)
+RUSTFS_PORT=9010
+RUSTFS_ACCESS_KEY=admin
+RUSTFS_SECRET_KEY=change-me-preview-rustfs-secret
+RUSTFS_LOBE_BUCKET=lobe
+S3_ENDPOINT=https://s3-preview.example.com
+
+JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me-preview","use":"sig","alg":"RS256","n":"replace-me","e":"AQAB","d":"replace-me","p":"replace-me","q":"replace-me","dp":"replace-me","dq":"replace-me","qi":"replace-me"}]}
+
+# Fingerprint / metadata only (not live PGDATA)
+PANACHAT_DATA_DIR=/var/lib/panachat-preview/data
+PANACHAT_BACKUP_DIR=/var/lib/panachat-preview/backups
+
+# Optional control-plane (preview)
+# PANACHAT_CONTROL_PLANE_PORT=3030
+# COMPOSE_PROFILES=control-plane
+
+# Nginx upstream rewritten by PANACHAT_ENV=preview deploy
+# PANACHAT_NGINX_UPSTREAM_FILE=/etc/nginx/conf.d/panachat-preview-upstream.conf

--- a/docker-compose/deploy/docker-compose.panachat.yml
+++ b/docker-compose/deploy/docker-compose.panachat.yml
@@ -1,21 +1,23 @@
-# Panachat production / canary CI-CD stack (blue-green app + durable data plane).
+# Panachat production / canary / preview CI-CD stack (blue-green app + durable data plane).
 #
 # Usage (from docker-compose/deploy):
 #   export PANACHAT_IMAGE=ghcr.io/panafor-ai-team/panachat:<sha>
-#   docker compose -f docker-compose.panachat.yml --env-file ../../.env --env-file .env up -d
+#   export PANACHAT_STACK=panachat                    # or panachat-preview
+#   export PANACHAT_VOLUME_PREFIX=panachat            # or panachat_preview
+#   docker compose -p "$PANACHAT_STACK" -f docker-compose.panachat.yml \
+#     --env-file ../../.env --env-file .env up -d
 #
-# Deploy script (scripts/panachat-deploy-remote.sh) starts only the inactive
-# app slot, verifies it, flips nginx, then stops the old slot.
-# Never run `docker compose down -v` — named volumes hold production data.
+# Preview uses a separate project, volumes, and ports — never share prod data.
+# Never run `docker compose down -v` — named volumes hold durable data.
 
-name: panachat
+name: ${PANACHAT_STACK:-panachat}
 
 services:
   # App slots are profile-gated so `compose up -d` (data plane) never
   # accidentally restarts a stopped color. Deploy script starts one profile.
   panachat-blue:
     image: ${PANACHAT_IMAGE:?set PANACHAT_IMAGE to ghcr.io/<owner>/panachat:<sha>}
-    container_name: panachat-blue
+    container_name: ${PANACHAT_STACK:-panachat}-blue
     pull_policy: always
     profiles:
       - slot-blue
@@ -48,15 +50,15 @@ services:
       - 'AICO_CONTROL_PLANE_URL=${AICO_CONTROL_PLANE_URL:-http://panachat-control-plane:3020}'
       - 'OPENROUTER_MANAGEMENT_API_KEY='
     env_file:
-      - ../../.env
-      - .env
+      - ${PANACHAT_APP_ENV_FILE:-../../.env}
+      - ${PANACHAT_INFRA_ENV_FILE:-.env}
     networks:
       - panachat-network
     restart: unless-stopped
 
   panachat-green:
     image: ${PANACHAT_IMAGE:?set PANACHAT_IMAGE to ghcr.io/<owner>/panachat:<sha>}
-    container_name: panachat-green
+    container_name: ${PANACHAT_STACK:-panachat}-green
     pull_policy: always
     profiles:
       - slot-green
@@ -89,15 +91,15 @@ services:
       - 'AICO_CONTROL_PLANE_URL=${AICO_CONTROL_PLANE_URL:-http://panachat-control-plane:3020}'
       - 'OPENROUTER_MANAGEMENT_API_KEY='
     env_file:
-      - ../../.env
-      - .env
+      - ${PANACHAT_APP_ENV_FILE:-../../.env}
+      - ${PANACHAT_INFRA_ENV_FILE:-.env}
     networks:
       - panachat-network
     restart: unless-stopped
 
   panachat-control-plane:
     image: ${PANACHAT_CONTROL_PLANE_IMAGE:-node:24-bookworm-slim}
-    container_name: panachat-control-plane
+    container_name: ${PANACHAT_STACK:-panachat}-control-plane
     profiles:
       - control-plane
     working_dir: ${PANACHAT_CONTROL_PLANE_WORKDIR:-/repo/apps/aico-control-plane}
@@ -105,8 +107,8 @@ services:
       - ${PANACHAT_REPO_ROOT:-../..}:/repo
     command: ['node', 'dist/standalone.js']
     env_file:
-      - ../../.env
-      - .env
+      - ${PANACHAT_APP_ENV_FILE:-../../.env}
+      - ${PANACHAT_INFRA_ENV_FILE:-.env}
     environment:
       AICO_IS_CONTROL_PLANE: '1'
       AICO_CONTROL_PLANE_PORT: '3020'
@@ -148,9 +150,9 @@ services:
 
   postgresql:
     image: paradedb/paradedb:latest-pg17
-    container_name: panachat-postgres
+    container_name: ${PANACHAT_STACK:-panachat}-postgres
     volumes:
-      - panachat_postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
     environment:
       - 'POSTGRES_DB=${PANACHAT_DB_NAME}'
@@ -166,10 +168,10 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: panachat-redis
+    container_name: ${PANACHAT_STACK:-panachat}-redis
     command: redis-server --save 60 1000 --appendonly yes
     volumes:
-      - panachat_redis_data:/data
+      - redis_data:/data
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 5s
@@ -181,7 +183,7 @@ services:
 
   rustfs:
     image: rustfs/rustfs:latest
-    container_name: panachat-rustfs
+    container_name: ${PANACHAT_STACK:-panachat}-rustfs
     ports:
       - '127.0.0.1:${RUSTFS_PORT:-9000}:9000'
     environment:
@@ -189,7 +191,7 @@ services:
       - RUSTFS_ACCESS_KEY=${RUSTFS_ACCESS_KEY}
       - RUSTFS_SECRET_KEY=${RUSTFS_SECRET_KEY}
     volumes:
-      - panachat_rustfs_data:/data
+      - rustfs_data:/data
     healthcheck:
       test: ['CMD-SHELL', 'wget -qO- http://localhost:9000/health >/dev/null 2>&1 || exit 1']
       interval: 5s
@@ -203,7 +205,7 @@ services:
 
   rustfs-init:
     image: minio/mc:latest
-    container_name: panachat-rustfs-init
+    container_name: ${PANACHAT_STACK:-panachat}-rustfs-init
     depends_on:
       rustfs:
         condition: service_healthy
@@ -217,7 +219,7 @@ services:
 
   searxng:
     image: searxng/searxng
-    container_name: panachat-searxng
+    container_name: ${PANACHAT_STACK:-panachat}-searxng
     volumes:
       - './searxng-settings.yml:/etc/searxng/settings.yml'
     environment:
@@ -226,17 +228,17 @@ services:
     networks:
       - panachat-network
     env_file:
-      - .env
+      - ${PANACHAT_INFRA_ENV_FILE:-.env}
 
 networks:
   panachat-network:
-    name: panachat-network
+    name: ${PANACHAT_STACK:-panachat}-network
     driver: bridge
 
 volumes:
-  panachat_postgres_data:
-    name: panachat_postgres_data
-  panachat_redis_data:
-    name: panachat_redis_data
-  panachat_rustfs_data:
-    name: panachat_rustfs_data
+  postgres_data:
+    name: ${PANACHAT_VOLUME_PREFIX:-panachat}_postgres_data
+  redis_data:
+    name: ${PANACHAT_VOLUME_PREFIX:-panachat}_redis_data
+  rustfs_data:
+    name: ${PANACHAT_VOLUME_PREFIX:-panachat}_rustfs_data

--- a/docker-compose/deploy/nginx/panachat-preview-site.example.conf
+++ b/docker-compose/deploy/nginx/panachat-preview-site.example.conf
@@ -1,0 +1,51 @@
+# Example HTTPS site for Panachat preview (own stack / own DB).
+# Place under /etc/nginx/sites-available/ and enable TLS (certbot).
+#
+# Upstream (auto-loaded from conf.d):
+#   sudo cp docker-compose/deploy/nginx/panachat-preview-upstream.blue.conf \
+#     /etc/nginx/conf.d/panachat-preview-upstream.conf
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name preview.chat.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name preview.chat.example.com;
+
+    # ssl_certificate     /etc/letsencrypt/live/preview.chat.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/preview.chat.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://panachat_preview_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
+    location /_spa/assets/ {
+        proxy_pass http://panachat_preview_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location /_spa-auth/assets/ {
+        proxy_pass http://panachat_preview_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/docker-compose/deploy/nginx/panachat-preview-upstream.blue.conf
+++ b/docker-compose/deploy/nginx/panachat-preview-upstream.blue.conf
@@ -1,0 +1,4 @@
+upstream panachat_preview_backend {
+    server 127.0.0.1:3220;
+    keepalive 32;
+}

--- a/docker-compose/deploy/nginx/panachat-preview-upstream.conf
+++ b/docker-compose/deploy/nginx/panachat-preview-upstream.conf
@@ -1,0 +1,9 @@
+# Active Panachat preview app upstream — rewritten by panachat-deploy-remote.sh
+# when PANACHAT_ENV=preview.
+#
+#   sudo cp panachat-preview-upstream.blue.conf /etc/nginx/conf.d/panachat-preview-upstream.conf
+
+upstream panachat_preview_backend {
+    server 127.0.0.1:3220;
+    keepalive 32;
+}

--- a/docker-compose/deploy/nginx/panachat-preview-upstream.green.conf
+++ b/docker-compose/deploy/nginx/panachat-preview-upstream.green.conf
@@ -1,0 +1,4 @@
+upstream panachat_preview_backend {
+    server 127.0.0.1:3221;
+    keepalive 32;
+}

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -1,27 +1,30 @@
 #!/usr/bin/env bash
-# Panachat blue-green remote deploy (canary CI-CD).
+# Panachat blue-green remote deploy (canary / preview CI-CD).
 #
 # Usage:
-#   ./scripts/panachat-deploy-remote.sh deploy <image-ref>   # e.g. ghcr.io/org/panachat:abc1234
+#   PANACHAT_ENV=canary  ./scripts/panachat-deploy-remote.sh deploy <image-ref>
+#   PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy <image-ref>
 #   ./scripts/panachat-deploy-remote.sh rollback
-#   ./scripts/panachat-deploy-remote.sh bootstrap            # data plane + blue slot
+#   ./scripts/panachat-deploy-remote.sh bootstrap <image-ref>
 #   ./scripts/panachat-deploy-remote.sh status
 #
 # Safety:
 #   - Always runs panachat-backup.sh before deploy (unless PANACHAT_SKIP_BACKUP=1)
-#   - Never runs `docker compose down -v` or removes panachat_* volumes
+#   - Never runs `docker compose down -v` or removes named volumes
 #   - Only starts/stops app slots; data plane stays up
 #   - On failure, traffic stays on the current slot
+#   - preview and canary use separate volumes / state / nginx upstreams
 #
-# Env (optional):
+# Env:
+#   PANACHAT_ENV                  canary (default) | preview
 #   PANACHAT_ROOT                 repo root (default: parent of scripts/)
-#   PANACHAT_STATE_DIR            default /var/lib/panachat
-#   PANACHAT_NGINX_UPSTREAM_FILE  default /etc/nginx/conf.d/panachat-upstream.conf
-#   PANACHAT_PUBLIC_URL           for post-flip verify (e.g. https://chat.example.com)
+#   PANACHAT_STATE_DIR            override state dir
+#   PANACHAT_NGINX_UPSTREAM_FILE  override nginx upstream path
+#   PANACHAT_PUBLIC_URL           for post-flip verify
 #   PANACHAT_HEALTH_TIMEOUT_SEC   default 180
 #   PANACHAT_IMAGE_KEEP           keep last N SHA images (default 5)
 #   PANACHAT_SKIP_BACKUP=1
-#   PANACHAT_SKIP_NGINX=1         skip upstream rewrite (manual proxy)
+#   PANACHAT_SKIP_NGINX=1
 #   COMPOSE_PROFILES              e.g. control-plane
 
 set -euo pipefail
@@ -30,27 +33,72 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ROOT="${PANACHAT_ROOT:-$ROOT}"
 DEPLOY_DIR="$ROOT/docker-compose/deploy"
 COMPOSE_FILE="$DEPLOY_DIR/docker-compose.panachat.yml"
-STATE_DIR="${PANACHAT_STATE_DIR:-/var/lib/panachat}"
-STATE_FILE="$STATE_DIR/deploy.env"
-NGINX_UPSTREAM="${PANACHAT_NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/panachat-upstream.conf}"
 HEALTH_TIMEOUT="${PANACHAT_HEALTH_TIMEOUT_SEC:-180}"
 IMAGE_KEEP="${PANACHAT_IMAGE_KEEP:-5}"
-NETWORK_NAME="panachat-network"
 APP_ALIAS="panachat-app"
 
-PORT_BLUE="${PANACHAT_PORT_BLUE:-3210}"
-PORT_GREEN="${PANACHAT_PORT_GREEN:-3211}"
+# --- Environment mode (canary vs preview) ---------------------------------
+PANACHAT_ENV="${PANACHAT_ENV:-canary}"
+case "$PANACHAT_ENV" in
+  canary|prod|production)
+    PANACHAT_ENV=canary
+    export PANACHAT_STACK="${PANACHAT_STACK:-panachat}"
+    export PANACHAT_VOLUME_PREFIX="${PANACHAT_VOLUME_PREFIX:-panachat}"
+    APP_ENV_FILE="${PANACHAT_APP_ENV_FILE:-$ROOT/.env}"
+    INFRA_ENV_FILE="${PANACHAT_INFRA_ENV_FILE:-$DEPLOY_DIR/.env}"
+    STATE_DIR="${PANACHAT_STATE_DIR:-/var/lib/panachat}"
+    NGINX_UPSTREAM="${PANACHAT_NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/panachat-upstream.conf}"
+    NGINX_TEMPLATE_PREFIX="panachat-upstream"
+    PORT_BLUE="${PANACHAT_PORT_BLUE:-3210}"
+    PORT_GREEN="${PANACHAT_PORT_GREEN:-3211}"
+    DEFAULT_BACKUP_DIR="${HOME}/.local/share/panachat-backups"
+    ;;
+  preview)
+    export PANACHAT_STACK="${PANACHAT_STACK:-panachat-preview}"
+    export PANACHAT_VOLUME_PREFIX="${PANACHAT_VOLUME_PREFIX:-panachat_preview}"
+    APP_ENV_FILE="${PANACHAT_APP_ENV_FILE:-$ROOT/.env.preview}"
+    INFRA_ENV_FILE="${PANACHAT_INFRA_ENV_FILE:-$DEPLOY_DIR/.env.preview}"
+    STATE_DIR="${PANACHAT_STATE_DIR:-/var/lib/panachat-preview}"
+    NGINX_UPSTREAM="${PANACHAT_NGINX_UPSTREAM_FILE:-/etc/nginx/conf.d/panachat-preview-upstream.conf}"
+    NGINX_TEMPLATE_PREFIX="panachat-preview-upstream"
+    PORT_BLUE="${PANACHAT_PORT_BLUE:-3220}"
+    PORT_GREEN="${PANACHAT_PORT_GREEN:-3221}"
+    DEFAULT_BACKUP_DIR="${HOME}/.local/share/panachat-preview-backups"
+    ;;
+  *)
+    echo "Error: PANACHAT_ENV must be canary or preview (got: $PANACHAT_ENV)" >&2
+    exit 1
+    ;;
+esac
+
+export PANACHAT_APP_ENV_FILE="$APP_ENV_FILE"
+export PANACHAT_INFRA_ENV_FILE="$INFRA_ENV_FILE"
+
+STATE_FILE="$STATE_DIR/deploy.env"
+NETWORK_NAME="${PANACHAT_STACK}-network"
 
 usage() {
-  sed -n '2,20p' "$0" | sed 's/^# \?//'
+  sed -n '2,28p' "$0" | sed 's/^# \?//'
   exit "${1:-0}"
 }
 
-log() { printf '==> %s\n' "$*"; }
-err() { printf 'Error: %s\n' "$*" >&2; }
+log() { printf '==> [%s] %s\n' "$PANACHAT_ENV" "$*"; }
+err() { printf 'Error: [%s] %s\n' "$PANACHAT_ENV" "$*" >&2; }
 
 ensure_state_dir() {
   mkdir -p "$STATE_DIR"
+}
+
+load_infra_defaults() {
+  if [[ -f "$INFRA_ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    # shellcheck disable=SC1090
+    source "$INFRA_ENV_FILE"
+    set +a
+  fi
+  PORT_BLUE="${PANACHAT_PORT_BLUE:-$PORT_BLUE}"
+  PORT_GREEN="${PANACHAT_PORT_GREEN:-$PORT_GREEN}"
 }
 
 load_state() {
@@ -72,15 +120,24 @@ CURRENT_SLOT=$1
 DEPLOYED_SHA=$2
 PREVIOUS_SLOT=${3:-}
 PREVIOUS_SHA=${4:-}
+PANACHAT_ENV=$PANACHAT_ENV
 UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 }
 
 slot_service() {
   case "$1" in
+    blue) echo "${PANACHAT_STACK}-blue" ;;
+    green) echo "${PANACHAT_STACK}-green" ;;
+    *) err "unknown slot: $1"; return 1 ;;
+  esac
+}
+
+slot_compose_service() {
+  case "$1" in
     blue) echo panachat-blue ;;
     green) echo panachat-green ;;
-    *) err "unknown slot: $1"; return 1 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -111,10 +168,10 @@ other_slot() {
 compose() {
   (
     cd "$DEPLOY_DIR"
-    # shellcheck disable=SC2086
     docker compose \
-      --env-file ../../.env \
-      --env-file .env \
+      -p "$PANACHAT_STACK" \
+      --env-file "$APP_ENV_FILE" \
+      --env-file "$INFRA_ENV_FILE" \
       -f docker-compose.panachat.yml \
       "$@"
   )
@@ -126,8 +183,9 @@ compose_with_profile() {
   (
     cd "$DEPLOY_DIR"
     docker compose \
-      --env-file ../../.env \
-      --env-file .env \
+      -p "$PANACHAT_STACK" \
+      --env-file "$APP_ENV_FILE" \
+      --env-file "$INFRA_ENV_FILE" \
       -f docker-compose.panachat.yml \
       --profile "$profile" \
       "$@"
@@ -137,8 +195,8 @@ compose_with_profile() {
 set_image_env() {
   local image="$1"
   export PANACHAT_IMAGE="$image"
-  # Persist for subsequent compose calls on this host
-  local envf="$DEPLOY_DIR/.env"
+  local envf="$INFRA_ENV_FILE"
+  mkdir -p "$(dirname "$envf")"
   if [[ -f "$envf" ]]; then
     if grep -qE '^PANACHAT_IMAGE=' "$envf"; then
       sed -i.bak "s|^PANACHAT_IMAGE=.*|PANACHAT_IMAGE=${image}|" "$envf"
@@ -149,6 +207,21 @@ set_image_env() {
   else
     printf 'PANACHAT_IMAGE=%s\n' "$image" >"$envf"
   fi
+  # Ensure stack identity is persisted for manual compose use
+  for kv in \
+    "PANACHAT_STACK=${PANACHAT_STACK}" \
+    "PANACHAT_VOLUME_PREFIX=${PANACHAT_VOLUME_PREFIX}" \
+    "PANACHAT_APP_ENV_FILE=${APP_ENV_FILE}" \
+    "PANACHAT_INFRA_ENV_FILE=${INFRA_ENV_FILE}"; do
+    local key="${kv%%=*}"
+    local val="${kv#*=}"
+    if grep -qE "^${key}=" "$envf" 2>/dev/null; then
+      sed -i.bak "s|^${key}=.*|${key}=${val}|" "$envf"
+      rm -f "${envf}.bak"
+    else
+      printf '%s=%s\n' "$key" "$val" >>"$envf"
+    fi
+  done
 }
 
 run_backup() {
@@ -156,9 +229,12 @@ run_backup() {
     log "Skipping backup (PANACHAT_SKIP_BACKUP=1)"
     return 0
   fi
-  log "Pre-deploy backup"
-  export POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-panachat-postgres}"
+  log "Pre-deploy backup (dir=${PANACHAT_BACKUP_DIR:-$DEFAULT_BACKUP_DIR})"
+  export POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-${PANACHAT_STACK}-postgres}"
+  export POSTGRES_VOLUME_NAME="${POSTGRES_VOLUME_NAME:-${PANACHAT_VOLUME_PREFIX}_postgres_data}"
+  export RUSTFS_VOLUME_NAME="${RUSTFS_VOLUME_NAME:-${PANACHAT_VOLUME_PREFIX}_rustfs_data}"
   export LOBE_DB_NAME="${LOBE_DB_NAME:-${PANACHAT_DB_NAME:-lobechat}}"
+  export PANACHAT_BACKUP_DIR="${PANACHAT_BACKUP_DIR:-$DEFAULT_BACKUP_DIR}"
   "$ROOT/scripts/panachat-backup.sh" --reason pre-deploy
 }
 
@@ -176,7 +252,6 @@ wait_healthy() {
       sleep 2
       continue
     fi
-    # Migration / ready signals in logs
     if docker logs "$service" 2>&1 | tail -n 200 | grep -qE 'database migration pass|Ready in |started server'; then
       local code
       code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${port}/signin" || echo 000)
@@ -211,14 +286,12 @@ verify_slot_spa() {
 
 set_network_alias() {
   local service="$1"
-  # Reconnect with alias so control-plane INTERNAL_APP_URL=http://panachat-app:3210 works
   docker network disconnect "$NETWORK_NAME" "$service" 2>/dev/null || true
   docker network connect --alias "$APP_ALIAS" "$NETWORK_NAME" "$service"
 }
 
 clear_network_alias() {
   local service="$1"
-  # Disconnect/reconnect without alias (best-effort)
   if docker inspect "$service" >/dev/null 2>&1; then
     docker network disconnect "$NETWORK_NAME" "$service" 2>/dev/null || true
     docker network connect "$NETWORK_NAME" "$service" 2>/dev/null || true
@@ -231,7 +304,7 @@ flip_nginx() {
     log "Skipping nginx flip (PANACHAT_SKIP_NGINX=1)"
     return 0
   fi
-  local src="$DEPLOY_DIR/nginx/panachat-upstream.${slot}.conf"
+  local src="$DEPLOY_DIR/nginx/${NGINX_TEMPLATE_PREFIX}.${slot}.conf"
   if [[ ! -f "$src" ]]; then
     err "Missing nginx template: $src"
     return 1
@@ -279,15 +352,33 @@ image_sha_tag() {
   fi
 }
 
+require_env_files() {
+  if [[ ! -f "$APP_ENV_FILE" ]]; then
+    err "Missing app env file: $APP_ENV_FILE (copy from .env.example.panachat or .env.example.preview)"
+    exit 1
+  fi
+  if [[ ! -f "$INFRA_ENV_FILE" ]]; then
+    err "Missing infra env file: $INFRA_ENV_FILE"
+    exit 1
+  fi
+}
+
 cmd_status() {
+  load_infra_defaults
   load_state
+  echo "PANACHAT_ENV=$PANACHAT_ENV"
+  echo "PANACHAT_STACK=$PANACHAT_STACK"
+  echo "PANACHAT_VOLUME_PREFIX=$PANACHAT_VOLUME_PREFIX"
+  echo "APP_ENV_FILE=$APP_ENV_FILE"
+  echo "INFRA_ENV_FILE=$INFRA_ENV_FILE"
   echo "State file: $STATE_FILE"
   echo "CURRENT_SLOT=${CURRENT_SLOT:-}"
   echo "DEPLOYED_SHA=${DEPLOYED_SHA:-}"
   echo "PREVIOUS_SLOT=${PREVIOUS_SLOT:-}"
   echo "PREVIOUS_SHA=${PREVIOUS_SHA:-}"
   echo "PANACHAT_IMAGE=${PANACHAT_IMAGE:-}"
-  docker ps --filter 'name=panachat-' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
+  echo "PORTS blue=$PORT_BLUE green=$PORT_GREEN"
+  docker ps --filter "name=${PANACHAT_STACK}-" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
 }
 
 cmd_bootstrap() {
@@ -296,20 +387,22 @@ cmd_bootstrap() {
     image="${PANACHAT_IMAGE:-}"
   fi
   if [[ -z "$image" ]]; then
-    err "bootstrap requires image: $0 bootstrap ghcr.io/<owner>/panachat:<sha>"
+    err "bootstrap requires image: PANACHAT_ENV=$PANACHAT_ENV $0 bootstrap ghcr.io/<owner>/panachat:<sha>"
     exit 1
   fi
+  require_env_files
+  load_infra_defaults
   ensure_state_dir
   set_image_env "$image"
-  log "Starting data plane + panachat-blue"
+  log "Starting data plane + ${PANACHAT_STACK}-blue"
   compose up -d postgresql redis rustfs rustfs-init searxng
   compose_with_profile slot-blue up -d --no-deps panachat-blue
-  set_network_alias panachat-blue
+  set_network_alias "$(slot_service blue)"
   wait_healthy blue
   verify_slot_spa "$PORT_BLUE"
   flip_nginx blue || true
   write_state blue "$(image_sha_tag "$image")" "" ""
-  log "Bootstrap complete — active slot=blue"
+  log "Bootstrap complete — active slot=blue stack=$PANACHAT_STACK"
 }
 
 cmd_deploy() {
@@ -319,6 +412,8 @@ cmd_deploy() {
     usage 1
   fi
 
+  require_env_files
+  load_infra_defaults
   load_state
   local active="$CURRENT_SLOT"
   local inactive
@@ -326,11 +421,12 @@ cmd_deploy() {
   local active_svc inactive_svc
   active_svc="$(slot_service "$active")"
   inactive_svc="$(slot_service "$inactive")"
-  local inactive_profile
+  local inactive_profile inactive_compose
   inactive_profile="$(slot_profile "$inactive")"
+  inactive_compose="$(slot_compose_service "$inactive")"
   local prev_sha="${DEPLOYED_SHA:-}"
 
-  log "Active=$active → deploying $image onto $inactive"
+  log "Active=$active → deploying $image onto $inactive (stack=$PANACHAT_STACK)"
 
   run_backup
   set_image_env "$image"
@@ -339,17 +435,17 @@ cmd_deploy() {
   docker pull "$image"
 
   log "Starting inactive slot $inactive_svc"
-  compose_with_profile "$inactive_profile" up -d --no-deps --force-recreate "$inactive_svc"
+  compose_with_profile "$inactive_profile" up -d --no-deps --force-recreate "$inactive_compose"
 
   if ! wait_healthy "$inactive"; then
     err "New slot unhealthy — leaving traffic on $active; stopping $inactive_svc"
-    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    compose_with_profile "$inactive_profile" stop "$inactive_compose" || true
     exit 1
   fi
 
   if ! verify_slot_spa "$(slot_port "$inactive")"; then
     err "SPA verify failed — leaving traffic on $active; stopping $inactive_svc"
-    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    compose_with_profile "$inactive_profile" stop "$inactive_compose" || true
     exit 1
   fi
 
@@ -358,14 +454,15 @@ cmd_deploy() {
     err "Nginx flip failed — leaving traffic on $active; clearing new alias"
     clear_network_alias "$inactive_svc" || true
     set_network_alias "$active_svc" || true
-    compose_with_profile "$inactive_profile" stop "$inactive_svc" || true
+    compose_with_profile "$inactive_profile" stop "$inactive_compose" || true
     exit 1
   fi
 
   log "Stopping old slot $active_svc"
-  local active_profile
+  local active_profile active_compose
   active_profile="$(slot_profile "$active")"
-  compose_with_profile "$active_profile" stop "$active_svc" || true
+  active_compose="$(slot_compose_service "$active")"
+  compose_with_profile "$active_profile" stop "$active_compose" || true
   clear_network_alias "$active_svc" || true
 
   write_state "$inactive" "$(image_sha_tag "$image")" "$active" "$prev_sha"
@@ -383,6 +480,8 @@ cmd_deploy() {
 }
 
 cmd_rollback() {
+  require_env_files
+  load_infra_defaults
   load_state
   if [[ -z "${PREVIOUS_SHA:-}" ]]; then
     err "No PREVIOUS_SHA in $STATE_FILE — cannot rollback"
@@ -390,9 +489,9 @@ cmd_rollback() {
   fi
 
   local image_repo
-  image_repo="$(grep -E '^PANACHAT_IMAGE=' "$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2- | sed 's/:.*//' || true)"
+  image_repo="$(grep -E '^PANACHAT_IMAGE=' "$INFRA_ENV_FILE" 2>/dev/null | cut -d= -f2- | sed 's/:.*//' || true)"
   if [[ -z "$image_repo" ]]; then
-    err "Cannot resolve image repository from deploy .env"
+    err "Cannot resolve image repository from $INFRA_ENV_FILE"
     exit 1
   fi
   local image="${image_repo}:${PREVIOUS_SHA}"


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #258

Plane: [AICO-156](https://plane.panafor.com/panaforai/browse/AICO-156)

#### Description of Change

Adds a long-lived `preview` branch CI/CD path on the same VPS as production, with a fully isolated data plane (`panachat_preview_*` volumes). Promote to prod via PR `preview` → `canary`.

- `PANACHAT_ENV=preview|canary` in `panachat-deploy-remote.sh`
- Parameterized compose stack names / volumes
- `deploy-preview.yml` → GHCR `:preview` + SSH deploy
- Preview nginx + env examples + `preview-cicd.md`

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `docker compose … config` validated for both `panachat` and `panachat-preview` stacks
- `bash -n` on deploy script

#### Checklist

- [x] Preview never shares prod volumes
- [x] Docs cover bootstrap + promote path


Made with [Cursor](https://cursor.com)