### PR TITLE
🔧 chore(ci): disable unused Test, E2E, and issue helper workflows

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -3,11 +3,10 @@ name: Auto Tag Release
 permissions:
   contents: write
 
+# Aico: not used (upstream LobeHub main-branch release tagging).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  pull_request_target:
-    types: [closed]
-    branches:
-      - main
+  workflow_dispatch: {}
 
 jobs:
   auto-tag:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,9 @@
 name: E2E CI
 
-on: [push, pull_request]
+# Aico: not used (upstream LobeHub CI; Panachat ships via deploy-canary/preview).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
+on:
+  workflow_dispatch: {}
 
 permissions:
   actions: write

--- a/.github/workflows/issue-auto-close-duplicates.yml
+++ b/.github/workflows/issue-auto-close-duplicates.yml
@@ -1,8 +1,9 @@
 name: Auto-close duplicate issues
 # Auto-closes issues that are duplicates of existing issues
+
+# Aico: not used (upstream LobeHub issue hygiene).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  schedule:
-    - cron: '0 2 * * *'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -1,14 +1,9 @@
 name: Issue Auto Comment
+
+# Aico: not used (upstream LobeHub Discord/comment bots).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  issues:
-    types:
-      - opened
-      - closed
-      - assigned
-  pull_request_target:
-    types:
-      - opened
-      - closed
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,9 +1,9 @@
 name: 'Lock Stale Issues'
 
+# Aico: not used (upstream LobeHub issue hygiene).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  schedule:
-    - cron: '0 1 * * *'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,10 @@ permissions:
   issues: write
   pull-requests: write
 
+# Aico: not used (upstream LobeHub semver tag releases).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sync-database-schema.yml
+++ b/.github/workflows/sync-database-schema.yml
@@ -2,12 +2,10 @@ name: Database Schema Visualization CI
 permissions:
   contents: read
 
+# Aico: not used (upstream docs schema viz on main).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/development/database-schema.dbml'
+  workflow_dispatch: {}
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test CI
 
-on: [push, pull_request]
+# Aico: not used (upstream LobeHub CI; Panachat ships via deploy-canary/preview).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
+on:
+  workflow_dispatch: {}
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary
Disable more upstream LobeHub workflows Aico does not use (manual `workflow_dispatch` only; YAML kept for upstream sync):

- **Test CI** / **E2E CI** — failing upstream suites; Panachat ships via deploy workflows
- **Issue Auto Comment** — LobeHub Discord spam on merge
- **Auto-close duplicates** / **Lock stale issues** — upstream issue hygiene
- **Auto Tag Release** / **Release CI** / **Database Schema Viz** — LobeHub main/tag release paths

## Still automatic
- **Deploy Panachat Canary** (`canary` push)
- **Deploy Panachat Preview** (`preview` push)
- **auto-i18n** (daily, non-visible locales)

Already manual-only from #268: Claude/MCP bots, desktop, official Docker, lighthouse, docs revalidate, model-bank, upstream sync.

## Test plan
- [ ] Merge → only deploy + auto-i18n run on push (no Test/E2E/issue comments)

Made with [Cursor](https://cursor.com)