### PR TITLE
🔧 chore(ci): silence Docker BuildKit secret-name warnings and bump Docker actions

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -63,10 +63,12 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+        with:
+          cleanup: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -74,7 +76,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
           tags: |
@@ -86,7 +88,7 @@ jobs:
             org.opencontainers.image.source=${{ github.repositoryUrl }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -145,10 +147,12 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+        with:
+          cleanup: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -156,7 +160,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
           tags: |
@@ -167,7 +171,7 @@ jobs:
             org.opencontainers.image.source=${{ github.repositoryUrl }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/aico-control-plane/Dockerfile

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -61,10 +61,12 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+        with:
+          cleanup: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -72,7 +74,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
           tags: |
@@ -84,7 +86,7 @@ jobs:
             org.opencontainers.image.source=${{ github.repositoryUrl }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -139,10 +141,12 @@ jobs:
           echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+        with:
+          cleanup: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -150,7 +154,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.vars.outputs.image }}
           tags: |
@@ -161,7 +165,7 @@ jobs:
             org.opencontainers.image.source=${{ github.repositoryUrl }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/aico-control-plane/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+# syntax=docker/dockerfile:1
+# Empty ENV names (*_API_KEY, AUTH_SECRET, …) document runtime config; real
+# values come from compose/host at start. Dummy builder placeholders are not
+# production secrets. BuildKit flags the names anyway.
+# check=skip=SecretsUsedInArgOrEnv
+
 ## Set global build ENV
 ARG NODEJS_VERSION="24"
 

--- a/apps/aico-control-plane/Dockerfile
+++ b/apps/aico-control-plane/Dockerfile
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:1
+# Dummy AUTH_SECRET / KEY_VAULTS_SECRET satisfy Next/env checks at build time
+# only; they are not production secrets. BuildKit still flags the names.
+# check=skip=SecretsUsedInArgOrEnv
+
 # Panachat control-plane image (operator UI + Hono on :3020).
 # Build from repo root:
 #   docker build -f apps/aico-control-plane/Dockerfile -t panachat-control-plane .


### PR DESCRIPTION
## Summary

- Skip BuildKit `SecretsUsedInArgOrEnv` on `Dockerfile` and `apps/aico-control-plane/Dockerfile`. Empty `*_API_KEY` / `AUTH_SECRET` names document runtime config; dummy `use-for-build` values are not production secrets.
- Bump canary/preview Docker actions to Node 24 runtimes: `setup-buildx-action@v4`, `login-action@v4`, `metadata-action@v6`, `build-push-action@v7`.
- Set `cleanup: false` on Buildx so the post-job `failed to remove one or more builders` noise stops.

## Test plan

- [ ] After merge, next canary image job should not annotate `SecretsUsedInArgOrEnv` or Node 20 deprecation for those Docker actions
- [ ] Confirm images still push to GHCR as `canary` / SHA tags
- [x] No tests needed (Dockerfile check directive + workflow pins)

## Related Issue

Fixes #285
Plane: [AICO-172](https://plane.panafor.com/panaforai/browse/AICO-172)


Made with [Cursor](https://cursor.com)