### PR TITLE
🐛 fix: refresh Aico wallet balance after managed usage

### DIFF
--- a/src/features/AicoBilling/cacheKeys.ts
+++ b/src/features/AicoBilling/cacheKeys.ts
@@ -1,0 +1,2 @@
+export const AICO_BILLING_SOURCES_SWR_KEY = 'aico-billing-sources';
+export const AICO_MY_WALLET_SWR_KEY = 'aico-my-wallet';

--- a/src/features/AicoBilling/index.ts
+++ b/src/features/AicoBilling/index.ts
@@ -1,4 +1,5 @@
 export { default as BillingSourceSwitcher } from './BillingSourceSwitcher';
+export { AICO_BILLING_SOURCES_SWR_KEY, AICO_MY_WALLET_SWR_KEY } from './cacheKeys';
 export {
   FUNDS_BLOCKED_SOUND_STORAGE_KEY,
   FUNDS_BLOCKED_SOUND_TOGGLE_CODE,
@@ -10,6 +11,7 @@ export {
   useFundsBlockedSoundEnabled,
 } from './fundsBlockedSoundFlag';
 export { FUNDS_BLOCKED_SOUND_URL, playFundsBlockedSound } from './playFundsBlockedSound';
+export { refreshAicoBillingBalance } from './refreshAicoBillingBalance';
 export {
   assertAicoBillingAllowsChat,
   resolveAicoBillingForRequest,
@@ -31,5 +33,5 @@ export {
   preferenceToBillingContext,
 } from './types';
 export { useAicoBillingChatGate } from './useAicoBillingChatGate';
-export { AICO_BILLING_SOURCES_SWR_KEY, useAicoBillingSources } from './useAicoBillingSources';
+export { useAicoBillingSources } from './useAicoBillingSources';
 export { useFundsBlockedComposerCue } from './useFundsBlockedComposerCue';

--- a/src/features/AicoBilling/refreshAicoBillingBalance.test.ts
+++ b/src/features/AicoBilling/refreshAicoBillingBalance.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mutate } from '@/libs/swr';
+
+import { AICO_BILLING_SOURCES_SWR_KEY, AICO_MY_WALLET_SWR_KEY } from './cacheKeys';
+import { refreshAicoBillingBalance } from './refreshAicoBillingBalance';
+import type { AicoBillingSourcesResponse } from './types';
+
+vi.mock('@/libs/swr', () => ({ mutate: vi.fn() }));
+
+const billingSources: AicoBillingSourcesResponse = {
+  preferredBillingSource: 'personal',
+  preferredOrganizationId: null,
+  sources: [
+    {
+      hasManagedKey: true,
+      isActive: true,
+      remainingMicroUsd: '2000000',
+      remainingUsd: '2.000000',
+      source: 'personal',
+    },
+    {
+      hasManagedKey: true,
+      isActive: true,
+      organizationId: 'org-1',
+      organizationName: 'One',
+      remainingMicroUsd: '5000000',
+      remainingUsd: '5.000000',
+      renewalBlocked: false,
+      source: 'organization',
+    },
+  ],
+  trialActive: false,
+  trialAvailable: false,
+};
+
+describe('refreshAicoBillingBalance', () => {
+  beforeEach(() => {
+    vi.mocked(mutate).mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates the selected source immediately before authoritative revalidation', async () => {
+    vi.useFakeTimers();
+
+    await refreshAicoBillingBalance({ billingContext: { source: 'personal' }, costUsd: 0.25 });
+
+    const optimisticUpdater = vi.mocked(mutate).mock.calls[0][1] as (
+      data: AicoBillingSourcesResponse,
+    ) => AicoBillingSourcesResponse;
+    expect(optimisticUpdater).toBeTypeOf('function');
+    expect(optimisticUpdater(billingSources)).toEqual({
+      ...billingSources,
+      sources: [
+        {
+          ...billingSources.sources[0],
+          remainingMicroUsd: '1750000',
+          remainingUsd: '1.750000',
+        },
+        billingSources.sources[1],
+      ],
+    });
+    expect(mutate).toHaveBeenNthCalledWith(1, AICO_BILLING_SOURCES_SWR_KEY, expect.any(Function), {
+      revalidate: false,
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    await vi.runAllTimersAsync();
+
+    expect(mutate).toHaveBeenNthCalledWith(2, AICO_BILLING_SOURCES_SWR_KEY);
+    expect(mutate).toHaveBeenNthCalledWith(3, AICO_MY_WALLET_SWR_KEY);
+  });
+
+  it('revalidates both balance caches when no optimistic cost is available', async () => {
+    await refreshAicoBillingBalance();
+
+    expect(mutate).toHaveBeenCalledTimes(2);
+    expect(mutate).toHaveBeenCalledWith(AICO_BILLING_SOURCES_SWR_KEY);
+    expect(mutate).toHaveBeenCalledWith(AICO_MY_WALLET_SWR_KEY);
+  });
+});

--- a/src/features/AicoBilling/refreshAicoBillingBalance.ts
+++ b/src/features/AicoBilling/refreshAicoBillingBalance.ts
@@ -1,0 +1,80 @@
+import { mutate } from '@/libs/swr';
+
+import { AICO_BILLING_SOURCES_SWR_KEY, AICO_MY_WALLET_SWR_KEY } from './cacheKeys';
+import type { AicoBillingContext, AicoBillingSourcesResponse } from './types';
+
+const BILLING_RECONCILE_DELAY_MS = 1500;
+
+interface RefreshAicoBillingBalanceOptions {
+  billingContext?: AicoBillingContext;
+  costUsd?: number;
+}
+
+const applyOptimisticDebit = (
+  data: AicoBillingSourcesResponse | undefined,
+  billingContext: AicoBillingContext,
+  costMicroUsd: number,
+): AicoBillingSourcesResponse | undefined => {
+  if (!data) return data;
+
+  return {
+    ...data,
+    sources: data.sources.map((source) => {
+      const isSelected =
+        billingContext.source === 'personal'
+          ? source.source === 'personal'
+          : source.source === 'organization' &&
+            source.organizationId === billingContext.organizationId;
+      if (!isSelected) return source;
+
+      const remainingMicroUsd = Number(source.remainingMicroUsd);
+      if (!Number.isSafeInteger(remainingMicroUsd)) return source;
+
+      const nextRemainingMicroUsd = Math.max(0, remainingMicroUsd - costMicroUsd);
+
+      return {
+        ...source,
+        remainingMicroUsd: String(nextRemainingMicroUsd),
+        remainingUsd: (nextRemainingMicroUsd / 1_000_000).toFixed(6),
+      };
+    }),
+  };
+};
+
+/**
+ * Keep every visible Aico balance coherent after managed usage.
+ *
+ * Chat can apply the stream's reported cost immediately, then both caches are
+ * revalidated against OpenRouter/server state. Async generation has no client-side
+ * cost until completion, so callers trigger the authoritative refresh when the
+ * generation task reaches a terminal state.
+ */
+export const refreshAicoBillingBalance = async (
+  options: RefreshAicoBillingBalanceOptions = {},
+): Promise<void> => {
+  const { billingContext, costUsd } = options;
+  const costMicroUsd = Math.round((costUsd ?? 0) * 1_000_000);
+  const revalidate = async () => {
+    await Promise.allSettled([
+      mutate(AICO_BILLING_SOURCES_SWR_KEY),
+      mutate(AICO_MY_WALLET_SWR_KEY),
+    ]);
+  };
+
+  if (billingContext && Number.isSafeInteger(costMicroUsd) && costMicroUsd > 0) {
+    await mutate(
+      AICO_BILLING_SOURCES_SWR_KEY,
+      (data: AicoBillingSourcesResponse | undefined) =>
+        applyOptimisticDebit(data, billingContext, costMicroUsd),
+      { revalidate: false },
+    );
+
+    // OpenRouter may expose the previous remaining amount for a short window
+    // after its stream closes. Keep the optimistic value stable, then reconcile
+    // once settlement has had a chance to land instead of snapping backward.
+    setTimeout(() => void revalidate(), BILLING_RECONCILE_DELAY_MS);
+    return;
+  }
+
+  await revalidate();
+};

--- a/src/features/AicoBilling/useAicoBillingSources.ts
+++ b/src/features/AicoBilling/useAicoBillingSources.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect } from 'react';
 import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
 
+import { AICO_BILLING_SOURCES_SWR_KEY } from './cacheKeys';
 import { useAicoBillingStore } from './store';
 import {
   type AicoBillingContext,
@@ -13,8 +14,6 @@ import {
   isSameBillingContext,
   preferenceToBillingContext,
 } from './types';
-
-export const AICO_BILLING_SOURCES_SWR_KEY = 'aico-billing-sources';
 
 export const useAicoBillingSources = () => {
   const context = useAicoBillingStore((s) => s.context);

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -12,9 +12,9 @@ import { Link } from 'react-router';
 
 import { toastAicoError } from '@/business/client/resolveAicoErrorMessage';
 import StatisticCard from '@/components/StatisticCard';
+import type { AicoBillingContext, AicoBillingSource } from '@/features/AicoBilling';
 import {
-  type AicoBillingContext,
-  type AicoBillingSource,
+  AICO_MY_WALLET_SWR_KEY,
   formatRemainingUsd,
   useAicoBillingSources,
 } from '@/features/AicoBilling';
@@ -97,7 +97,7 @@ export const AicoWallet = () => {
     Boolean(userProfileSelectors.userProfile(s)?.phoneNumberVerified),
   );
 
-  const { data: wallet, mutate: mutateWallet } = useClientDataSWR('aico-my-wallet', () =>
+  const { data: wallet, mutate: mutateWallet } = useClientDataSWR(AICO_MY_WALLET_SWR_KEY, () =>
     lambdaClient.aicoBilling.getMyWallet.query(),
   );
   const { data: fx } = useClientDataSWR('aico-fx', () =>
@@ -114,6 +114,9 @@ export const AicoWallet = () => {
   );
 
   const { canSwitch, data: billingSources, isSelected, selectSource } = useAicoBillingSources();
+  const personalRemainingUsd = billingSources?.sources.find(
+    (source) => source.source === 'personal',
+  )?.remainingUsd;
 
   return (
     <Flexbox className={styles.page} gap={20}>
@@ -129,8 +132,10 @@ export const AicoWallet = () => {
 
       <div className={styles.grid}>
         <StatisticCard
-          statistic={{ value: `$${Number(wallet?.balanceUsd ?? 0).toFixed(4)}` }}
           title={t('wallet.balanceUsd')}
+          statistic={{
+            value: `$${Number(personalRemainingUsd ?? wallet?.balanceUsd ?? 0).toFixed(4)}`,
+          }}
         />
         <StatisticCard
           statistic={{ value: Number(wallet?.balanceToman ?? 0).toLocaleString() }}

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -2,6 +2,7 @@ import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { REQUEST_TRIGGER_HEADER } from '@lobechat/const';
 import { createVisualFileRef } from '@lobechat/const/visualRef';
+import type { FetchSSEOptions } from '@lobechat/fetch-sse';
 import type { ChatStreamPayload, LobeTool, UIChatMessage } from '@lobechat/types';
 import { ChatErrorType, RequestTrigger } from '@lobechat/types';
 import { act } from '@testing-library/react';
@@ -9,6 +10,7 @@ import { type EnabledAiModel, ModelProvider } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
+import type * as AicoBillingModule from '@/features/AicoBilling';
 import { isCanUseFC } from '@/helpers/isCanUseFC';
 import * as toolEngineeringModule from '@/helpers/toolEngineering';
 import { agentDocumentService } from '@/services/agentDocument';
@@ -48,6 +50,8 @@ vi.hoisted(() => {
 const mockCreateHeaderWithAuth = vi.hoisted(() =>
   vi.fn(async ({ headers }: { headers: Record<string, string> }) => headers),
 );
+const mockAssertAicoBillingAllowsChat = vi.hoisted(() => vi.fn());
+const mockRefreshAicoBillingBalance = vi.hoisted(() => vi.fn());
 
 // Helper to compute expected date content from SystemDateProvider
 const getCurrentDateContent = () => {
@@ -125,6 +129,8 @@ afterEach(() => {
 beforeEach(async () => {
   // Reset all mocks
   vi.clearAllMocks();
+  mockAssertAicoBillingAllowsChat.mockResolvedValue(undefined);
+  mockRefreshAicoBillingBalance.mockResolvedValue(undefined);
   // 清除所有模块的缓存
   vi.resetModules();
 
@@ -160,6 +166,15 @@ vi.mock('../_auth', () => ({
 vi.mock('@/helpers/isCanUseFC', () => ({
   isCanUseFC: vi.fn(() => true), // Default to true, tests can override
 }));
+
+vi.mock('@/features/AicoBilling', async (importOriginal) => {
+  const actual = await importOriginal<typeof AicoBillingModule>();
+  return {
+    ...actual,
+    assertAicoBillingAllowsChat: mockAssertAicoBillingAllowsChat,
+    refreshAicoBillingBalance: mockRefreshAicoBillingBalance,
+  };
+});
 
 describe('ChatService', () => {
   describe('createAssistantMessage', () => {
@@ -1753,6 +1768,33 @@ describe('ChatService', () => {
       const payload = JSON.parse(mockFetchSSE.mock.calls[0][1].body);
       expect(payload).not.toHaveProperty('requestTrigger');
       expect(payload).not.toHaveProperty('metadata');
+    });
+
+    it('updates a managed wallet immediately with the final stream cost', async () => {
+      const billingContext = { source: 'personal' as const };
+      const onFinish = vi.fn();
+      mockAssertAicoBillingAllowsChat.mockResolvedValueOnce(billingContext);
+      mockFetchSSE.mockImplementationOnce(async (_url: string, fetchOptions: FetchSSEOptions) => {
+        await fetchOptions.onFinish?.('done', {
+          type: 'done',
+          usage: { cost: 0.25, totalTokens: 10 },
+        });
+        return new Response('mock response');
+      });
+
+      await chatService.getChatCompletion(
+        { messages: [], model: 'managed-model', provider: 'aico' },
+        { onFinish },
+      );
+
+      expect(onFinish).toHaveBeenCalled();
+      expect(mockRefreshAicoBillingBalance).toHaveBeenCalledWith({
+        billingContext,
+        costUsd: 0.25,
+      });
+      expect(JSON.parse(mockFetchSSE.mock.calls[0][1].body)).toMatchObject({
+        aicoBilling: billingContext,
+      });
     });
 
     it('should make a POST request with chatCompletion apiMode in non-openai provider payload', async () => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -500,25 +500,21 @@ class ChatService {
 
     // Managed OpenRouter/Aico chat must send an explicit billing context so the
     // server can pick the personal vs org key (credits are never pooled).
-    const { AICO_BILLING_SOURCES_SWR_KEY, assertAicoBillingAllowsChat } =
+    const { assertAicoBillingAllowsChat, refreshAicoBillingBalance } =
       await import('@/features/AicoBilling');
     const aicoBilling = await assertAicoBillingAllowsChat(provider);
     const requestBody = aicoBilling ? { ...payload, aicoBilling } : payload;
 
-    const refreshBillingAfterFinish = aicoBilling
-      ? async () => {
-          const { mutate: globalMutate } = await import('@/libs/swr');
-          void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
-          void globalMutate('aico-my-wallet');
-        }
-      : undefined;
-
-    const onFinish: FetchSSEOptions['onFinish'] | undefined = refreshBillingAfterFinish
+    const onFinish: FetchSSEOptions['onFinish'] | undefined = aicoBilling
       ? async (content, context) => {
+          const refreshPromise = refreshAicoBillingBalance({
+            billingContext: aicoBilling,
+            costUsd: context.usage?.cost,
+          });
           try {
             return await options?.onFinish?.(content, context);
           } finally {
-            await refreshBillingAfterFinish();
+            await refreshPromise;
           }
         }
       : options?.onFinish;

--- a/src/services/image.ts
+++ b/src/services/image.ts
@@ -12,7 +12,7 @@ export class AiImageService {
 
     try {
       // Managed OpenRouter/Aico must send explicit billing — same contract as chat.
-      const { AICO_BILLING_SOURCES_SWR_KEY, assertAicoBillingAllowsChat } =
+      const { assertAicoBillingAllowsChat, refreshAicoBillingBalance } =
         await import('@/features/AicoBilling');
       const aicoBilling = await assertAicoBillingAllowsChat(payload.provider);
       const requestPayload = aicoBilling ? { ...payload, aicoBilling } : payload;
@@ -25,9 +25,7 @@ export class AiImageService {
       });
 
       if (aicoBilling) {
-        const { mutate: globalMutate } = await import('@/libs/swr');
-        void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
-        void globalMutate('aico-my-wallet');
+        void refreshAicoBillingBalance();
       }
 
       return result;

--- a/src/services/video.ts
+++ b/src/services/video.ts
@@ -10,7 +10,7 @@ export class AiVideoService {
     log('Creating video with payload: %O', payload);
 
     try {
-      const { AICO_BILLING_SOURCES_SWR_KEY, assertAicoBillingAllowsChat } =
+      const { assertAicoBillingAllowsChat, refreshAicoBillingBalance } =
         await import('@/features/AicoBilling');
       const aicoBilling = await assertAicoBillingAllowsChat(payload.provider);
       const requestPayload = aicoBilling ? { ...payload, aicoBilling } : payload;
@@ -23,9 +23,7 @@ export class AiVideoService {
       });
 
       if (aicoBilling) {
-        const { mutate: globalMutate } = await import('@/libs/swr');
-        void globalMutate(AICO_BILLING_SOURCES_SWR_KEY);
-        void globalMutate('aico-my-wallet');
+        void refreshAicoBillingBalance();
       }
 
       return result;

--- a/src/store/image/slices/generationBatch/action.test.ts
+++ b/src/store/image/slices/generationBatch/action.test.ts
@@ -2,6 +2,10 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  AICO_BILLING_SOURCES_SWR_KEY,
+  AICO_MY_WALLET_SWR_KEY,
+} from '@/features/AicoBilling/cacheKeys';
 import type * as SwrModule from '@/libs/swr';
 import { mutate } from '@/libs/swr';
 import { generationService } from '@/services/generation';
@@ -434,8 +438,8 @@ describe('GenerationBatchAction', () => {
 
       vi.mocked(generationBatchService.getGenerationBatches).mockResolvedValue(batches);
 
-      const { result } = renderHook(() => {
-        const store = useImageStore();
+      renderHook(() => {
+        useImageStore();
 
         // Simulate the onSuccess callback behavior directly
         React.useEffect(() => {
@@ -491,6 +495,50 @@ describe('GenerationBatchAction', () => {
       // When disabled, SWR returns an object with undefined data
       expect(result.current.data).toBeUndefined();
       expect(generationService.getGenerationStatus).not.toHaveBeenCalled();
+    });
+
+    it('refreshes the managed wallet as soon as generation reaches a terminal status', async () => {
+      const topicId = 'gt_wallet_refresh';
+      const generationId = 'gen_wallet_refresh';
+      const asyncTaskId = 'task_wallet_refresh';
+
+      useImageStore.setState({
+        activeGenerationTopicId: topicId,
+        generationBatchesMap: {
+          [topicId]: [
+            {
+              createdAt: new Date(),
+              generations: [
+                {
+                  asyncTaskId,
+                  createdAt: new Date(),
+                  id: generationId,
+                  seed: null,
+                  task: { id: asyncTaskId, status: AsyncTaskStatus.Pending },
+                },
+              ],
+              id: 'batch_wallet_refresh',
+              model: 'managed-image-model',
+              prompt: 'test',
+              provider: 'aico',
+            },
+          ],
+        },
+      });
+      vi.mocked(generationService.getGenerationStatus).mockResolvedValue({
+        error: null,
+        generation: null,
+        status: AsyncTaskStatus.Error,
+      });
+
+      renderHook(() =>
+        useImageStore().useCheckGenerationStatus(generationId, asyncTaskId, topicId, true),
+      );
+
+      await waitFor(() => {
+        expect(mutate).toHaveBeenCalledWith(AICO_BILLING_SOURCES_SWR_KEY);
+        expect(mutate).toHaveBeenCalledWith(AICO_MY_WALLET_SWR_KEY);
+      });
     });
   });
 });

--- a/src/store/image/slices/generationBatch/action.ts
+++ b/src/store/image/slices/generationBatch/action.ts
@@ -2,6 +2,8 @@ import { isEqual } from 'es-toolkit/compat';
 import { useRef } from 'react';
 import { type SWRResponse } from 'swr';
 
+import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
+import { refreshAicoBillingBalance } from '@/features/AicoBilling/refreshAicoBillingBalance';
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { imageKeys } from '@/libs/swr/keys';
 import { type GetGenerationStatusResult } from '@/server/routers/lambda/generation';
@@ -292,8 +294,14 @@ export class GenerationBatchActionImpl {
               }
             }
 
-            // Refresh generation batches after success or failure
-            await this.#get().refreshGenerationBatches();
+            // Refresh generation data and reconcile the managed wallet only after
+            // the async charge/refund has reached its terminal boundary.
+            await Promise.all([
+              this.#get().refreshGenerationBatches(),
+              isAicoManagedRuntimeProvider(targetBatch.provider)
+                ? refreshAicoBillingBalance()
+                : Promise.resolve(),
+            ]);
           }
         },
       },

--- a/src/store/video/slices/generationBatch/action.ts
+++ b/src/store/video/slices/generationBatch/action.ts
@@ -2,6 +2,8 @@ import { isEqual } from 'es-toolkit/compat';
 import { useRef } from 'react';
 import type { SWRResponse } from 'swr';
 
+import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
+import { refreshAicoBillingBalance } from '@/features/AicoBilling/refreshAicoBillingBalance';
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { videoKeys } from '@/libs/swr/keys';
 import { type GetGenerationStatusResult } from '@/server/routers/lambda/generation';
@@ -210,7 +212,12 @@ export class GenerationBatchActionImpl {
               }
             }
 
-            await this.#get().refreshGenerationBatches();
+            await Promise.all([
+              this.#get().refreshGenerationBatches(),
+              isAicoManagedRuntimeProvider(targetBatch.provider)
+                ? refreshAicoBillingBalance()
+                : Promise.resolve(),
+            ]);
           }
         },
         refreshInterval: (data: GetGenerationStatusResult | undefined) => {


### PR DESCRIPTION
## Summary

- Apply the final managed-chat stream cost optimistically so the visible Aico balance updates as soon as streaming completes.
- Reconcile billing sources and wallet data after provider settlement, and refresh asynchronous image/video charges at terminal task status.
- Display the personal spendable USD amount on the wallet card while keeping managed-provider refreshes scoped to Aico billing.

## UI

No layout change. This PR changes balance timing and the USD value source, so screenshots are not applicable.

#### Test

- `bunx vitest run --silent='passed-only' src/features/AicoBilling/refreshAicoBillingBalance.test.ts src/services/chat/chat.test.ts src/store/image/slices/generationBatch/action.test.ts` — 3 files, 62 tests passed.
- `bun --no-env-file run check --lint <13 changed files>` — 13 files lint clean.
- `git diff --check` — clean.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #289

Plane: pending because neither the Plane connector nor a connected browser is available in the shipping session. The AICO work item and cross-links must be added during closeout.
