### PR TITLE
🐛 fix(deploy): pin DATABASE_DRIVER=node for compose Postgres

### DIFF
--- a/docker-compose/deploy/docker-compose.aico.control-plane.override.yml
+++ b/docker-compose/deploy/docker-compose.aico.control-plane.override.yml
@@ -44,6 +44,8 @@ services:
       OPENROUTER_MANAGEMENT_API_KEY: ${OPENROUTER_MANAGEMENT_API_KEY:-}
       # Prefer the compose network DB/Redis, not host-only URLs from repo .env
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${LOBE_DB_NAME}
+      # env_file can leak DATABASE_DRIVER=neon; Neon WS fails against compose Postgres.
+      DATABASE_DRIVER: node
       REDIS_URL: redis://redis:6379
       REDIS_PREFIX: ${REDIS_PREFIX:-lobechat}
       REDIS_TLS: '0'

--- a/docker-compose/deploy/docker-compose.panachat.yml
+++ b/docker-compose/deploy/docker-compose.panachat.yml
@@ -34,6 +34,8 @@ services:
         condition: service_completed_successfully
     environment:
       - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}'
+      # env_file can leak DATABASE_DRIVER=neon; Neon WS fails against compose Postgres.
+      - 'DATABASE_DRIVER=node'
       - 'INTERNAL_APP_URL=http://localhost:3210'
       - 'S3_ENDPOINT=${S3_ENDPOINT}'
       - 'S3_INTERNAL_ENDPOINT=http://rustfs:9000'
@@ -78,6 +80,8 @@ services:
         condition: service_completed_successfully
     environment:
       - 'DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}'
+      # env_file can leak DATABASE_DRIVER=neon; Neon WS fails against compose Postgres.
+      - 'DATABASE_DRIVER=node'
       - 'INTERNAL_APP_URL=http://localhost:3210'
       - 'S3_ENDPOINT=${S3_ENDPOINT}'
       - 'S3_INTERNAL_ENDPOINT=http://rustfs:9000'
@@ -121,6 +125,8 @@ services:
       AICO_CONTROL_PLANE_SERVICE_TOKEN: ${AICO_CONTROL_PLANE_SERVICE_TOKEN:-}
       OPENROUTER_MANAGEMENT_API_KEY: ${OPENROUTER_MANAGEMENT_API_KEY:-}
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@postgresql:5432/${PANACHAT_DB_NAME}
+      # env_file can leak DATABASE_DRIVER=neon; Neon WS fails against compose Postgres.
+      DATABASE_DRIVER: node
       REDIS_URL: redis://redis:6379
       REDIS_PREFIX: ${REDIS_PREFIX:-panachat}
       REDIS_TLS: '0'


### PR DESCRIPTION
<!-- Brief and heads-up -->

Pin `DATABASE_DRIVER: node` on Panachat blue/green, control-plane, and moz control-plane override so compose `environment` wins over `env_file`. Neon WebSockets fail against local Postgres.

| Before | After |
| ------ | ----- |
| Compose could inherit `DATABASE_DRIVER=neon` from repo `.env` | Compose Postgres always uses the node driver |

#### Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Compose env pin only; no application code.

#### 🔗 Related Issue

Fixes #287

Plane: [AICO-173](https://plane.panafor.com/panaforai/browse/AICO-173)

Made with [Cursor](https://cursor.com)