### PR TITLE
🐛 fix(deploy): sudo fallback for nginx flip on unbootstrapped VPS

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -139,6 +139,8 @@ jobs:
             set -euo pipefail
             DEPLOY_PATH="${DEPLOY_PATH:-$HOME/panachat}"
             cd "$DEPLOY_PATH"
+            git fetch origin canary
+            git merge --ff-only FETCH_HEAD || echo "WARN: could not fast-forward (local changes?); deploying with existing scripts"
             if [ -n "${GHCR_TOKEN:-}" ]; then
               echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
             fi

--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Auto Comment on Issues Closed
         uses: wow-actions/auto-comment@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           issuesClosed: |
             ✅ @{{ author }}
 
@@ -43,7 +43,7 @@ jobs:
       - name: Auto Comment on Pull Request Merged
         if: github.event.pull_request.merged == true && steps.maintainer-check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<'EOF'
           ❤️ Great PR @${{ github.event.pull_request.user.login }} ❤️

--- a/docker-compose/deploy/SERVER-BOOTSTRAP.md
+++ b/docker-compose/deploy/SERVER-BOOTSTRAP.md
@@ -147,6 +147,8 @@ sudo chown panachat:panachat \
 
 sudo tee /etc/sudoers.d/panachat-nginx > /dev/null << 'EOF'
 panachat ALL=(root) NOPASSWD: /usr/sbin/nginx
+panachat ALL=(root) NOPASSWD: /bin/cp, /usr/bin/cp
+panachat ALL=(root) NOPASSWD: /bin/chown
 EOF
 sudo chmod 440 /etc/sudoers.d/panachat-nginx
 

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -298,6 +298,42 @@ clear_network_alias() {
   fi
 }
 
+run_nginx() {
+  # Prefer the bootstrap wrapper (/usr/local/bin/nginx → sudo /usr/sbin/nginx).
+  if [[ -x /usr/local/bin/nginx ]]; then
+    /usr/local/bin/nginx "$@"
+    return $?
+  fi
+  if sudo -n /usr/sbin/nginx "$@" 2>/dev/null; then
+    return 0
+  fi
+  if command -v nginx >/dev/null 2>&1; then
+    nginx "$@"
+    return $?
+  fi
+  if [[ -x /usr/sbin/nginx ]]; then
+    /usr/sbin/nginx "$@"
+    return $?
+  fi
+  err "nginx binary not found"
+  return 1
+}
+
+write_nginx_upstream() {
+  local src="$1"
+  local dest="$2"
+  if cp "$src" "$dest" 2>/dev/null; then
+    return 0
+  fi
+  if sudo -n cp "$src" "$dest" 2>/dev/null; then
+    sudo -n chown "$(id -un):$(id -gn)" "$dest" 2>/dev/null || true
+    return 0
+  fi
+  err "Cannot write $dest (permission denied)"
+  err "Run docker-compose/deploy/SERVER-BOOTSTRAP.md section 6 on the VPS (chown upstream + nginx sudo wrapper)"
+  return 1
+}
+
 flip_nginx() {
   local slot="$1"
   if [[ "${PANACHAT_SKIP_NGINX:-0}" == "1" ]]; then
@@ -314,15 +350,15 @@ flip_nginx() {
     return 1
   fi
   log "Flipping nginx upstream → $slot ($src → $NGINX_UPSTREAM)"
-  cp "$src" "$NGINX_UPSTREAM"
-  if command -v nginx >/dev/null 2>&1; then
-    nginx -t
-    nginx -s reload
-  elif [[ -x /usr/sbin/nginx ]]; then
-    /usr/sbin/nginx -t
-    /usr/sbin/nginx -s reload
-  else
-    err "nginx binary not found; upstream file updated but not reloaded"
+  if ! write_nginx_upstream "$src" "$NGINX_UPSTREAM"; then
+    return 1
+  fi
+  if ! run_nginx -t; then
+    err "nginx -t failed — upstream not switched"
+    return 1
+  fi
+  if ! run_nginx -s reload; then
+    err "nginx reload failed — upstream file updated but traffic may be stale"
     return 1
   fi
 }


### PR DESCRIPTION
## Summary
- Deploy Canary failed after #268 merge: the new image was healthy on green, but nginx upstream copy/reload failed with permission denied (VPS missing SERVER-BOOTSTRAP section 6).
- Add sudo fallbacks for upstream copy and nginx reload in `panachat-deploy-remote.sh`.
- Expand bootstrap sudoers for passwordless `cp`/`chown` fallback.
- Fix `issue-auto-comments.yml` to use `github.token` instead of missing `GH_TOKEN` secret.

## Test plan
- [ ] On VPS: run SERVER-BOOTSTRAP.md section 6 (chown upstream files + nginx wrapper + sudoers)
- [ ] Merge this PR, re-run **Deploy Panachat Canary** workflow (or `PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy ghcr.io/panafor-ai-team/panachat:canary` on the server)
- [ ] Confirm `panachat-green` stays up and traffic flips successfully

Made with [Cursor](https://cursor.com)