### PR TITLE
📝 docs(deploy): add kamyar VPS bootstrap runbook

### DIFF
--- a/.agents/skills/self-host-deploy/SKILL.md
+++ b/.agents/skills/self-host-deploy/SKILL.md
@@ -100,6 +100,10 @@ For a Linux server that must always match GitHub `canary` with no data loss and 
 
 → **[canary-cicd.md](canary-cicd.md)** (`deploy-canary.yml` + `panachat-deploy-remote.sh` + `docker-compose.panachat.yml`)
 
+First-time VPS (Ubuntu packages, env, DNS/TLS, first GHCR image, bootstrap) for `chat.panafor.com` / `preview.panafor.com`:
+
+→ **[SERVER-BOOTSTRAP.md](../../../docker-compose/deploy/SERVER-BOOTSTRAP.md)**
+
 Image: private `ghcr.io/<owner>/panachat:<sha>`. Volumes: `panachat_*` only.
 
 ### Path D: Preview branch (staging on same VPS)

--- a/.agents/skills/self-host-deploy/canary-cicd.md
+++ b/.agents/skills/self-host-deploy/canary-cicd.md
@@ -18,6 +18,12 @@ Keep a single Linux VPS in sync with GitHub `canary`: build in Actions → priva
 
 ## One-time server bootstrap
 
+For the **kamyar VPS** (`https://chat.panafor.com` + `https://preview.panafor.com`), use the numbered Ubuntu 24.04 operator runbook (packages, env, DNS/TLS, first GHCR image, bootstrap):
+
+→ **[SERVER-BOOTSTRAP.md](../../../docker-compose/deploy/SERVER-BOOTSTRAP.md)**
+
+The steps below are the generic checklist (any host).
+
 ### 1. Prerequisites
 
 - Docker + Compose v2

