### PR TITLE
🐛 fix(ci): drop allow-all-builds from control-plane image

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -192,7 +192,7 @@ jobs:
   deploy:
     name: SSH blue-green deploy
     needs: [build, build-control-plane]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
+    if: ${{ always() && needs.build.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true) }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH
@@ -216,7 +216,7 @@ jobs:
             PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
         env:
           IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
-          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.outputs.image }}:${{ needs.build-control-plane.outputs.sha_short }}
+          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.result == 'success' && format('{0}:{1}', needs.build-control-plane.outputs.image, needs.build-control-plane.outputs.sha_short) || '' }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           GHCR_USER: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -186,7 +186,7 @@ jobs:
   deploy:
     name: SSH preview blue-green deploy
     needs: [build, build-control-plane]
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true }}
+    if: ${{ always() && needs.build.result == 'success' && (github.event_name != 'workflow_dispatch' || inputs.skip_deploy != true) }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy preview over SSH
@@ -211,7 +211,7 @@ jobs:
             PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy "$IMAGE"
         env:
           IMAGE: ${{ needs.build.outputs.image }}:${{ needs.build.outputs.sha_short }}
-          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.outputs.image }}:${{ needs.build-control-plane.outputs.sha_short }}
+          CONTROL_PLANE_IMAGE: ${{ needs.build-control-plane.result == 'success' && format('{0}:{1}', needs.build-control-plane.outputs.image, needs.build-control-plane.outputs.sha_short) || '' }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           GHCR_USER: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}

--- a/apps/aico-control-plane/Dockerfile
+++ b/apps/aico-control-plane/Dockerfile
@@ -8,12 +8,11 @@ ARG NODEJS_VERSION="24"
 
 FROM node:${NODEJS_VERSION}-bookworm-slim AS builder
 
-# This repo sets lockfile=false (.npmrc / pnpm-workspace.yaml). `--frozen-lockfile`
-# plus CI=true (GitHub Actions / Buildx) makes the next `pnpm run` attempt a
-# headless install and fail with:
-#   Headless installation requires a pnpm-lock.yaml file
-# Match the product Dockerfile: `pnpm i` (not frozen). Empty CI so pnpm does not
-# treat the environment as CI. Allow postinstall so vite's esbuild binary exists.
+# This repo sets lockfile=false. Do not use frozen-lockfile (headless install
+# fails) or pnpm's allow-all-builds config (conflicts with
+# onlyBuiltDependencies: neverBuiltDependencies + onlyBuiltDependencies).
+# Empty CI so `pnpm run` does not re-install in GitHub Actions / Buildx.
+# Add esbuild to the allowlist so Vite has a binary (postinstall is otherwise skipped).
 ENV DEBIAN_FRONTEND=noninteractive \
     NODE_OPTIONS=--max-old-space-size=8192 \
     APP_URL=http://app.com \
@@ -32,8 +31,11 @@ RUN apt-get update \
 
 COPY . .
 
-RUN corepack use "$(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json)" \
-    && pnpm i --config.dangerouslyAllowAllBuilds=true
+RUN set -e; \
+    grep -qE '^[[:space:]]*-[[:space:]]*esbuild$' pnpm-workspace.yaml \
+      || sed -i '/^onlyBuiltDependencies:/a\  - esbuild' pnpm-workspace.yaml; \
+    corepack use "$(sed -n 's/.*"packageManager": "\(.*\)".*/\1/p' package.json)"; \
+    pnpm i
 
 RUN pnpm run build:spa:control-plane \
     && pnpm --filter @aico/control-plane build \

--- a/scripts/panachat-deploy-remote.guard.test.ts
+++ b/scripts/panachat-deploy-remote.guard.test.ts
@@ -41,5 +41,21 @@ describe('control-plane CI/CD wiring', () => {
     expect(dockerfile).toContain('pnpm --filter @aico/control-plane build');
     expect(dockerfile).toContain('CMD ["node", "dist/standalone.js"]');
     expect(dockerfile).toContain('Do not bind-mount');
+    expect(dockerfile).not.toMatch(/pnpm i[^\n]*--frozen-lockfile/);
+    expect(dockerfile).not.toMatch(/--config\.dangerouslyAllowAllBuilds/);
+  });
+
+  it('prints moz-like status (users, health) and deploys chat even if control-plane build fails', () => {
+    const script = read('scripts/panachat-deploy-remote.sh');
+    const canary = read('.github/workflows/deploy-canary.yml');
+    const preview = read('.github/workflows/deploy-preview.yml');
+
+    expect(script).toContain('echo "Users:');
+    expect(script).toContain('Platform admins:');
+    expect(script).toContain('Control plane /health');
+
+    for (const yaml of [canary, preview]) {
+      expect(yaml).toContain("always() && needs.build.result == 'success'");
+    }
   });
 });

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -6,7 +6,7 @@
 #   PANACHAT_ENV=preview ./scripts/panachat-deploy-remote.sh deploy <image-ref>
 #   ./scripts/panachat-deploy-remote.sh rollback
 #   ./scripts/panachat-deploy-remote.sh bootstrap <image-ref>
-#   ./scripts/panachat-deploy-remote.sh status
+#   ./scripts/panachat-deploy-remote.sh status     # moz -i equivalent (containers, users, health)
 #
 # Safety:
 #   - Always runs panachat-backup.sh before deploy (unless PANACHAT_SKIP_BACKUP=1)
