### PR TITLE
👷 ci(deploy): build and restart the control-plane on canary/preview

### DIFF
--- a/.agents/skills/self-host-deploy/canary-cicd.md
+++ b/.agents/skills/self-host-deploy/canary-cicd.md
@@ -7,6 +7,7 @@ Keep a single Linux VPS in sync with GitHub `canary`: build in Actions → priva
 | Piece          | Name                                                                                                              |
 | -------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Image          | `ghcr.io/<owner>/panachat:<sha>` and `:canary`                                                                    |
+| Control-plane  | `ghcr.io/<owner>/panachat-control-plane:<sha>` and `:canary`                                                      |
 | Compose        | [`docker-compose/deploy/docker-compose.panachat.yml`](../../../docker-compose/deploy/docker-compose.panachat.yml) |
 | Deploy         | [`scripts/panachat-deploy-remote.sh`](../../../scripts/panachat-deploy-remote.sh)                                 |
 | Workflow       | [`.github/workflows/deploy-canary.yml`](../../../.github/workflows/deploy-canary.yml)                             |
@@ -40,11 +41,11 @@ chmod 600 .env docker-compose/deploy/.env
 # Rotate AUTH_SECRET, KEY_VAULTS_SECRET, POSTGRES_PASSWORD, RUSTFS_SECRET_KEY, JWKS_KEY
 ```
 
-Set `APP_URL`, `AUTH_TRUSTED_ORIGINS`, browser-reachable `S3_ENDPOINT`, and `PANACHAT_IMAGE` (filled by deploy script after first pull).
+Set `APP_URL`, `AUTH_TRUSTED_ORIGINS` (include the admin origin), browser-reachable `S3_ENDPOINT`, `AICO_CONTROL_PLANE_PUBLIC_URL`, and `PANACHAT_IMAGE` / `PANACHAT_CONTROL_PLANE_IMAGE` (filled by deploy after first pull).
 
 ### 3. Private GHCR login
 
-The repo may be public; the **`panachat` package must stay private**.
+The repo may be public; the **`panachat` and `panachat-control-plane` packages must stay private**.
 
 ```bash
 # PAT with read:packages (classic) or fine-grained Packages read
@@ -70,14 +71,11 @@ export PANACHAT_IMAGE=ghcr.io/ < owner > /panachat:canary # or a SHA tag
 ./scripts/panachat-backup.sh --install-cron
 ```
 
-Optional control plane (requires built `apps/aico-control-plane` on the checkout):
+Optional control plane is now **part of CI**. Do not bind-mount the git checkout over `/app`. The image is `apps/aico-control-plane/Dockerfile` (SPA + `standalone.js`). First start still works via bootstrap; later pushes recreate `panachat-control-plane` only.
 
 ```bash
-export COMPOSE_PROFILES=control-plane
-# set AICO_CONTROL_PLANE_SERVICE_TOKEN in .env
-docker compose -f docker-compose/deploy/docker-compose.panachat.yml \
-  --env-file .env --env-file docker-compose/deploy/.env \
-  --profile control-plane up -d panachat-control-plane
+# Image pin is written to docker-compose/deploy/.env by the deploy script
+# AICO_CONTROL_PLANE_SERVICE_TOKEN and AICO_CONTROL_PLANE_PUBLIC_URL live in repo-root .env
 ```
 
 ### 6. GitHub Actions secrets
@@ -90,11 +88,16 @@ docker compose -f docker-compose/deploy/docker-compose.panachat.yml \
 | `DEPLOY_PATH`     | Optional repo root on server (default `~/panachat`)   |
 | `GHCR_READ_TOKEN` | PAT with `read:packages` for the server `docker pull` |
 
-Every push to `canary` builds, pushes GHCR, then runs:
+Every push to `canary` builds **both** images, `git fetch` + fast-forward on the VPS, then:
 
 ```bash
+export PANACHAT_CONTROL_PLANE_IMAGE=ghcr.io/<owner>/panachat-control-plane:<sha>
 PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy ghcr.io/<owner>/panachat:<sha>
 ```
+
+That script blue/green-flips chat and then `docker compose --profile control-plane up -d --no-deps --force-recreate panachat-control-plane`. It never runs `docker compose down -v`.
+
+Set `AICO_CONTROL_PLANE_PUBLIC_URL=https://adchat.panafor.com` (kamyar) and `AICO_INSECURE_AUTH_COOKIES=0` in `.env`.
 
 Manual: Actions → **Deploy Panachat Canary** → `workflow_dispatch` (optional skip deploy).
 