--- a/docker-compose/deploy/SERVER-BOOTSTRAP.md
+++ b/docker-compose/deploy/SERVER-BOOTSTRAP.md
@@ -1,0 +1,277 @@
+# Panachat server bootstrap (kamyar VPS)
+
+Numbered operator runbook for Ubuntu 24.04. Assumes GitHub **repository** secrets are already set (`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, `DEPLOY_PATH`, `GHCR_READ_TOKEN`) and the repo is cloned.
+
+| Setting    | Value                                        |
+| ---------- | -------------------------------------------- |
+| Host       | `5.135.244.12`                               |
+| SSH user   | `panachat`                                   |
+| Repo path  | `/home/panachat/panachat`                    |
+| Production | `https://chat.panafor.com`                   |
+| Preview    | `https://preview.panafor.com` (own database) |
+| Image      | `ghcr.io/panafor-ai-team/panachat`           |
+
+**Hard bans:** never `docker compose down -v`; never `docker volume rm panachat_*` or `panachat_preview_*`; never point preview env at prod volumes.
+
+Do not commit `.env` / `.env.preview` / `docker-compose/deploy/.env*`.
+
+---
+
+## 0. Already done (skip if true)
+
+- [x] Repo secrets in GitHub Actions
+- [x] `git clone https://github.com/Panafor-Ai-Team/Aico.git /home/panachat/panachat`
+- [x] SSH key in `~/.ssh/authorized_keys` so Actions can log in without a password (`github-actions-panachat`)
+
+---
+
+## 1. Server packages
+
+SSH as `panachat`. Install Docker Engine + Compose plugin, nginx, certbot, ufw.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg nginx certbot python3-certbot-nginx ufw
+
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+sudo usermod -aG docker panachat
+sudo systemctl enable --now docker nginx
+
+sudo ufw allow OpenSSH
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw --force enable
+```
+
+Log out and back in so the `docker` group applies. Check:
+
+```bash
+docker version
+docker compose version
+nginx -v
+```
+
+---
+
+## 2. Repo on canary
+
+```bash
+cd /home/panachat/panachat
+git checkout canary
+git pull
+```
+
+---
+
+## 3. Production env
+
+```bash
+cd /home/panachat/panachat
+cp .env.example.panachat .env
+cp docker-compose/deploy/.env.example.panachat docker-compose/deploy/.env
+chmod 600 .env docker-compose/deploy/.env
+```
+
+Edit **both** files. Required:
+
+- `APP_URL=https://chat.panafor.com`
+- `AUTH_TRUSTED_ORIGINS=https://chat.panafor.com`
+- `INTERNAL_APP_URL=http://localhost:3210`
+- Rotate `AUTH_SECRET`, `KEY_VAULTS_SECRET`, `POSTGRES_PASSWORD`, `RUSTFS_SECRET_KEY`, `JWKS_KEY` (do not keep example values)
+- Browser-reachable `S3_ENDPOINT` (not `http://rustfs:9000`). Example: proxy RustFS as `https://s3.chat.panafor.com` → `127.0.0.1:9000`
+
+Infra file (`docker-compose/deploy/.env`) should keep:
+
+- `PANACHAT_STACK=panachat`
+- `PANACHAT_VOLUME_PREFIX=panachat`
+- `PANACHAT_PORT_BLUE=3210` / `PANACHAT_PORT_GREEN=3211`
+- `POSTGRES_CONTAINER=panachat-postgres`
+
+---
+
+## 4. Preview env (same VPS, own DB)
+
+```bash
+cd /home/panachat/panachat
+cp .env.example.preview .env.preview
+cp docker-compose/deploy/.env.example.preview docker-compose/deploy/.env.preview
+chmod 600 .env.preview docker-compose/deploy/.env.preview
+```
+
+Use **different** secrets from prod. Set:
+
+- `APP_URL=https://preview.panafor.com`
+- `AUTH_TRUSTED_ORIGINS=https://preview.panafor.com`
+- Ports `3220` / `3221`, `RUSTFS_PORT=9010`
+- `PANACHAT_STACK=panachat-preview`
+- `PANACHAT_VOLUME_PREFIX=panachat_preview`
+
+---
+
+## 5. DNS
+
+A records (or AAAA) pointing at `5.135.244.12`:
+
+- `chat.panafor.com`
+- `preview.panafor.com`
+- S3 host if you use a separate name (e.g. `s3.chat.panafor.com`)
+
+Wait until `dig +short chat.panafor.com` returns the VPS IP.
+
+---
+
+## 6. Nginx (HTTP first, then TLS)
+
+The deploy script copies an upstream file **as `panachat` (no sudo)** then runs `nginx -t` / `nginx -s reload`. Prepare ownership and a PATH wrapper so that works from Actions SSH.
+
+```bash
+cd /home/panachat/panachat
+sudo cp docker-compose/deploy/nginx/panachat-upstream.blue.conf \
+  /etc/nginx/conf.d/panachat-upstream.conf
+sudo cp docker-compose/deploy/nginx/panachat-preview-upstream.blue.conf \
+  /etc/nginx/conf.d/panachat-preview-upstream.conf
+sudo chown panachat:panachat \
+  /etc/nginx/conf.d/panachat-upstream.conf \
+  /etc/nginx/conf.d/panachat-preview-upstream.conf
+
+sudo tee /etc/sudoers.d/panachat-nginx > /dev/null << 'EOF'
+panachat ALL=(root) NOPASSWD: /usr/sbin/nginx
+EOF
+sudo chmod 440 /etc/sudoers.d/panachat-nginx
+
+# First on default PATH so `command -v nginx` is not /usr/sbin/nginx
+sudo tee /usr/local/bin/nginx > /dev/null << 'EOF'
+#!/bin/sh
+exec sudo /usr/sbin/nginx "$@"
+EOF
+sudo chmod 755 /usr/local/bin/nginx
+```
+
+Copy the example sites and set hostnames:
+
+```bash
+sudo cp docker-compose/deploy/nginx/panachat-site.example.conf \
+  /etc/nginx/sites-available/panachat
+sudo cp docker-compose/deploy/nginx/panachat-preview-site.example.conf \
+  /etc/nginx/sites-available/panachat-preview
+sudo sed -i 's/chat.example.com/chat.panafor.com/g' /etc/nginx/sites-available/panachat
+sudo sed -i 's/preview.chat.example.com/preview.panafor.com/g' \
+  /etc/nginx/sites-available/panachat-preview
+```
+
+The examples 301 HTTP → HTTPS. Until Certbot has issued certs, comment out each `listen 443` server block and change the port-80 `return 301` to a `location /` that `proxy_pass`es `http://panachat_backend` (prod) or `http://panachat_preview_backend` (preview), matching the example `location /` headers.
+
+```bash
+sudo ln -sf /etc/nginx/sites-available/panachat /etc/nginx/sites-enabled/panachat
+sudo ln -sf /etc/nginx/sites-available/panachat-preview /etc/nginx/sites-enabled/panachat-preview
+sudo rm -f /etc/nginx/sites-enabled/default
+sudo /usr/sbin/nginx -t && sudo systemctl reload nginx
+```
+
+TLS (prod first is fine; preview can wait until step 10 if that DNS is not ready):
+
+```bash
+sudo certbot --nginx -d chat.panafor.com
+sudo certbot --nginx -d preview.panafor.com
+sudo /usr/sbin/nginx -t && sudo systemctl reload nginx
+```
+
+If you use a separate S3 hostname, add a server that `proxy_pass`es to `127.0.0.1:9000` (prod) and `127.0.0.1:9010` (preview).
+
+`PANACHAT_SKIP_NGINX=1` is for debugging only — production needs the blue/green flip.
+
+---
+
+## 7. First GHCR image
+
+On GitHub: **Actions** → **Deploy Panachat Canary** → **Run workflow** (branch `canary`).
+
+Wait until the **build** job pushes `ghcr.io/panafor-ai-team/panachat:canary`. Open org **Packages** and set the `panachat` package to **Private** if it is public.
+
+You can skip the deploy job on first run (`skip_deploy`) until bootstrap env is ready; you still need a successful **push**.
+
+---
+
+## 8. GHCR login on the server
+
+Classic PAT with `read:packages` (same value as `GHCR_READ_TOKEN`). Username = your GitHub username.
+
+```bash
+echo 'PASTE_TOKEN_ONCE' | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+docker pull ghcr.io/panafor-ai-team/panachat:canary
+```
+
+Do not paste the token into git or chat. After login, Docker stores credentials for the `panachat` user so later Actions SSH deploys can pull (Actions also logs in with `GHCR_READ_TOKEN` during the job).
+
+---
+
+## 9. Bootstrap production
+
+State and fingerprint dirs must be writable by `panachat` (compose env uses `/var/lib/panachat/data`):
+
+```bash
+sudo mkdir -p /var/lib/panachat/data /var/lib/panachat/backups \
+  /var/lib/panachat-preview/data /var/lib/panachat-preview/backups
+sudo chown -R panachat:panachat /var/lib/panachat /var/lib/panachat-preview
+```
+
+```bash
+cd /home/panachat/panachat
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh bootstrap \
+  ghcr.io/panafor-ai-team/panachat:canary
+```
+
+Then:
+
+```bash
+./scripts/panachat-backup.sh --install-cron
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status
+```
+
+Open `https://chat.panafor.com`. Sign up the first user; grant platform admin if needed (see self-host-deploy skill).
+
+---
+
+## 10. Preview (after prod is healthy)
+
+On your laptop (not required on the VPS):
+
+```bash
+git fetch origin
+git checkout canary && git pull
+git checkout -b preview # only if origin/preview does not exist
+git push -u origin preview
+```
+
+On the VPS, after a preview image exists (`:preview`):
+
+```bash
+cd /home/panachat/panachat
+PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh bootstrap \
+  ghcr.io/panafor-ai-team/panachat:preview
+```
+
+Smoke-test `https://preview.panafor.com`. Promote with a PR `preview` → `canary`.
+
+---
+
+## 11. Verify
+
+- `https://chat.panafor.com` loads; `/_spa/` assets return 200
+- Settings → About shows version / `canary` / Git SHA after the versioned image is deployed
+- From your laptop, key-based SSH: `ssh -i <deploy-key> panachat@5.135.244.12` (no password)
+
+Day-2:
+
+```bash
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status
+PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh rollback
+```
+
+Architecture notes: [canary-cicd.md](../../.cursor/skills/self-host-deploy/canary-cicd.md), [preview-cicd.md](../../.cursor/skills/self-host-deploy/preview-cicd.md).


### PR DESCRIPTION
<!-- Brief and heads-up -->

Numbered operator runbook for first Panachat deploy on the kamyar VPS (`chat.panafor.com` + `preview.panafor.com`).

| Before | After |
| ------ | ----- |
| Bootstrap steps lived only in chat / canary-cicd fragments | `docker-compose/deploy/SERVER-BOOTSTRAP.md` on the server clone |

#### Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 🔗 Related Issue

Fixes #262

Plane: [AICO-158](https://plane.panafor.com/panaforai/browse/AICO-158)

#### Description of Change

Adds Ubuntu 24.04 steps: packages, env, DNS/TLS, first GHCR image, bootstrap, then preview. Links from canary CI/CD docs and self-host-deploy Path C. No secrets in the file.

#### How to Test

Read `docker-compose/deploy/SERVER-BOOTSTRAP.md` on the VPS after merge + `git pull` on `canary`.

Made with [Cursor](https://cursor.com)