@@ -237,6 +237,12 @@ postgres_user_count() {
   local container="${POSTGRES_CONTAINER:-${PANACHAT_STACK}-postgres}"
   local db="${LOBE_DB_NAME:-${PANACHAT_DB_NAME:-lobechat}}"
   docker exec "$container" psql -U postgres -d "$db" -Atc "SELECT count(*) FROM users;" 2>/dev/null || echo "?"
+}
+
+postgres_admin_count() {
+  local container="${POSTGRES_CONTAINER:-${PANACHAT_STACK}-postgres}"
+  local db="${LOBE_DB_NAME:-${PANACHAT_DB_NAME:-lobechat}}"
+  docker exec "$container" psql -U postgres -d "$db" -Atc "SELECT count(*) FROM platform_admins;" 2>/dev/null || echo "?"
 }
 
 # Same safety as moz: refuse deploy if live users dropped vs last healthy fingerprint.
@@ -510,6 +516,21 @@ require_env_files() {
 cmd_status() {
   load_infra_defaults
   load_state
+  if [[ -f "$APP_ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    # shellcheck disable=SC1090
+    source "$APP_ENV_FILE"
+    set +a
+  fi
+  local live_port live_http cp_code cp_name fp_file fp_users
+  live_port="$(slot_port "${CURRENT_SLOT:-blue}")"
+  live_http="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${live_port}/signin" 2>/dev/null || echo 000)"
+  cp_name="${PANACHAT_STACK}-control-plane"
+  cp_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${CONTROL_PLANE_PORT}/health" 2>/dev/null || echo 000)"
+  fp_file="$(fingerprint_file)"
+  fp_users="$(grep -E '^users=' "$fp_file" 2>/dev/null | head -1 | cut -d= -f2- || echo none)"
+
   echo "PANACHAT_ENV=$PANACHAT_ENV"
   echo "PANACHAT_STACK=$PANACHAT_STACK"
   echo "PANACHAT_VOLUME_PREFIX=$PANACHAT_VOLUME_PREFIX"
@@ -521,7 +542,13 @@ cmd_status() {
   echo "PREVIOUS_SLOT=${PREVIOUS_SLOT:-}"
   echo "PREVIOUS_SHA=${PREVIOUS_SHA:-}"
   echo "PANACHAT_IMAGE=${PANACHAT_IMAGE:-}"
-  echo "PORTS blue=$PORT_BLUE green=$PORT_GREEN"
+  echo "PORTS blue=$PORT_BLUE green=$PORT_GREEN control-plane=$CONTROL_PLANE_PORT"
+  echo "HTTP /signin (slot ${CURRENT_SLOT:-?} :${live_port}): $live_http"
+  echo "Control plane /health (:${CONTROL_PLANE_PORT}): $cp_code  container=$(docker inspect -f '{{.State.Status}}' "$cp_name" 2>/dev/null || echo missing)"
+  echo "Users: $(postgres_user_count)"
+  echo "Platform admins: $(postgres_admin_count)"
+  echo "DB fingerprint users: $fp_users  ($fp_file)"
+  echo ""
   docker ps --filter "name=${PANACHAT_STACK}-" --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
 }
 

--- a/src/utils/controlPlaneDockerfile.test.ts
+++ b/src/utils/controlPlaneDockerfile.test.ts
@@ -6,16 +6,20 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Regression: Deploy Canary job "Build and push control-plane image" failed with
- * `Headless installation requires a pnpm-lock.yaml file` after `pnpm i --frozen-lockfile`.
- * This repo disables the lockfile (`.npmrc` / `pnpm-workspace.yaml`).
+ * `Headless installation requires a pnpm-lock.yaml file` after `pnpm i --frozen-lockfile`,
+ * then `ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES` after `dangerouslyAllowAllBuilds`.
+ * This repo disables the lockfile (`.npmrc` / `pnpm-workspace.yaml`) and already lists
+ * `onlyBuiltDependencies`.
  */
 describe('control-plane Dockerfile install', () => {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
   const read = (relativePath: string) => readFileSync(path.join(root, relativePath), 'utf8');
 
-  it('does not use --frozen-lockfile while the repo has lockfile=false', () => {
+  it('does not use --frozen-lockfile or dangerouslyAllowAllBuilds', () => {
     expect(read('.npmrc')).toMatch(/^lockfile=false$/m);
     expect(read('pnpm-workspace.yaml')).toMatch(/^lockfile:\s*false$/m);
-    expect(read('apps/aico-control-plane/Dockerfile')).not.toMatch(/pnpm i[^\n]*--frozen-lockfile/);
+    const dockerfile = read('apps/aico-control-plane/Dockerfile');
+    expect(dockerfile).not.toMatch(/pnpm i[^\n]*--frozen-lockfile/);
+    expect(dockerfile).not.toMatch(/--config\.dangerouslyAllowAllBuilds/);
   });
 });


### PR DESCRIPTION
## Summary

- After #275, control-plane image still failed: `ERR_PNPM_CONFIG_CONFLICT_BUILT_DEPENDENCIES` from `pnpm i --config.dangerouslyAllowAllBuilds=true` vs workspace `onlyBuiltDependencies`.
- Install is now plain `pnpm i`, plus esbuild on the allowlist so Vite has a binary.
- Chat SSH deploy no longer waits on a failed admin image.
- `./scripts/panachat-deploy-remote.sh status` prints users, admins, fingerprint, slot HTTP, and control-plane `/health` (server equivalent of `moz -i`). Do not install moz on the VPS.

## Test plan

- [x] Regression tests for Dockerfile flags, status output, and workflow `always()` deploy
- [ ] Deploy Canary control-plane image is green
- [ ] After merge, `https://adchat.panafor.com` is no longer 502
- [ ] On the VPS: `PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status` shows Users: 1

Fixes #277

Plane: [AICO-166](https://plane.panafor.com/panaforai/browse/AICO-166)


Made with [Cursor](https://cursor.com)