--- a/.agents/skills/self-host-deploy/preview-cicd.md
+++ b/.agents/skills/self-host-deploy/preview-cicd.md
@@ -15,24 +15,25 @@ feature/*  →  preview  →  (smoke test)  →  canary  →  production VPS
                     PANACHAT_ENV=preview           PANACHAT_ENV=canary
 ```
 
-| Branch    | Workflow                                                              | Image tags       | Stack                                             |
-| --------- | --------------------------------------------------------------------- | ---------------- | ------------------------------------------------- |
-| `preview` | [`deploy-preview.yml`](../../../.github/workflows/deploy-preview.yml) | `:preview` + SHA | `panachat-preview` + `panachat_preview_*` volumes |
-| `canary`  | [`deploy-canary.yml`](../../../.github/workflows/deploy-canary.yml)   | `:canary` + SHA  | `panachat` + `panachat_*` volumes                 |
+| Branch    | Workflow                                                              | Image tags                            | Stack                                             |
+| --------- | --------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------- |
+| `preview` | [`deploy-preview.yml`](../../../.github/workflows/deploy-preview.yml) | chat + control-plane `:preview` + SHA | `panachat-preview` + `panachat_preview_*` volumes |
+| `canary`  | [`deploy-canary.yml`](../../../.github/workflows/deploy-canary.yml)   | chat + control-plane `:canary` + SHA  | `panachat` + `panachat_*` volumes                 |
 
 ## Isolation map
 
-| Setting          | Preview                                                                 | Prod (canary)                   |
-| ---------------- | ----------------------------------------------------------------------- | ------------------------------- |
-| Compose project  | `panachat-preview`                                                      | `panachat`                      |
-| Volumes          | `panachat_preview_postgres_data` (etc.)                                 | `panachat_postgres_data` (etc.) |
-| App ports        | `3220` / `3221`                                                         | `3210` / `3211`                 |
-| RustFS host port | `9010` (example)                                                        | `9000`                          |
-| App env          | `.env.preview`                                                          | `.env`                          |
-| Infra env        | `docker-compose/deploy/.env.preview`                                    | `docker-compose/deploy/.env`    |
-| State            | `/var/lib/panachat-preview/deploy.env`                                  | `/var/lib/panachat/deploy.env`  |
-| Nginx upstream   | `panachat_preview_backend`                                              | `panachat_backend`              |
-| Backup dir       | `~/…/panachat-preview-backups` (or `/var/lib/panachat-preview/backups`) | prod backup dir                 |
+| Setting          | Preview                                                                 | Prod (canary)                                                      |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Compose project  | `panachat-preview`                                                      | `panachat`                                                         |
+| Volumes          | `panachat_preview_postgres_data` (etc.)                                 | `panachat_postgres_data` (etc.)                                    |
+| App ports        | `3220` / `3221`                                                         | `3210` / `3211`                                                    |
+| RustFS host port | `9010` (example)                                                        | `9000`                                                             |
+| App env          | `.env.preview`                                                          | `.env`                                                             |
+| Infra env        | `docker-compose/deploy/.env.preview`                                    | `docker-compose/deploy/.env`                                       |
+| State            | `/var/lib/panachat-preview/deploy.env`                                  | `/var/lib/panachat/deploy.env`                                     |
+| Nginx upstream   | `panachat_preview_backend`                                              | `panachat_backend`                                                 |
+| Control-plane    | `panachat-preview-control-plane` on `:3030`                             | `panachat-control-plane` on `:3020` (`https://adchat.panafor.com`) |
+| Backup dir       | `~/…/panachat-preview-backups` (or `/var/lib/panachat-preview/backups`) | prod backup dir                                                    |
 
 **Hard bans:** `docker compose down -v`, deleting `panachat_*` or `panachat_preview_*` volumes casually, pointing preview `DATABASE_URL` at prod.
 

--- a/.env.example.panachat
+++ b/.env.example.panachat
@@ -44,7 +44,7 @@ AUTH_SECRET=change-me-auth-secret
 
 SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
 
-# Product ↔ control-plane (required if profile control-plane is enabled)
+# Product ↔ control-plane (Deploy Canary/Preview restarts panachat-control-plane)
 # AICO_CONTROL_PLANE_SERVICE_TOKEN=
 # AICO_CONTROL_PLANE_PUBLIC_URL=https://admin.example.com
 # AICO_INSECURE_AUTH_COOKIES=0

--- a/.env.example.preview
+++ b/.env.example.preview
@@ -31,6 +31,11 @@ AUTH_SECRET=change-me-preview-auth-secret
 
 SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
 
+# Preview control-plane (port 3030). Do not set this to https://adchat.panafor.com.
+# AICO_CONTROL_PLANE_SERVICE_TOKEN=
+# AICO_CONTROL_PLANE_PUBLIC_URL=https://preview.example.com:3030
+# AICO_INSECURE_AUTH_COOKIES=0
+
 # Browser-reachable S3 for preview (separate bucket or path recommended)
 # S3_ENDPOINT=https://s3-preview.example.com
 # S3_BUCKET=lobe

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -1,7 +1,7 @@
 name: Deploy Panachat Canary
 
-# Build ghcr.io/<owner>/panachat on every push to canary, then SSH-deploy
-# with blue-green swap (scripts/panachat-deploy-remote.sh).
+# Build ghcr.io/<owner>/panachat and panachat-control-plane on every push
+# to canary, then SSH-deploy chat (blue-green) + restart the admin panel.
 #
 # Required secrets:
 #   DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
@@ -39,6 +39,7 @@ jobs:
     outputs:
       image: ${{ steps.vars.outputs.image }}
       sha_short: ${{ steps.vars.outputs.sha_short }}
+      control_plane_image: ${{ steps.vars.outputs.control_plane_image }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -48,6 +49,7 @@ jobs:
         run: |
           owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
           echo "image=${{ env.REGISTRY }}/${owner_lc}/panachat" >> "$GITHUB_OUTPUT"
+          echo "control_plane_image=${{ env.REGISTRY }}/${owner_lc}/panachat-control-plane" >> "$GITHUB_OUTPUT"
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
@@ -121,9 +123,75 @@ jobs:
             echo "Package not visible yet via API — set Private in GitHub Packages UI after first push."
           fi
 
+  build-control-plane:
+    name: Build and push control-plane image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vars.outputs.image }}
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Image name (lowercase)
+        id: vars
+        run: |
+          owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image=${{ env.REGISTRY }}/${owner_lc}/panachat-control-plane" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.vars.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.sha_short }}
+            type=raw,value=canary
+          labels: |
+            org.opencontainers.image.title=panachat-control-plane
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/aico-control-plane/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=control-plane
+          cache-to: type=gha,mode=max,scope=control-plane
+          platforms: linux/amd64
+
+      - name: Ensure GHCR package is private
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner='${{ github.repository_owner }}'
+          pkg='panachat-control-plane'
+          if gh api "orgs/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "orgs/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+          elif gh api "users/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "users/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+          fi
+
   deploy:
     name: SSH blue-green deploy
-    needs: build
+    needs: [build, build-control-plane]
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
     runs-on: ubuntu-latest
     steps:
@@ -134,7 +202,7 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script_stop: true
-          envs: IMAGE,DEPLOY_PATH,GHCR_USER,GHCR_TOKEN
+          envs: IMAGE,CONTROL_PLANE_IMAGE,DEPLOY_PATH,GHCR_USER,GHCR_TOKEN
           script: |
             set -euo pipefail
             DEPLOY_PATH="${DEPLOY_PATH:-$HOME/panachat}"
@@ -144,9 +212,11 @@ jobs:
             if [ -n "${GHCR_TOKEN:-}" ]; then
               echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
             fi
+            export PANACHAT_CONTROL_PLANE_IMAGE="$CONTROL_PLANE_IMAGE"
             PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
         env:
           IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
+          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.outputs.image }}:${{ needs.build-control-plane.outputs.sha_short }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           GHCR_USER: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy Panachat Preview
 
-# Build ghcr.io/<owner>/panachat on every push to preview, then SSH-deploy
-# the isolated preview stack (own DB volumes) with PANACHAT_ENV=preview.
+# Build ghcr.io/<owner>/panachat and panachat-control-plane on every push
+# to preview, then SSH-deploy the isolated preview stack (own DB volumes).
 #
 # Required secrets (same as canary deploy):
 #   DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
@@ -117,9 +117,75 @@ jobs:
             echo "Package not visible yet via API — set Private in GitHub Packages UI after first push."
           fi
 
+  build-control-plane:
+    name: Build and push preview control-plane image
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vars.outputs.image }}
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Image name (lowercase)
+        id: vars
+        run: |
+          owner_lc="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image=${{ env.REGISTRY }}/${owner_lc}/panachat-control-plane" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.vars.outputs.image }}
+          tags: |
+            type=raw,value=${{ steps.vars.outputs.sha_short }}
+            type=raw,value=preview
+          labels: |
+            org.opencontainers.image.title=panachat-control-plane
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/aico-control-plane/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=control-plane-preview
+          cache-to: type=gha,mode=max,scope=control-plane-preview
+          platforms: linux/amd64
+
+      - name: Ensure GHCR package is private
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner='${{ github.repository_owner }}'
+          pkg='panachat-control-plane'
+          if gh api "orgs/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "orgs/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+          elif gh api "users/${owner}/packages/container/${pkg}" >/dev/null 2>&1; then
+            gh api --method PATCH "users/${owner}/packages/container/${pkg}" \
+              -f visibility=private || true
+          fi
+
   deploy:
     name: SSH preview blue-green deploy
-    needs: build
+    needs: [build, build-control-plane]
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
     runs-on: ubuntu-latest
     steps:
@@ -130,17 +196,22 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script_stop: true
-          envs: IMAGE,DEPLOY_PATH,GHCR_USER,GHCR_TOKEN
+          envs: IMAGE,CONTROL_PLANE_IMAGE,DEPLOY_PATH,GHCR_USER,GHCR_TOKEN
           script: |
             set -euo pipefail
             DEPLOY_PATH="${DEPLOY_PATH:-$HOME/panachat}"
             cd "$DEPLOY_PATH"
+            # Shared checkout with prod — always track canary for compose/scripts.
+            git fetch origin canary
+            git merge --ff-only FETCH_HEAD || echo "WARN: could not fast-forward (local changes?); deploying with existing scripts"
             if [ -n "${GHCR_TOKEN:-}" ]; then
               echo "$GHCR_TOKEN" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
             fi
+            export PANACHAT_CONTROL_PLANE_IMAGE="$CONTROL_PLANE_IMAGE"
             PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
         env:
           IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
+          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.outputs.image }}:${{ needs.build-control-plane.outputs.sha_short }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           GHCR_USER: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,9 @@
 name: E2E CI
 
-on: [push, pull_request]
+# Aico: not used (upstream LobeHub CI; Panachat ships via deploy-canary/preview).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
+on:
+  workflow_dispatch: {}
 
 permissions:
   actions: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test CI
 
-on: [push, pull_request]
+# Aico: not used (upstream LobeHub CI; Panachat ships via deploy-canary/preview).
+# Restore upstream `on:` when re-enabling. Manual run still possible.
+on:
+  workflow_dispatch: {}
 
 permissions:
   actions: write

--- a/apps/aico-control-plane/Dockerfile
+++ b/apps/aico-control-plane/Dockerfile
@@ -1,23 +1,60 @@
-# Minimal runtime image for @aico/control-plane (optional standalone builds).
-# Prefer the moz bind-mount override for local deploys — it reuses the monorepo
-# node_modules after `pnpm --filter @aico/control-plane build`.
+# Panachat control-plane image (operator UI + Hono on :3020).
+# Build from repo root:
+#   docker build -f apps/aico-control-plane/Dockerfile -t panachat-control-plane .
 #
-# Standalone image build (from repo root, after control-plane build):
-#   docker build -f apps/aico-control-plane/Dockerfile -t aico-control-plane:local .
-FROM node:24-bookworm-slim
+# Runtime is self-contained. Do not bind-mount the git checkout over /app.
+
+ARG NODEJS_VERSION="24"
+
+FROM node:${NODEJS_VERSION}-bookworm-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NODE_OPTIONS=--max-old-space-size=8192 \
+    APP_URL=http://app.com \
+    DATABASE_DRIVER=node \
+    DATABASE_URL=postgres://postgres:password@localhost:5432/postgres \
+    KEY_VAULTS_SECRET=use-for-build \
+    AUTH_SECRET=use-for-build
+
 WORKDIR /app
-ENV NODE_ENV=production
-ENV AICO_IS_CONTROL_PLANE=1
-ENV AICO_CONTROL_PLANE_PORT=3020
-ENV HONO_HOST=0.0.0.0
-COPY apps/aico-control-plane/dist ./dist
-COPY apps/aico-control-plane/src/web ./web
-COPY apps/aico-control-plane/package.json ./
-# Resolve external imports from the monorepo install (copied by moz packaging).
-COPY node_modules ./node_modules
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates python3 make g++ git \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm i -g corepack@latest && corepack enable
+
+COPY . .
+
+RUN corepack use "$(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json)" \
+    && pnpm i --frozen-lockfile \
+    && pnpm run build:spa:control-plane \
+    && pnpm --filter @aico/control-plane build \
+    && test -f apps/aico-control-plane/dist/standalone.js \
+    && test -f apps/aico-control-plane/web/spa/index.html
+
+FROM node:${NODEJS_VERSION}-bookworm-slim
+
+WORKDIR /app
+ENV NODE_ENV=production \
+    AICO_IS_CONTROL_PLANE=1 \
+    AICO_CONTROL_PLANE_PORT=3020 \
+    HONO_HOST=0.0.0.0 \
+    NODE_PATH=/app/node_modules
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/aico-control-plane/dist ./dist
+COPY --from=builder /app/apps/aico-control-plane/web/spa ./web/spa
+COPY --from=builder /app/apps/aico-control-plane/src/web ./src/web
+COPY --from=builder /app/apps/aico-control-plane/package.json ./package.json
+
 RUN groupadd --system --gid 1001 nodejs \
-  && useradd --system --uid 1001 --gid nodejs --home-dir /app --no-create-home nextjs \
-  && chown -R nextjs:nodejs /app
+    && useradd --system --uid 1001 --gid nodejs --home-dir /app --no-create-home nextjs \
+    && chown -R nextjs:nodejs /app
+
 USER nextjs
 EXPOSE 3020
 CMD ["node", "dist/standalone.js"]

--- a/apps/aico-control-plane/README.md
+++ b/apps/aico-control-plane/README.md
@@ -65,6 +65,16 @@ moz -i # status includes control-plane /health
 
 Open **<http://127.0.0.1:3020/>** — design-system panel with login. Auth is proxied to the product app; tRPC stays on 3020.
 
+## Production image (CI)
+
+Build from repo root (never bind-mount git over `/app`):
+
+```bash
+docker build -f apps/aico-control-plane/Dockerfile -t panachat-control-plane .
+```
+
+Canary/Preview Actions push `ghcr.io/<owner>/panachat-control-plane:<sha>` and the remote deploy script recreates `${PANACHAT_STACK}-control-plane`. Set `AICO_CONTROL_PLANE_PUBLIC_URL` to the browser origin (kamyar: `https://adchat.panafor.com`).
+
 ## Optional Vite HMR (3021)
 
 Only for UI development with hot reload:

--- a/docker-compose/deploy/.env.example.panachat
+++ b/docker-compose/deploy/.env.example.panachat
@@ -34,8 +34,9 @@ JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me","use":"sig","alg":"RS256","n":
 PANACHAT_DATA_DIR=/var/lib/panachat/data
 # PANACHAT_BACKUP_DIR=/var/lib/panachat/backups
 
-# Optional control-plane profile
-# PANACHAT_CONTROL_PLANE_PORT=3020
+# Control-plane (CI sets PANACHAT_CONTROL_PLANE_IMAGE; script uses --profile control-plane)
+# PANACHAT_CONTROL_PLANE_IMAGE=ghcr.io/panafor-ai-team/panachat-control-plane:canary
+PANACHAT_CONTROL_PLANE_PORT=3020
 # COMPOSE_PROFILES=control-plane
 # AICO_CONTROL_PLANE_SERVICE_TOKEN=
 # AICO_CONTROL_PLANE_PUBLIC_URL=https://admin.example.com

--- a/docker-compose/deploy/.env.example.preview
+++ b/docker-compose/deploy/.env.example.preview
@@ -34,8 +34,9 @@ JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me-preview","use":"sig","alg":"RS2
 PANACHAT_DATA_DIR=/var/lib/panachat-preview/data
 PANACHAT_BACKUP_DIR=/var/lib/panachat-preview/backups
 
-# Optional control-plane (preview)
-# PANACHAT_CONTROL_PLANE_PORT=3030
+# Control-plane (preview stack, own DB — not adchat.panafor.com)
+# PANACHAT_CONTROL_PLANE_IMAGE=ghcr.io/panafor-ai-team/panachat-control-plane:preview
+PANACHAT_CONTROL_PLANE_PORT=3030
 # COMPOSE_PROFILES=control-plane
 
 # Nginx upstream rewritten by PANACHAT_ENV=preview deploy

--- a/docker-compose/deploy/SERVER-BOOTSTRAP.md
+++ b/docker-compose/deploy/SERVER-BOOTSTRAP.md
@@ -86,7 +86,7 @@ Edit **both** files. Required:
 - `INTERNAL_APP_URL=http://localhost:3210`
 - `AICO_CONTROL_PLANE_PUBLIC_URL=https://adchat.panafor.com`
 - Rotate `AUTH_SECRET`, `KEY_VAULTS_SECRET`, `POSTGRES_PASSWORD`, `RUSTFS_SECRET_KEY`, `JWKS_KEY`, `AICO_CONTROL_PLANE_SERVICE_TOKEN` (do not keep example values)
-- Browser-reachable `S3_ENDPOINT` (not `http://rustfs:9000`). Example: proxy RustFS as `https://s3.chat.panafor.com` → `127.0.0.1:9000`
+- Browser-reachable `S3_ENDPOINT` (not `http://rustfs:9000`). One-level host only: `https://s3.panafor.com` → `127.0.0.1:9000` (never `s3.chat.*`)
 
 Infra file (`docker-compose/deploy/.env`) should keep:
 
@@ -95,7 +95,7 @@ Infra file (`docker-compose/deploy/.env`) should keep:
 - `PANACHAT_PORT_BLUE=3210` / `PANACHAT_PORT_GREEN=3211`
 - `POSTGRES_CONTAINER=panachat-postgres`
 - `PANACHAT_CONTROL_PLANE_PORT=3020`
-- `COMPOSE_PROFILES=control-plane` (uncomment when you start the admin container)
+- `PANACHAT_CONTROL_PLANE_IMAGE` is filled by Deploy Canary (GHCR `panachat-control-plane:<sha>`)
 
 ---
 
@@ -125,9 +125,10 @@ A records (or AAAA) pointing at `5.135.244.12`:
 - `chat.panafor.com`
 - `preview.panafor.com`
 - `adchat.panafor.com`
-- S3 host if you use a separate name (e.g. `s3.chat.panafor.com`)
+- `s3.panafor.com`
+- `s3-preview.panafor.com`
 
-Wait until `dig +short chat.panafor.com` returns the VPS IP.
+Wait until `dig +short chat.panafor.com` returns the VPS IP (`5.135.244.12`). If you use ArvanCloud (or any CDN), **Cloud must be OFF** (DNS-only). Proxied A records hide the origin and HTTP-01 / nginx on this VPS never see the challenge.
 
 ---
 
@@ -169,10 +170,13 @@ sudo cp docker-compose/deploy/nginx/panachat-preview-site.example.conf \
   /etc/nginx/sites-available/panachat-preview
 sudo cp docker-compose/deploy/nginx/panachat-admin-site.example.conf \
   /etc/nginx/sites-available/panachat-admin
+sudo cp docker-compose/deploy/nginx/panachat-s3-site.example.conf \
+  /etc/nginx/sites-available/panachat-s3
 sudo sed -i 's/chat.example.com/chat.panafor.com/g' /etc/nginx/sites-available/panachat
 sudo sed -i 's/preview.chat.example.com/preview.panafor.com/g' \
   /etc/nginx/sites-available/panachat-preview
 sudo sed -i 's/admin.example.com/adchat.panafor.com/g' /etc/nginx/sites-available/panachat-admin
+sudo sed -i 's/s3.example.com/s3.panafor.com/g' /etc/nginx/sites-available/panachat-s3
 ```
 
 The examples 301 HTTP → HTTPS. Until Certbot has issued certs, comment out each `listen 443` server block and change the port-80 `return 301` to a `location /` that `proxy_pass`es `http://panachat_backend` (prod), `http://panachat_preview_backend` (preview), or `http://127.0.0.1:3020` (admin), matching the example `location /` headers.
@@ -181,20 +185,27 @@ The examples 301 HTTP → HTTPS. Until Certbot has issued certs, comment out eac
 sudo ln -sf /etc/nginx/sites-available/panachat /etc/nginx/sites-enabled/panachat
 sudo ln -sf /etc/nginx/sites-available/panachat-preview /etc/nginx/sites-enabled/panachat-preview
 sudo ln -sf /etc/nginx/sites-available/panachat-admin /etc/nginx/sites-enabled/panachat-admin
+sudo ln -sf /etc/nginx/sites-available/panachat-s3 /etc/nginx/sites-enabled/panachat-s3
 # This host already serves developer.panafor.com from sites-enabled/default — do not delete it.
 sudo /usr/sbin/nginx -t && sudo systemctl reload nginx
 ```
 
-TLS (prod + admin first is fine; preview can wait until step 10 if that DNS is not ready):
+### Let's Encrypt (certbot)
+
+1. Confirm DNS A records hit this VPS (`dig +short …` → `5.135.244.12`) with CDN/cloud **off**.
+2. Serve **HTTP on port 80** first (comment out `listen 443` until certs exist, as above). `curl -I http://chat.panafor.com` should reach nginx on this host, not an Apache default page.
+3. Issue certs (certbot edits the nginx site and adds HTTPS + redirect):
 
 ```bash
 sudo certbot --nginx -d chat.panafor.com
 sudo certbot --nginx -d adchat.panafor.com
 sudo certbot --nginx -d preview.panafor.com
+sudo certbot --nginx -d s3.panafor.com
+# optional: sudo certbot --nginx -d s3-preview.panafor.com
 sudo /usr/sbin/nginx -t && sudo systemctl reload nginx
 ```
 
-If you use a separate S3 hostname, add a server that `proxy_pass`es to `127.0.0.1:9000` (prod) and `127.0.0.1:9010` (preview).
+Renewal is `certbot.timer` (already installed with `python3-certbot-nginx`). Test with `sudo certbot renew --dry-run`.
 
 `PANACHAT_SKIP_NGINX=1` is for debugging only — production needs the blue/green flip.
 
@@ -204,9 +215,14 @@ If you use a separate S3 hostname, add a server that `proxy_pass`es to `127.0.0.
 
 On GitHub: **Actions** → **Deploy Panachat Canary** → **Run workflow** (branch `canary`).
 
-Wait until the **build** job pushes `ghcr.io/panafor-ai-team/panachat:canary`. Open org **Packages** and set the `panachat` package to **Private** if it is public.
+Wait until **build** and **build-control-plane** push:
 
-You can skip the deploy job on first run (`skip_deploy`) until bootstrap env is ready; you still need a successful **push**.
+- `ghcr.io/panafor-ai-team/panachat:<sha>` and `:canary`
+- `ghcr.io/panafor-ai-team/panachat-control-plane:<sha>` and `:canary`
+
+Open org **Packages** and set both packages to **Private** if they are public.
+
+You can skip the deploy job on first run (`skip_deploy`) until bootstrap env is ready; you still need a successful **push**. After bootstrap, every push to `canary` / `preview` deploys chat **and** restarts `panachat-control-plane` / `panachat-preview-control-plane` (`docker compose down -v` is never used).
 
 ---
 
@@ -246,9 +262,9 @@ Then:
 PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status
 ```
 
-Open `https://chat.panafor.com`. Sign up the first user; grant platform admin if needed (see self-host-deploy skill).
+Open `https://chat.panafor.com`. Sign up the first user; grant platform admin if needed (see self-host-deploy skill). Do not commit passwords.
 
-Admin UI (after `COMPOSE_PROFILES=control-plane` is set and the control-plane container is up): `https://adchat.panafor.com`.
+Admin UI: `https://adchat.panafor.com` (`AICO_CONTROL_PLANE_PUBLIC_URL` must match). CI pulls the control-plane image and runs `compose --profile control-plane up -d --force-recreate panachat-control-plane`.
 
 ---
 

--- a/docker-compose/deploy/docker-compose.panachat.yml
+++ b/docker-compose/deploy/docker-compose.panachat.yml
@@ -98,13 +98,12 @@ services:
     restart: unless-stopped
 
   panachat-control-plane:
-    image: ${PANACHAT_CONTROL_PLANE_IMAGE:-node:24-bookworm-slim}
+    image: ${PANACHAT_CONTROL_PLANE_IMAGE:-panachat-control-plane:canary}
     container_name: ${PANACHAT_STACK:-panachat}-control-plane
+    pull_policy: always
     profiles:
       - control-plane
-    working_dir: ${PANACHAT_CONTROL_PLANE_WORKDIR:-/repo/apps/aico-control-plane}
-    volumes:
-      - ${PANACHAT_REPO_ROOT:-../..}:/repo
+    working_dir: /app
     command: ['node', 'dist/standalone.js']
     env_file:
       - ${PANACHAT_APP_ENV_FILE:-../../.env}

--- a/docker-compose/deploy/nginx/panachat-admin-site.example.conf
+++ b/docker-compose/deploy/nginx/panachat-admin-site.example.conf
@@ -1,8 +1,8 @@
-# Example HTTPS site for the Panachat control-plane / admin UI.
-# Place under /etc/nginx/sites-available/. Not blue-green — proxy loopback :3020.
+# Example HTTPS site for Panachat control-plane (operator admin).
+# Place under /etc/nginx/sites-available/ and enable TLS (certbot).
 #
-# Compose: COMPOSE_PROFILES=control-plane
-# Env:     AICO_CONTROL_PLANE_PUBLIC_URL=https://admin.example.com
+# Prod admin: adchat.panafor.com → 127.0.0.1:3020
+# Do not point this vhost at the preview control-plane port (3030).
 
 server {
     listen 80;

--- a/docker-compose/deploy/nginx/panachat-s3-site.example.conf
+++ b/docker-compose/deploy/nginx/panachat-s3-site.example.conf
@@ -1,0 +1,36 @@
+# Example HTTPS site for browser-reachable RustFS (S3 API).
+# One-level hostname only — never s3.chat.example.com.
+#
+# Prod:  s3.example.com        → 127.0.0.1:9000
+# Preview: s3-preview.example.com → 127.0.0.1:9010
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name s3.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name s3.example.com;
+
+    # ssl_certificate     /etc/letsencrypt/live/s3.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/s3.example.com/privkey.pem;
+
+    client_max_body_size 0;
+
+    location / {
+        proxy_pass http://127.0.0.1:9000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}

--- a/scripts/panachat-deploy-remote.guard.test.ts
+++ b/scripts/panachat-deploy-remote.guard.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (rel: string) => readFileSync(path.join(root, rel), 'utf8');
+
+describe('control-plane CI/CD wiring', () => {
+  it('builds and deploys a GHCR control-plane image on canary and preview', () => {
+    const canary = read('.github/workflows/deploy-canary.yml');
+    const preview = read('.github/workflows/deploy-preview.yml');
+
+    for (const yaml of [canary, preview]) {
+      expect(yaml).toContain('build-control-plane:');
+      expect(yaml).toContain('file: ./apps/aico-control-plane/Dockerfile');
+      expect(yaml).toContain('PANACHAT_CONTROL_PLANE_IMAGE');
+      expect(yaml).toContain('needs: [build, build-control-plane]');
+    }
+  });
+
+  it('recreates the control-plane container without compose down -v', () => {
+    const script = read('scripts/panachat-deploy-remote.sh');
+    const compose = read('docker-compose/deploy/docker-compose.panachat.yml');
+    const dockerfile = read('apps/aico-control-plane/Dockerfile');
+
+    expect(script).toContain('deploy_control_plane');
+    expect(script).toMatch(
+      /compose_with_profile control-plane up -d --no-deps --force-recreate panachat-control-plane/,
+    );
+    expect(script).not.toMatch(/^\s*(docker compose|compose).*down\s+-v/m);
+
+    expect(compose).not.toMatch(
+      /panachat-control-plane:[\s\S]*?volumes:[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*-\s+\.\.:\/app/,
+    );
+    expect(compose).toContain('pull_policy: always');
+
+    expect(dockerfile).toContain('pnpm run build:spa:control-plane');
+    expect(dockerfile).toContain('pnpm --filter @aico/control-plane build');
+    expect(dockerfile).toContain('CMD ["node", "dist/standalone.js"]');
+    expect(dockerfile).toContain('Do not bind-mount');
+  });
+});

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -23,6 +23,7 @@
 #   PANACHAT_PUBLIC_URL           for post-flip verify
 #   PANACHAT_HEALTH_TIMEOUT_SEC   default 180
 #   PANACHAT_IMAGE_KEEP           keep last N SHA images (default 5)
+#   PANACHAT_CONTROL_PLANE_IMAGE  ghcr.io/<owner>/panachat-control-plane:<sha>
 #   PANACHAT_SKIP_BACKUP=1
 #   PANACHAT_SKIP_NGINX=1
 #   PANACHAT_ALLOW_DB_DRIFT=1     allow deploy when live user count dropped vs fingerprint
@@ -54,6 +55,7 @@ case "$PANACHAT_ENV" in
     NGINX_TEMPLATE_PREFIX="panachat-upstream"
     PORT_BLUE="${PANACHAT_PORT_BLUE:-3210}"
     PORT_GREEN="${PANACHAT_PORT_GREEN:-3211}"
+    CONTROL_PLANE_PORT="${PANACHAT_CONTROL_PLANE_PORT:-3020}"
     DEFAULT_BACKUP_DIR="${HOME}/.local/share/panachat-backups"
     ;;
   preview)
@@ -66,6 +68,7 @@ case "$PANACHAT_ENV" in
     NGINX_TEMPLATE_PREFIX="panachat-preview-upstream"
     PORT_BLUE="${PANACHAT_PORT_BLUE:-3220}"
     PORT_GREEN="${PANACHAT_PORT_GREEN:-3221}"
+    CONTROL_PLANE_PORT="${PANACHAT_CONTROL_PLANE_PORT:-3030}"
     DEFAULT_BACKUP_DIR="${HOME}/.local/share/panachat-preview-backups"
     ;;
   *)
@@ -102,6 +105,7 @@ load_infra_defaults() {
   fi
   PORT_BLUE="${PANACHAT_PORT_BLUE:-$PORT_BLUE}"
   PORT_GREEN="${PANACHAT_PORT_GREEN:-$PORT_GREEN}"
+  CONTROL_PLANE_PORT="${PANACHAT_CONTROL_PLANE_PORT:-$CONTROL_PLANE_PORT}"
 }
 
 load_state() {
@@ -198,33 +202,31 @@ compose_with_profile() {
 set_image_env() {
   local image="$1"
   export PANACHAT_IMAGE="$image"
+  persist_infra_kv "PANACHAT_IMAGE" "$image"
+  persist_infra_kv "PANACHAT_STACK" "$PANACHAT_STACK"
+  persist_infra_kv "PANACHAT_VOLUME_PREFIX" "$PANACHAT_VOLUME_PREFIX"
+  persist_infra_kv "PANACHAT_APP_ENV_FILE" "$APP_ENV_FILE"
+  persist_infra_kv "PANACHAT_INFRA_ENV_FILE" "$INFRA_ENV_FILE"
+  if [[ -n "${PANACHAT_CONTROL_PLANE_IMAGE:-}" ]]; then
+    persist_infra_kv "PANACHAT_CONTROL_PLANE_IMAGE" "$PANACHAT_CONTROL_PLANE_IMAGE"
+  fi
+}
+
+persist_infra_kv() {
+  local key="$1"
+  local val="$2"
   local envf="$INFRA_ENV_FILE"
   mkdir -p "$(dirname "$envf")"
-  if [[ -f "$envf" ]]; then
-    if grep -qE '^PANACHAT_IMAGE=' "$envf"; then
-      sed -i.bak "s|^PANACHAT_IMAGE=.*|PANACHAT_IMAGE=${image}|" "$envf"
-      rm -f "${envf}.bak"
-    else
-      printf '\nPANACHAT_IMAGE=%s\n' "$image" >>"$envf"
-    fi
-  else
-    printf 'PANACHAT_IMAGE=%s\n' "$image" >"$envf"
+  if [[ ! -f "$envf" ]]; then
+    printf '%s=%s\n' "$key" "$val" >"$envf"
+    return 0
   fi
-  # Ensure stack identity is persisted for manual compose use
-  for kv in \
-    "PANACHAT_STACK=${PANACHAT_STACK}" \
-    "PANACHAT_VOLUME_PREFIX=${PANACHAT_VOLUME_PREFIX}" \
-    "PANACHAT_APP_ENV_FILE=${APP_ENV_FILE}" \
-    "PANACHAT_INFRA_ENV_FILE=${INFRA_ENV_FILE}"; do
-    local key="${kv%%=*}"
-    local val="${kv#*=}"
-    if grep -qE "^${key}=" "$envf" 2>/dev/null; then
-      sed -i.bak "s|^${key}=.*|${key}=${val}|" "$envf"
-      rm -f "${envf}.bak"
-    else
-      printf '%s=%s\n' "$key" "$val" >>"$envf"
-    fi
-  done
+  if grep -qE "^${key}=" "$envf"; then
+    sed -i.bak "s|^${key}=.*|${key}=${val}|" "$envf"
+    rm -f "${envf}.bak"
+  else
+    printf '%s=%s\n' "$key" "$val" >>"$envf"
+  fi
 }
 
 fingerprint_file() {
@@ -269,6 +271,40 @@ stack=${PANACHAT_STACK}
 users=${live_users}
 EOF
   log "DB fingerprint saved users=${live_users} ($file)"
+}
+
+wait_control_plane() {
+  local deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local svc="${PANACHAT_STACK}-control-plane"
+  log "Waiting for $svc on 127.0.0.1:${CONTROL_PLANE_PORT} (timeout ${HEALTH_TIMEOUT}s)"
+  while ((SECONDS < deadline)); do
+    if docker inspect -f '{{.State.Running}}' "$svc" 2>/dev/null | grep -q true; then
+      local code
+      code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${CONTROL_PLANE_PORT}/health" || echo 000)
+      if [[ "$code" == "200" ]]; then
+        log "$svc is healthy (HTTP $code)"
+        return 0
+      fi
+    fi
+    sleep 3
+  done
+  err "$svc did not become healthy within ${HEALTH_TIMEOUT}s"
+  docker logs "$svc" 2>&1 | tail -n 80 || true
+  return 1
+}
+
+deploy_control_plane() {
+  if [[ -z "${PANACHAT_CONTROL_PLANE_IMAGE:-}" ]]; then
+    log "Skipping control-plane (PANACHAT_CONTROL_PLANE_IMAGE unset)"
+    return 0
+  fi
+  persist_infra_kv "PANACHAT_CONTROL_PLANE_IMAGE" "$PANACHAT_CONTROL_PLANE_IMAGE"
+  persist_infra_kv "PANACHAT_CONTROL_PLANE_PORT" "$CONTROL_PLANE_PORT"
+  log "Pulling control-plane ${PANACHAT_CONTROL_PLANE_IMAGE}"
+  docker pull "$PANACHAT_CONTROL_PLANE_IMAGE"
+  log "Starting ${PANACHAT_STACK}-control-plane"
+  compose_with_profile control-plane up -d --no-deps --force-recreate panachat-control-plane
+  wait_control_plane
 }
 
 # Until DNS, APP_URL may be http://IP:3210 or :3211. Rewrite to the slot we are starting
@@ -511,6 +547,7 @@ cmd_bootstrap() {
   flip_nginx blue || true
   write_state blue "$(image_sha_tag "$image")" "" ""
   save_db_fingerprint
+  deploy_control_plane
   log "Bootstrap complete — active slot=blue stack=$PANACHAT_STACK"
 }
 
@@ -579,6 +616,7 @@ cmd_deploy() {
   write_state "$inactive" "$(image_sha_tag "$image")" "$active" "$prev_sha"
   save_db_fingerprint
   prune_old_images
+  deploy_control_plane
 
   if [[ -n "${PANACHAT_PUBLIC_URL:-}" ]]; then
     local verify="$ROOT/.claude/skills/self-host-deploy/scripts/verify-deployment.sh"


### PR DESCRIPTION
## Summary

- Deploy Canary and Deploy Preview now build `ghcr.io/<owner>/panachat-control-plane` (SPA + Hono standalone) in parallel with the chat image.
- SSH deploy fast-forwards the canary checkout, pulls that image, and recreates `panachat-control-plane` (preview: port 3030). Never `docker compose down -v`.
- Production public URL is `AICO_CONTROL_PLANE_PUBLIC_URL=https://adchat.panafor.com`. Certbot / Arvan-cloud-off steps are in `SERVER-BOOTSTRAP.md`.

## Test plan

- [x] Guard test: workflows wire `build-control-plane`; deploy script recreates CP without `down -v`
- [ ] After merge: Actions builds both packages (Private)
- [ ] `https://adchat.panafor.com/health` returns 200
- [ ] Chat blue/green still flips; Postgres volumes unchanged
- [ ] Preview CP does not bind `adchat.panafor.com`

#### 🔗 Related Issue

Fixes #272

Plane: [AICO-163](https://plane.panafor.com/panaforai/browse/AICO-163)

Made with [Cursor](https://cursor.com)