### PR TITLE
🐛 fix(ci): stop frozen lockfile in control-plane Docker build

### DIFF
--- a/apps/aico-control-plane/Dockerfile
+++ b/apps/aico-control-plane/Dockerfile
@@ -8,13 +8,20 @@ ARG NODEJS_VERSION="24"
 
 FROM node:${NODEJS_VERSION}-bookworm-slim AS builder
 
+# This repo sets lockfile=false (.npmrc / pnpm-workspace.yaml). `--frozen-lockfile`
+# plus CI=true (GitHub Actions / Buildx) makes the next `pnpm run` attempt a
+# headless install and fail with:
+#   Headless installation requires a pnpm-lock.yaml file
+# Match the product Dockerfile: `pnpm i` (not frozen). Empty CI so pnpm does not
+# treat the environment as CI. Allow postinstall so vite's esbuild binary exists.
 ENV DEBIAN_FRONTEND=noninteractive \
     NODE_OPTIONS=--max-old-space-size=8192 \
     APP_URL=http://app.com \
     DATABASE_DRIVER=node \
     DATABASE_URL=postgres://postgres:password@localhost:5432/postgres \
     KEY_VAULTS_SECRET=use-for-build \
-    AUTH_SECRET=use-for-build
+    AUTH_SECRET=use-for-build \
+    CI=
 
 WORKDIR /app
 
@@ -26,8 +33,9 @@ RUN apt-get update \
 COPY . .
 
 RUN corepack use "$(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json)" \
-    && pnpm i --frozen-lockfile \
-    && pnpm run build:spa:control-plane \
+    && pnpm i --config.dangerouslyAllowAllBuilds=true
+
+RUN pnpm run build:spa:control-plane \
     && pnpm --filter @aico/control-plane build \
     && test -f apps/aico-control-plane/dist/standalone.js \
     && test -f apps/aico-control-plane/web/spa/index.html

--- a/src/utils/controlPlaneDockerfile.test.ts
+++ b/src/utils/controlPlaneDockerfile.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression: Deploy Canary job "Build and push control-plane image" failed with
+ * `Headless installation requires a pnpm-lock.yaml file` after `pnpm i --frozen-lockfile`.
+ * This repo disables the lockfile (`.npmrc` / `pnpm-workspace.yaml`).
+ */
+describe('control-plane Dockerfile install', () => {
+  const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  const read = (relativePath: string) => readFileSync(path.join(root, relativePath), 'utf8');
+
+  it('does not use --frozen-lockfile while the repo has lockfile=false', () => {
+    expect(read('.npmrc')).toMatch(/^lockfile=false$/m);
+    expect(read('pnpm-workspace.yaml')).toMatch(/^lockfile:\s*false$/m);
+    expect(read('apps/aico-control-plane/Dockerfile')).not.toMatch(/pnpm i[^\n]*--frozen-lockfile/);
+  });
+});


### PR DESCRIPTION
## Summary

- Control-plane image build failed in Deploy Canary with `Headless installation requires a pnpm-lock.yaml file` after `pnpm i --frozen-lockfile`.
- This repo sets `lockfile=false`. Match the product Dockerfile (`pnpm i`), unset `CI` in the builder, and allow postinstall so Vite's esbuild binary exists.
- SSH deploy is blocked until this image builds (`needs: [build, build-control-plane]`), so `https://adchat.panafor.com` stays 502 until merge.

## Test plan

- [x] Regression test asserts the control-plane Dockerfile does not run `pnpm i --frozen-lockfile`
- [ ] Deploy Canary `Build and push control-plane image` is green
- [ ] After merge, `https://adchat.panafor.com` is no longer 502

Fixes #274

Plane: [AICO-164](https://plane.panafor.com/panaforai/browse/AICO-164)


Made with [Cursor](https://cursor.com)