### PR TITLE
🐛 fix: rebrand chat prompts and fix generation billing bugs

### DIFF
--- a/apps/server/src/routers/async/image.ts
+++ b/apps/server/src/routers/async/image.ts
@@ -250,9 +250,14 @@ export const imageRouter = router({
           checkAbortSignal(signal);
 
           log('Updating generation asset and file');
+          const costUsd =
+            typeof modelUsage?.cost === 'number' && Number.isFinite(modelUsage.cost)
+              ? modelUsage.cost
+              : undefined;
           await generationModel.createAssetAndFile(
             generationId,
             {
+              ...(typeof costUsd === 'number' ? { costUsd } : {}),
               height: height ?? image.height,
               // If imageUrl is base64 data, use uploadedImageUrl instead to avoid storing large base64 in DB
               originalUrl: imageUrl.startsWith('data:') ? uploadedImageUrl : imageUrl,

--- a/apps/server/src/routers/async/video.ts
+++ b/apps/server/src/routers/async/video.ts
@@ -63,7 +63,7 @@ async function pollUntilCompletion(
   modelRuntime: any,
   inferenceId: string,
   signal: AbortSignal,
-): Promise<{ headers?: Record<string, string>; videoUrl: string } | null> {
+): Promise<{ costUsd?: number; headers?: Record<string, string>; videoUrl: string } | null> {
   const maxRetries = 120;
   const pollingInterval = 5000;
 
@@ -77,7 +77,11 @@ async function pollUntilCompletion(
 
       if (result.status === 'success') {
         log('Video generation succeeded for inferenceId: %s', inferenceId);
-        return { headers: result.headers, videoUrl: result.videoUrl };
+        return {
+          ...(typeof result.costUsd === 'number' ? { costUsd: result.costUsd } : {}),
+          headers: result.headers,
+          videoUrl: result.videoUrl,
+        };
       }
 
       if (result.status === 'failed') {
@@ -202,6 +206,7 @@ export const videoRouter = router({
         await generationModel.createAssetAndFile(
           generationId,
           {
+            ...(typeof pollResult.costUsd === 'number' ? { costUsd: pollResult.costUsd } : {}),
             coverUrl: processResult.coverKey,
             duration: processResult.duration,
             height: processResult.height,

--- a/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
@@ -36,13 +36,17 @@ vi.mock('@/server/services/sms', () => ({
 
 const {
   disableAllOrgMemberKeysMock,
+  disableUserKeyMock,
   ensureMemberKeyMock,
+  ensureUserKeyMock,
   getUserRemainingMock,
   reclaimMemberKeyMock,
   syncMemberCycleUsageMock,
 } = vi.hoisted(() => ({
   disableAllOrgMemberKeysMock: vi.fn().mockResolvedValue([]),
+  disableUserKeyMock: vi.fn().mockResolvedValue(null),
   ensureMemberKeyMock: vi.fn().mockResolvedValue({ created: false, keyId: null }),
+  ensureUserKeyMock: vi.fn().mockResolvedValue({ created: false, keyId: null }),
   getUserRemainingMock: vi.fn().mockResolvedValue({ remainingMicroUsd: 0, usageMicroUsd: null }),
   reclaimMemberKeyMock: vi.fn().mockResolvedValue(null),
   syncMemberCycleUsageMock: vi.fn().mockResolvedValue(null),
@@ -50,8 +54,9 @@ const {
 
 vi.mock('@/server/services/openrouter/keyService', () => ({
   AicoOpenRouterKeyService: class {
-    ensureUserKey = vi.fn().mockResolvedValue({ created: false, keyId: null });
+    ensureUserKey = ensureUserKeyMock;
     ensureMemberKey = ensureMemberKeyMock;
+    disableUserKey = disableUserKeyMock;
     disableMemberKey = vi.fn().mockResolvedValue(null);
     disableAllOrgMemberKeys = disableAllOrgMemberKeysMock;
     getUserRemaining = getUserRemainingMock;
@@ -109,6 +114,8 @@ const cleanup = async () => {
 
 beforeEach(async () => {
   disableAllOrgMemberKeysMock.mockClear();
+  disableUserKeyMock.mockClear();
+  ensureUserKeyMock.mockClear();
   reclaimMemberKeyMock.mockClear();
   reclaimMemberKeyMock.mockResolvedValue(null);
   testDB = await getTestDB();
@@ -357,6 +364,17 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     const wallet = wallets.find((w) => w.userId === strangerId);
     expect(wallet).toBeTruthy();
     expect(Number(wallet!.balanceToman)).toBe(50_000);
+  });
+
+  it('reactivateUser re-enables the managed OpenRouter key', async () => {
+    const platformCaller = platformAdminRouter.createCaller(createAdminContext(operatorId));
+
+    await platformCaller.deactivateUser({ reason: 'abuse', userId: strangerId });
+    expect(disableUserKeyMock).toHaveBeenCalledWith(strangerId);
+
+    ensureUserKeyMock.mockClear();
+    await platformCaller.reactivateUser({ userId: strangerId });
+    expect(ensureUserKeyMock).toHaveBeenCalledWith(strangerId);
   });
 
   it('platform admin can suspend; member procedures still reachable on model (enforcement gap covered elsewhere)', async () => {

--- a/apps/server/src/routers/lambda/platformAdmin.ts
+++ b/apps/server/src/routers/lambda/platformAdmin.ts
@@ -656,6 +656,9 @@ export const platformAdminRouter = router({
         .set({ isActive: true })
         .where(eq(userWallets.userId, input.userId));
 
+      const keyService = new AicoOpenRouterKeyService(ctx.serverDB);
+      await keyService.ensureUserKey(input.userId);
+
       return { ok: true as const };
     }),
 

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -355,7 +355,7 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
     // Verify createOperation was called with agentConfig containing the runtime systemRole
     expect(mockCreateOperation).toHaveBeenCalledTimes(1);
     const callArgs = mockCreateOperation.mock.calls[0][0];
-    expect(callArgs.agentConfig.systemRole).toContain('You are Lobe');
+    expect(callArgs.agentConfig.systemRole).toContain('You are Panachat AI');
     // Model identity is injected by ModelInfoProvider now, not the `{{model}}`
     // template placeholder; `{{date}}` still proves the runtime template merged.
     expect(callArgs.agentConfig.systemRole).toContain('{{date}}');

--- a/apps/server/src/services/aico/generationBilling.test.ts
+++ b/apps/server/src/services/aico/generationBilling.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveManagedGenerationBilling, toManagedGenerationModelId } from './generationBilling';
+import {
+  filterManagedGenerationProviders,
+  resolveManagedGenerationBilling,
+  resolvePreferredGenerationBilling,
+  toManagedGenerationModelId,
+} from './generationBilling';
 import { AicoManagedPolicyError } from './managedPolicy';
 
 describe('toManagedGenerationModelId', () => {
@@ -46,5 +51,44 @@ describe('resolveManagedGenerationBilling', () => {
         provider: 'openrouter',
       }),
     ).toEqual({ organizationId: 'org_1', source: 'organization' });
+  });
+});
+
+describe('resolvePreferredGenerationBilling', () => {
+  it('uses the stored organization preference when present', async () => {
+    await expect(
+      resolvePreferredGenerationBilling(
+        async () => ({
+          preferredBillingSource: 'organization',
+          preferredOrganizationId: 'org_9',
+        }),
+        'user-1',
+      ),
+    ).resolves.toEqual({ organizationId: 'org_9', source: 'organization' });
+  });
+
+  it('falls back to personal when the org preference is incomplete', async () => {
+    await expect(
+      resolvePreferredGenerationBilling(
+        async () => ({
+          preferredBillingSource: 'organization',
+          preferredOrganizationId: null,
+        }),
+        'user-1',
+      ),
+    ).resolves.toEqual({ source: 'personal' });
+  });
+});
+
+describe('filterManagedGenerationProviders', () => {
+  it('keeps only wallet-backed providers', () => {
+    expect(
+      filterManagedGenerationProviders([
+        { id: 'google' },
+        { id: 'openrouter' },
+        { id: 'aico' },
+        { id: 'openai' },
+      ]),
+    ).toEqual([{ id: 'openrouter' }, { id: 'aico' }]);
   });
 });

--- a/apps/server/src/services/aico/generationBilling.ts
+++ b/apps/server/src/services/aico/generationBilling.ts
@@ -40,3 +40,31 @@ export const managedPolicyErrorToTrpc = (error: AicoManagedPolicyError) => ({
   code: 'BAD_REQUEST' as const,
   message: error.code || error.message,
 });
+
+/**
+ * Billing context for server-side generation tools that have no client header.
+ * Uses the user's stored wallet preference — not a first-match inference.
+ */
+export const resolvePreferredGenerationBilling = async (
+  getWallet: (userId: string) => Promise<{
+    preferredBillingSource: string | null;
+    preferredOrganizationId: string | null;
+  } | null>,
+  userId: string,
+): Promise<AicoBillingContext> => {
+  const wallet = await getWallet(userId);
+  if (
+    wallet?.preferredBillingSource === 'organization' &&
+    typeof wallet.preferredOrganizationId === 'string' &&
+    wallet.preferredOrganizationId.trim()
+  ) {
+    return { organizationId: wallet.preferredOrganizationId.trim(), source: 'organization' };
+  }
+  return { source: 'personal' };
+};
+
+export const isManagedGenerationProvider = (provider: string): boolean =>
+  AicoManagedPolicy.isManagedProvider(provider);
+
+export const filterManagedGenerationProviders = <T extends { id: string }>(providers: T[]): T[] =>
+  providers.filter((item) => isManagedGenerationProvider(item.id));

--- a/apps/server/src/services/generation/videoBackgroundPolling.ts
+++ b/apps/server/src/services/generation/videoBackgroundPolling.ts
@@ -88,6 +88,7 @@ export async function processBackgroundVideoPolling(
     });
 
     const asset: VideoGenerationAsset = {
+      ...(typeof pollResult.costUsd === 'number' ? { costUsd: pollResult.costUsd } : {}),
       coverUrl: processResult.coverKey,
       duration: processResult.duration,
       height: processResult.height,
@@ -161,7 +162,7 @@ export async function processBackgroundVideoPolling(
 async function pollUntilCompletion(
   modelRuntime: any,
   inferenceId: string,
-): Promise<{ headers?: Record<string, string>; videoUrl: string } | null> {
+): Promise<{ costUsd?: number; headers?: Record<string, string>; videoUrl: string } | null> {
   const maxRetries = 120;
   const pollingInterval = 5000;
 
@@ -173,7 +174,11 @@ async function pollUntilCompletion(
 
       if (result.status === 'success') {
         log('Video generation succeeded for task: %s', inferenceId);
-        return { headers: result.headers, videoUrl: result.videoUrl };
+        return {
+          ...(typeof result.costUsd === 'number' ? { costUsd: result.costUsd } : {}),
+          headers: result.headers,
+          videoUrl: result.videoUrl,
+        };
       }
 
       if (result.status === 'failed') {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/imageGeneration.test.ts
@@ -10,6 +10,16 @@ const callerMocks = vi.hoisted(() => ({
   image: vi.fn(() => ({})),
 }));
 
+const billingMocks = vi.hoisted(() => ({
+  getOrCreateUserWallet: vi.fn(),
+}));
+
+vi.mock('@/database/models/aicoBilling', () => ({
+  AicoBillingModel: vi.fn(() => ({
+    getOrCreateUserWallet: billingMocks.getOrCreateUserWallet,
+  })),
+}));
+
 vi.mock('@/server/routers/lambda/aiModel', () => ({
   aiModelRouter: { createCaller: callerMocks.aiModel },
 }));
@@ -26,6 +36,14 @@ vi.mock('@/server/routers/lambda/image', () => ({
   imageRouter: { createCaller: callerMocks.image },
 }));
 
+const factoryContext = {
+  clientIp: '203.0.113.7',
+  serverDB: {} as never,
+  toolManifestMap: {},
+  userId: 'user-1',
+  workspaceId: 'workspace-1',
+};
+
 describe('imageGenerationRuntime', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,15 +52,14 @@ describe('imageGenerationRuntime', () => {
     callerMocks.generation.mockReturnValue({});
     callerMocks.generationTopic.mockReturnValue({});
     callerMocks.image.mockReturnValue({});
+    billingMocks.getOrCreateUserWallet.mockResolvedValue({
+      preferredBillingSource: 'personal',
+      preferredOrganizationId: null,
+    });
   });
 
-  it('passes the request and workspace scope to every router caller', () => {
-    imageGenerationRuntime.factory({
-      clientIp: '203.0.113.7',
-      toolManifestMap: {},
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
-    });
+  it('passes the request and workspace scope to every router caller', async () => {
+    await imageGenerationRuntime.factory(factoryContext);
 
     const callerContext = {
       clientIp: '203.0.113.7',
@@ -61,7 +78,7 @@ describe('imageGenerationRuntime', () => {
     callerMocks.generationTopic.mockReturnValue({ createTopic });
     callerMocks.aiProvider.mockReturnValue({
       getAiProviderRuntimeState: vi.fn().mockResolvedValue({
-        enabledImageAiProviders: [{ id: 'provider-1', name: 'Provider 1' }],
+        enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
       }),
     });
     callerMocks.aiModel.mockReturnValue({
@@ -77,11 +94,9 @@ describe('imageGenerationRuntime', () => {
       }),
     });
 
-    const runtime = imageGenerationRuntime.factory({
+    const runtime = await imageGenerationRuntime.factory({
+      ...factoryContext,
       agentVisibility: 'public',
-      toolManifestMap: {},
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
     });
 
     const result = await runtime.generateImage({
@@ -97,10 +112,49 @@ describe('imageGenerationRuntime', () => {
     });
   });
 
+  it('passes stored wallet billing into createImage', async () => {
+    const createImage = vi.fn().mockResolvedValue({
+      data: {
+        batch: { id: 'batch-1' },
+        generations: [{ asyncTaskId: 'task-1', id: 'generation-1' }],
+      },
+      success: true,
+    });
+    billingMocks.getOrCreateUserWallet.mockResolvedValue({
+      preferredBillingSource: 'organization',
+      preferredOrganizationId: 'org_9',
+    });
+    callerMocks.generationTopic.mockReturnValue({
+      createTopic: vi.fn().mockResolvedValue('topic-1'),
+    });
+    callerMocks.aiProvider.mockReturnValue({
+      getAiProviderRuntimeState: vi.fn().mockResolvedValue({
+        enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
+      }),
+    });
+    callerMocks.aiModel.mockReturnValue({
+      getAiProviderModelList: vi.fn().mockResolvedValue([{ id: 'or-image' }]),
+    });
+    callerMocks.image.mockReturnValue({ createImage });
+
+    const runtime = await imageGenerationRuntime.factory(factoryContext);
+
+    await runtime.generateImage({
+      prompt: 'Wallet-backed photo',
+      waitUntilComplete: false,
+    });
+
+    expect(createImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aicoBilling: { organizationId: 'org_9', source: 'organization' },
+      }),
+    );
+  });
+
   it('preserves model descriptions and complete parameter schemas', async () => {
     callerMocks.aiProvider.mockReturnValue({
       getAiProviderRuntimeState: vi.fn().mockResolvedValue({
-        enabledImageAiProviders: [{ id: 'provider-1', name: 'Provider 1' }],
+        enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
       }),
     });
     callerMocks.aiModel.mockReturnValue({
@@ -122,13 +176,9 @@ describe('imageGenerationRuntime', () => {
       ]),
     });
 
-    const runtime = imageGenerationRuntime.factory({
-      toolManifestMap: {},
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
-    });
+    const runtime = await imageGenerationRuntime.factory(factoryContext);
 
-    const result = await runtime.listImageModels({ provider: 'provider-1' });
+    const result = await runtime.listImageModels({ provider: 'openrouter' });
 
     expect(result.success).toBe(true);
     expect(result.content).toContain('Description: A fast image generation and editing model.');
@@ -153,8 +203,8 @@ describe('imageGenerationRuntime', () => {
   it('does not list models hidden for the current user', async () => {
     callerMocks.aiProvider.mockReturnValue({
       getAiProviderRuntimeState: vi.fn().mockResolvedValue({
-        enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
-        hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'lobehub' }],
+        enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
+        hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'openrouter' }],
       }),
     });
     callerMocks.aiModel.mockReturnValue({
@@ -164,17 +214,38 @@ describe('imageGenerationRuntime', () => {
       }),
     });
 
-    const runtime = imageGenerationRuntime.factory({
-      toolManifestMap: {},
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
-    });
+    const runtime = await imageGenerationRuntime.factory(factoryContext);
 
-    const result = await runtime.listImageModels({ limit: 1, provider: 'lobehub' });
+    const result = await runtime.listImageModels({ limit: 1, provider: 'openrouter' });
 
     expect(result).toMatchObject({
       state: {
-        providers: [{ id: 'lobehub', models: [{ id: 'visible-image' }] }],
+        providers: [{ id: 'openrouter', models: [{ id: 'visible-image' }] }],
+        totalModels: 1,
+      },
+      success: true,
+    });
+  });
+
+  it('omits unmanaged image providers from the chat tool list', async () => {
+    callerMocks.aiProvider.mockReturnValue({
+      getAiProviderRuntimeState: vi.fn().mockResolvedValue({
+        enabledImageAiProviders: [
+          { id: 'google', name: 'Google' },
+          { id: 'openrouter', name: 'OpenRouter' },
+        ],
+      }),
+    });
+    callerMocks.aiModel.mockReturnValue({
+      getAiProviderModelList: vi.fn().mockResolvedValue([{ id: 'or-image' }]),
+    });
+
+    const runtime = await imageGenerationRuntime.factory(factoryContext);
+    const result = await runtime.listImageModels({});
+
+    expect(result).toMatchObject({
+      state: {
+        providers: [{ id: 'openrouter', models: [{ id: 'or-image' }] }],
         totalModels: 1,
       },
       success: true,
@@ -186,17 +257,13 @@ describe('imageGenerationRuntime', () => {
     callerMocks.aiModel.mockReturnValue({ getAiProviderModelList });
     callerMocks.aiProvider.mockReturnValue({
       getAiProviderRuntimeState: vi.fn().mockResolvedValue({
-        enabledImageAiProviders: [{ id: 'provider-1', name: 'Provider 1' }],
+        enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
       }),
     });
 
-    const runtime = imageGenerationRuntime.factory({
-      toolManifestMap: {},
-      userId: 'user-1',
-      workspaceId: 'workspace-1',
-    });
+    const runtime = await imageGenerationRuntime.factory(factoryContext);
 
-    const result = await runtime.listImageModels({ provider: 'provider-2' });
+    const result = await runtime.listImageModels({ provider: 'google' });
 
     expect(result).toMatchObject({
       state: { providers: [], totalModels: 0 },

--- a/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/imageGeneration.ts
@@ -3,11 +3,16 @@ import { ImageGenerationIdentifier } from '@lobechat/builtin-tool-image-generati
 import { ImageGenerationExecutionRuntime } from '@lobechat/builtin-tool-image-generation/executionRuntime';
 import type { AiProviderModelListItem } from 'model-bank';
 
+import { AicoBillingModel } from '@/database/models/aicoBilling';
 import { aiModelRouter } from '@/server/routers/lambda/aiModel';
 import { aiProviderRouter } from '@/server/routers/lambda/aiProvider';
 import { generationRouter } from '@/server/routers/lambda/generation';
 import { generationTopicRouter } from '@/server/routers/lambda/generationTopic';
 import { imageRouter } from '@/server/routers/lambda/image';
+import {
+  filterManagedGenerationProviders,
+  resolvePreferredGenerationBilling,
+} from '@/server/services/aico/generationBilling';
 import { filterHiddenProviderModels } from '@/utils/aiProvider';
 
 import { type ServerRuntimeRegistration } from './types';
@@ -22,9 +27,12 @@ const normalizeModel = (model: AiProviderModelListItem): ImageGenerationModelSum
 });
 
 export const imageGenerationRuntime: ServerRuntimeRegistration = {
-  factory: (context) => {
+  factory: async (context) => {
     if (!context.userId) {
       throw new Error('userId is required for Image Generation tool execution');
+    }
+    if (!context.serverDB) {
+      throw new Error('serverDB is required for Image Generation tool execution');
     }
 
     const callerContext = {
@@ -37,6 +45,11 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
     const generationCaller = generationRouter.createCaller(callerContext);
     const generationTopicCaller = generationTopicRouter.createCaller(callerContext);
     const imageCaller = imageRouter.createCaller(callerContext);
+    const billingModel = new AicoBillingModel(context.serverDB);
+    const aicoBilling = await resolvePreferredGenerationBilling(
+      (userId) => billingModel.getOrCreateUserWallet(userId),
+      context.userId,
+    );
 
     return new ImageGenerationExecutionRuntime({
       createGenerationTopic: (type, title) =>
@@ -47,7 +60,7 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
             ? { visibility: context.agentVisibility }
             : {}),
         }),
-      createImage: (payload) => imageCaller.createImage(payload),
+      createImage: (payload) => imageCaller.createImage({ ...payload, aicoBilling }),
       getGenerationStatus: async ({ asyncTaskId, generationId }) => {
         const result = await generationCaller.getGenerationStatus({ asyncTaskId, generationId });
         return {
@@ -58,9 +71,11 @@ export const imageGenerationRuntime: ServerRuntimeRegistration = {
       },
       listImageModels: async ({ provider, limit }) => {
         const runtimeState = await aiProviderCaller.getAiProviderRuntimeState({});
-        const enabledProviders = provider
-          ? runtimeState.enabledImageAiProviders.filter((item) => item.id === provider)
-          : runtimeState.enabledImageAiProviders;
+        const enabledProviders = filterManagedGenerationProviders(
+          provider
+            ? runtimeState.enabledImageAiProviders.filter((item) => item.id === provider)
+            : runtimeState.enabledImageAiProviders,
+        );
         const providers = await Promise.all(
           enabledProviders.map(async (item) => {
             /**

--- a/locales/en-US/image.json
+++ b/locales/en-US/image.json
@@ -48,6 +48,7 @@
   "generation.actions.seedApplyFailed": "Failed to Apply Seed",
   "generation.actions.seedCopied": "Seed Copied to Clipboard",
   "generation.actions.seedCopyFailed": "Failed to Copy Seed",
+  "generation.cost": "Cost",
   "generation.metadata.by": "by {{name}}",
   "generation.metadata.count": "{{count}} Images",
   "generation.metadata.createdAt": "Created at {{time}}",

--- a/locales/en-US/video.json
+++ b/locales/en-US/video.json
@@ -21,6 +21,7 @@
   "generation.actions.errorCopied": "Error Message Copied to Clipboard",
   "generation.actions.errorCopyFailed": "Failed to Copy Error Message",
   "generation.actions.generate": "Generate",
+  "generation.cost": "Cost",
   "generation.freeQuota.exhausted": "🎁 Free quota used up, credits will be consumed",
   "generation.freeQuota.remaining": "🎁 {{remaining}} free videos today",
   "generation.status.failed": "Generation Failed",

--- a/locales/fa-IR/image.json
+++ b/locales/fa-IR/image.json
@@ -48,6 +48,7 @@
   "generation.actions.seedApplyFailed": "اعمال بذر ناموفق بود",
   "generation.actions.seedCopied": "بذر در کلیپ‌بورد کپی شد",
   "generation.actions.seedCopyFailed": "کپی بذر ناموفق بود",
+  "generation.cost": "هزینه",
   "generation.metadata.by": "توسط {{name}}",
   "generation.metadata.count": "{{count}} تصویر",
   "generation.metadata.createdAt": "ایجاد شده در {{time}}",

--- a/locales/fa-IR/video.json
+++ b/locales/fa-IR/video.json
@@ -21,6 +21,7 @@
   "generation.actions.errorCopied": "پیام خطا در کلیپ‌بورد کپی شد",
   "generation.actions.errorCopyFailed": "کپی پیام خطا ناموفق بود",
   "generation.actions.generate": "تولید",
+  "generation.cost": "هزینه",
   "generation.freeQuota.exhausted": "🎁 سهمیه رایگان تمام شده است، از اعتبار استفاده خواهد شد",
   "generation.freeQuota.remaining": "🎁 {{remaining}} ویدیوی رایگان باقی‌مانده برای امروز",
   "generation.status.failed": "تولید ناموفق بود",

--- a/locales/fr-FR/image.json
+++ b/locales/fr-FR/image.json
@@ -48,6 +48,7 @@
   "generation.actions.seedApplyFailed": "Échec de l'application de la graine",
   "generation.actions.seedCopied": "Graine copiée dans le presse-papiers",
   "generation.actions.seedCopyFailed": "Échec de la copie de la graine",
+  "generation.cost": "Coût",
   "generation.metadata.by": "par {{name}}",
   "generation.metadata.count": "{{count}} images",
   "generation.metadata.createdAt": "Créé à {{time}}",

--- a/locales/fr-FR/video.json
+++ b/locales/fr-FR/video.json
@@ -21,6 +21,7 @@
   "generation.actions.errorCopied": "Message d'erreur copié dans le presse-papiers",
   "generation.actions.errorCopyFailed": "Échec de la copie du message d'erreur",
   "generation.actions.generate": "Générer",
+  "generation.cost": "Coût",
   "generation.freeQuota.exhausted": "🎁 Quota gratuit épuisé, des crédits seront utilisés",
   "generation.freeQuota.remaining": "🎁 {{remaining}} vidéos gratuites aujourd'hui",
   "generation.status.failed": "Échec de la génération",

--- a/locales/zh-CN/image.json
+++ b/locales/zh-CN/image.json
@@ -48,6 +48,7 @@
   "generation.actions.seedApplyFailed": "应用种子遇到了问题。你可以重试",
   "generation.actions.seedCopied": "种子已复制到剪贴板",
   "generation.actions.seedCopyFailed": "复制遇到了问题。你可以再试一次",
+  "generation.cost": "费用",
   "generation.metadata.by": "由 {{name}}",
   "generation.metadata.count": "{{count}} 张图片",
   "generation.metadata.createdAt": "创建于 {{time}}",

--- a/locales/zh-CN/video.json
+++ b/locales/zh-CN/video.json
@@ -21,6 +21,7 @@
   "generation.actions.errorCopied": "错误信息已复制到剪贴板",
   "generation.actions.errorCopyFailed": "复制错误信息失败",
   "generation.actions.generate": "生成",
+  "generation.cost": "费用",
   "generation.freeQuota.exhausted": "🎁 免费额度已用完，将开始消耗积分",
   "generation.freeQuota.remaining": "🎁 今日剩余 {{remaining}} 个免费视频",
   "generation.status.failed": "生成失败",

--- a/packages/builtin-agents/src/agents/agent-builder/systemRole.ts
+++ b/packages/builtin-agents/src/agents/agent-builder/systemRole.ts
@@ -3,7 +3,9 @@
  *
  * This agent helps users configure and optimize their AI agents through natural conversation.
  */
-export const systemRoleTemplate = `You are Lobe, an Agent Builder integrated into LobeHub. Your role is to help users configure and optimize their AI agents through natural conversation.
+import { BRANDING_INBOX_NAME, BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemRoleTemplate = `You are ${BRANDING_INBOX_NAME}, an Agent Builder integrated into ${BRANDING_NAME}. Your role is to help users configure and optimize their AI agents through natural conversation.
 
 <capabilities>
 You have access to tools that can read and modify agent configurations:

--- a/packages/builtin-agents/src/agents/group-supervisor/systemRole.ts
+++ b/packages/builtin-agents/src/agents/group-supervisor/systemRole.ts
@@ -9,7 +9,9 @@
  * - {{model}} - Current model ID (requires )
  * - {{provider}} - Current provider (requires )
  */
-export const supervisorSystemRole = `You are LobeAI, an intelligent team coordinator developed by LobeHub, powered by {{model}}. You are orchestrating the multi-agent group "{{GROUP_TITLE}}". Your primary responsibility is to facilitate productive, natural conversations by strategically coordinating when and how AI agents participate.
+import { BRANDING_INBOX_NAME, BRANDING_NAME } from '@lobechat/business-const';
+
+export const supervisorSystemRole = `You are ${BRANDING_INBOX_NAME}, an intelligent team coordinator developed by ${BRANDING_NAME}, powered by {{model}}. You are orchestrating the multi-agent group "{{GROUP_TITLE}}". Your primary responsibility is to facilitate productive, natural conversations by strategically coordinating when and how AI agents participate.
 
 <system_context>
 - Current date: {{date}}

--- a/packages/builtin-agents/src/agents/inbox/systemRole.ts
+++ b/packages/builtin-agents/src/agents/inbox/systemRole.ts
@@ -3,7 +3,11 @@
  *
  * This is the default assistant agent for general conversations.
  */
-const systemRoleTemplate = `You are Lobe, an AI Agent will help users.
+import { getLocalizedBrandingInboxName } from '@lobechat/business-const';
+
+const createSystemRoleTemplate = (
+  userLocale?: string,
+) => `You are ${getLocalizedBrandingInboxName(userLocale)}, an AI Agent will help users.
 
 Today's date: {{date}}
 
@@ -13,11 +17,13 @@ Your role is to:
 - Provide clear and concise explanations
 - Be friendly and professional in your responses
 
-Respond in the same language the user is using.`;
+Respond in the same language the user is using.
+
+This chat can generate photos via the image generation tool. It cannot generate video. If the user asks for a video, tell them to open Create → Video at /video. Do not activate skills, the \`lh\` CLI, or a sandbox to work around this.`;
 
 export const createSystemRole = (userLocale?: string) =>
   [
-    systemRoleTemplate,
+    createSystemRoleTemplate(userLocale),
     userLocale
       ? `Preferred reply language: ${userLocale}. Use this language unless the user explicitly asks to switch.`
       : '',

--- a/packages/builtin-skills/package.json
+++ b/packages/builtin-skills/package.json
@@ -8,7 +8,8 @@
   },
   "main": "./src/index.ts",
   "dependencies": {
-    "@lobechat/artifact-template": "workspace:*"
+    "@lobechat/artifact-template": "workspace:*",
+    "@lobechat/business-const": "workspace:*"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-skills/src/lobehub/content.ts
+++ b/packages/builtin-skills/src/lobehub/content.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `<lobehub_platform_guides>
 
 # Identity & Current Context (pre-resolved — DO NOT look up)
@@ -36,9 +38,9 @@ Treat them as common knowledge — you never need to call any tool to discover t
    your own agent_id / topic_id.** Those are already known above. The list commands
    are only for finding OTHER agents / topics / resources you don't yet know about.
 
-# LobeHub Platform CLI
+# ${BRANDING_NAME} Platform CLI
 
-You can manage the LobeHub platform via the \`lh\` CLI. Use the \`runCommand\` tool to
+You can manage the ${BRANDING_NAME} platform via the \`lh\` CLI. Use the \`runCommand\` tool to
 run commands.
 
 # Available Modules

--- a/packages/builtin-skills/src/lobehub/index.ts
+++ b/packages/builtin-skills/src/lobehub/index.ts
@@ -1,3 +1,4 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
 import { type BuiltinSkill } from '@lobechat/types';
 
 import { systemPrompt } from './content';
@@ -35,8 +36,7 @@ const LOBEHUB_AVATAR =
 export const LobeHubSkill: BuiltinSkill = {
   avatar: LOBEHUB_AVATAR,
   content: systemPrompt,
-  description:
-    "Manage the LobeHub platform via the `lh` CLI — INCLUDING modifying THIS agent's own configuration. ACTIVATE this skill whenever the user asks you to: change your system prompt / instructions / persona, enable or disable tools / plugins / skills, switch model or provider, attach knowledge bases or files, edit the opening message, rename the topic, OR operate on any other platform resource (agents, topics, memory, documents, search, content generation, model/provider/plugin management, bot integrations, evals, usage stats). ALSO ACTIVATE when the user asks to connect, link, or set up a messaging platform bot — including Discord, Telegram, Slack, Feishu (飞书), Lark, QQ, or WeChat (微信) — or uses phrases like '帮我链接 Discord', 'connect my Slack', '接入飞书', '配置 QQ 机器人', 'link WeChat'. Without activation you cannot persist any change — you can only describe what you would do.",
+  description: `Manage the ${BRANDING_NAME} platform via the \`lh\` CLI — INCLUDING modifying THIS agent's own configuration. ACTIVATE this skill whenever the user asks you to: change your system prompt / instructions / persona, enable or disable tools / plugins / skills, switch model or provider, attach knowledge bases or files, edit the opening message, rename the topic, OR operate on any other platform resource (agents, topics, memory, documents, search, content generation, model/provider/plugin management, bot integrations, evals, usage stats). ALSO ACTIVATE when the user asks to connect, link, or set up a messaging platform bot — including Discord, Telegram, Slack, Feishu (飞书), Lark, QQ, or WeChat (微信) — or uses phrases like '帮我链接 Discord', 'connect my Slack', '接入飞书', '配置 QQ 机器人', 'link WeChat'. Without activation you cannot persist any change — you can only describe what you would do.`,
   identifier: LobeHubIdentifier,
   name: 'lobehub',
   resources: toResourceMeta({

--- a/packages/builtin-skills/src/lobehub/references/bot-qq.ts
+++ b/packages/builtin-skills/src/lobehub/references/bot-qq.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 const content = `# QQ Bot Setup Guide
 
 Connect a QQ Official Bot to your agent.
@@ -74,14 +76,14 @@ Some specialized events require explicit approval from Tencent.
 
 #### WebSocket Mode
 
-- LobeHub's \`lh bot connect\` handles the WebSocket gateway automatically
+- ${BRANDING_NAME}'s \`lh bot connect\` handles the WebSocket gateway automatically
 - No URL configuration needed — just provide AppID and AppSecret
 
 ### Step 6: Configure IP Whitelist
 
 1. In development settings, add your server's IP address to the **IP whitelist**
 2. IP whitelist is required — without it, API calls and bot launch are blocked
-3. For LobeHub-hosted bots, contact support for the outbound IP range to whitelist
+3. For ${BRANDING_NAME}-hosted bots, contact support for the outbound IP range to whitelist
 
 ### Step 7: Test in Sandbox, Then Submit for Review
 

--- a/packages/builtin-skills/src/lobehub/references/bot-telegram.ts
+++ b/packages/builtin-skills/src/lobehub/references/bot-telegram.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 const content = `# Telegram Bot Setup Guide
 
 Connect a Telegram bot to your agent.
@@ -54,7 +56,7 @@ lh bot connect <botId>
 ## Notes
 
 - **App ID** is the numeric bot ID extracted from the token prefix (e.g. token \`987654321:XYZ...\` → app-id \`987654321\`)
-- **Secret Token** (optional): a custom string you define; LobeHub includes it in webhook requests so you can verify they genuinely come from LobeHub — leave blank unless you have a security requirement
+- **Secret Token** (optional): a custom string you define; ${BRANDING_NAME} includes it in webhook requests so you can verify they genuinely come from ${BRANDING_NAME} — leave blank unless you have a security requirement
 - Telegram does not have native message search; use \`lh bot message read\` with pagination instead
 - If you lose the token, retrieve it by sending \`/token\` (then select your bot) to @BotFather
 `;

--- a/packages/builtin-skills/src/lobehub/references/bot-wechat.ts
+++ b/packages/builtin-skills/src/lobehub/references/bot-wechat.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 const content = `# WeChat Bot Setup Guide
 
 Connect a WeChat bot to your agent via iLink API.
@@ -14,9 +16,9 @@ WeChat uses **polling** mode (long-polling) — no webhook URL or WebSocket setu
 
 ## Setup: Use the Web UI
 
-WeChat requires a QR code scan to link your account, which is only supported through the LobeHub Web UI:
+WeChat requires a QR code scan to link your account, which is only supported through the ${BRANDING_NAME} Web UI:
 
-1. Open your agent in LobeHub
+1. Open your agent in ${BRANDING_NAME}
 2. In the left sidebar, click **Message Channel** (消息频道)
 3. Select **WeChat** from the platform list on the right
 4. A QR code is displayed — scan it with WeChat to authenticate

--- a/packages/builtin-skills/src/lobehub/references/generate.ts
+++ b/packages/builtin-skills/src/lobehub/references/generate.ts
@@ -2,6 +2,10 @@ const content = `# lh gen - Content Generation
 
 Generate text, images, videos, and audio. Alias: \`lh generate\`.
 
+## Video in chat
+
+This chat session cannot generate video. If the user asks for a video, tell them to open **Create → Video** at \`/video\`. Do **not** use \`lh gen video\`, skill-store, or a sandbox as a workaround.
+
 ## Subcommands
 
 - \`lh gen text <prompt> [-m <model>] [-p <provider>] [--stream] [--temperature <t>]\` - Generate text

--- a/packages/builtin-tool-activator/package.json
+++ b/packages/builtin-tool-activator/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/prompts": "workspace:*",
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-activator/src/systemRole.ts
+++ b/packages/builtin-tool-activator/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `You have access to a Tools Activator that allows you to dynamically activate tools on demand. Not all tools are loaded by default — you must activate them before use.
 
 <how_it_works>
@@ -26,17 +28,17 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 **CRITICAL: Always activate \`lobe-skill-store\` FIRST when ANY of the following conditions are met:**
 
 **Trigger keywords/patterns (MUST activate lobe-skill-store immediately):**
-- User mentions: "SKILL.md", "LobeHub Skills", "skill store", "install skill", "search skill"
+- User mentions: "SKILL.md", "${BRANDING_NAME} Skills", "skill store", "install skill", "search skill"
 - User provides a GitHub link to install a skill (e.g., github.com/xxx/xxx containing SKILL.md)
-- User mentions installing from LobeHub marketplace
-- User provides LobeHub skill URLs like: \`https://lobehub.com/skills/{identifier}/skill.md\` → extract identifier and use \`importFromMarket\`
+- User mentions installing from ${BRANDING_NAME} marketplace
+- User provides ${BRANDING_NAME} skill URLs like: \`https://lobehub.com/skills/{identifier}/skill.md\` → extract identifier and use \`importFromMarket\`
 - User provides instructions like: "curl https://lobehub.com/skills/..." → extract identifier from URL, use \`importFromMarket\`
 - User asks to "follow instructions to set up/install a skill"
 - User's task involves a specialized domain (e.g., creating presentations/PPT, generating PDFs, charts, diagrams) and no matching tool exists
 
 **Decision flow:**
 1. **If ANY trigger condition above is met** → Immediately activate \`lobe-skill-store\`
-2. **For LobeHub skill URLs** (e.g., \`https://lobehub.com/skills/{identifier}/skill.md\`):
+2. **For ${BRANDING_NAME} skill URLs** (e.g., \`https://lobehub.com/skills/{identifier}/skill.md\`):
    - Extract the identifier from the URL path (the part between \`/skills/\` and \`/skill.md\`)
    - Use \`importFromMarket\` with that identifier directly (NOT \`importSkill\`)
    - Example: \`lobehub.com/skills/openclaw-openclaw-github/skill.md\` → identifier is \`openclaw-openclaw-github\`
@@ -73,7 +75,7 @@ export const systemPrompt = `You have access to a Tools Activator that allows yo
 2. Check if the required credential already exists using the credentials list in context
 3. If credential exists → use \`getPlaintextCred\` or \`injectCredsToSandbox\` (for sandbox execution)
 4. If credential doesn't exist:
-   - For LobeHub OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
+   - For ${BRANDING_NAME} OAuth services (GitHub, Linear, Microsoft, Notion, Twitter) → use \`initiateOAuthConnect\`
    - For Composio-managed services (Slack, Google Drive, Airtable, Jira, etc.)
      → use \`connectComposioService\` after activating \`lobe-creds\`. The full list of
      available Composio services is shown in \`<composio_integrations>\` inside the
@@ -98,7 +100,8 @@ When sandbox mode is false (\`lobe-cloud-sandbox\` does not exist in this sessio
 
 <best_practices>
 - **IMPORTANT: Plan ahead and activate all needed tools upfront in a single call.** Before responding to the user, analyze their request and determine ALL tools you will need, then activate them together. Do NOT activate tools incrementally during a multi-step task.
-- **SKILL-FIRST: Any mention of skills, SKILL.md, GitHub skill links, or LobeHub marketplace → activate \`lobe-skill-store\` FIRST, no exceptions.**
+- **VIDEO: This session cannot generate video.** If the user asks for a video, tell them to open Create → Video at /video. Do not activate skill-store, the \`lh\` CLI, or a sandbox to work around this.
+- **SKILL-FIRST: Any mention of skills, SKILL.md, GitHub skill links, or ${BRANDING_NAME} marketplace → activate \`lobe-skill-store\` FIRST, no exceptions.**
 - **CREDS-FIRST: Any need for authentication, API keys, OAuth, tokens, or env variables → activate \`lobe-creds\` FIRST to manage credentials securely.**
 - Check the \`<available_tools>\` list before activating tools
 - For specialized tasks, search the Skill Marketplace first — a dedicated skill is almost always better than a generic approach

--- a/packages/builtin-tool-agent-builder/src/systemRole.ts
+++ b/packages/builtin-tool-agent-builder/src/systemRole.ts
@@ -4,7 +4,9 @@
  * This provides guidance on how to effectively use the agent builder tools
  * for configuring and optimizing AI agents.
  */
-export const systemPrompt = `You are an Agent Configuration Assistant integrated into LobeChat. Your role is to help users configure and optimize their AI agents through natural conversation.
+import { BRANDING_NAME } from '@lobechat/const';
+
+export const systemPrompt = `You are an Agent Configuration Assistant integrated into ${BRANDING_NAME}. Your role is to help users configure and optimize their AI agents through natural conversation.
 
 <context_awareness>
 **Important**: The current agent's configuration, metadata, and available official tools are automatically injected into the conversation context as \`<current_agent_context>\`. You can reference this information directly without calling any read APIs.
@@ -34,9 +36,9 @@ The distinction is simple: **you configure agents; you do not act as them.** If 
 </identity_boundary>
 
 <skill_coexistence>
-When LobeHub skills appear in the system context (listed under \`<available_skills>\`), those skills provide task-execution capabilities (e.g., web search, calendar access, coding assistance). However, for all agent **configuration** tasks — updating the agent's model, system prompt, plugins, metadata, or any other settings — always use the Agent Builder tools directly (\`updateConfig\`, \`updatePrompt\`, \`installPlugin\`, etc.).
+When ${BRANDING_NAME} skills appear in the system context (listed under \`<available_skills>\`), those skills provide task-execution capabilities (e.g., web search, calendar access, coding assistance). However, for all agent **configuration** tasks — updating the agent's model, system prompt, plugins, metadata, or any other settings — always use the Agent Builder tools directly (\`updateConfig\`, \`updatePrompt\`, \`installPlugin\`, etc.).
 
-Do not delegate agent configuration to a LobeHub skill, even if the skill's name or description appears to overlap. Agent Builder tools apply changes immediately and directly to the current agent's stored configuration; LobeHub skills do not modify agent configuration.
+Do not delegate agent configuration to a ${BRANDING_NAME} skill, even if the skill's name or description appears to overlap. Agent Builder tools apply changes immediately and directly to the current agent's stored configuration; ${BRANDING_NAME} skills do not modify agent configuration.
 </skill_coexistence>
 
 <capabilities>

--- a/packages/builtin-tool-agent-management/src/systemRole.ts
+++ b/packages/builtin-tool-agent-management/src/systemRole.ts
@@ -4,6 +4,8 @@
  * This provides guidance on how to effectively use the agent management tools
  * to create, configure, search, and orchestrate AI agents.
  */
+import { BRANDING_NAME } from '@lobechat/const';
+
 export const systemPrompt = `You have Agent Management tools to create, configure, and orchestrate AI agents. Your primary responsibility is to help users build and manage their agent ecosystem effectively.
 
 <core_capabilities>
@@ -98,9 +100,9 @@ You are a [role] specialized in [domain].
 
 When selecting a model, follow this priority order:
 
-1. **First Priority - LobeHub Provider Models**:
+1. **First Priority - ${BRANDING_NAME} Provider Models**:
    - If available, prioritize models from the "lobehub" provider
-   - These are optimized for the LobeHub ecosystem
+   - These are optimized for the ${BRANDING_NAME} ecosystem
 
 2. **Second Priority - Premium Frontier Models**:
    - **Anthropic**: Claude Sonnet 4.5, Claude Opus 4.5, or newer Opus/Sonnet series

--- a/packages/builtin-tool-creds/package.json
+++ b/packages/builtin-tool-creds/package.json
@@ -10,7 +10,9 @@
     "./executor": "./src/executor/index.ts"
   },
   "main": "./src/index.ts",
-  "dependencies": {},
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   }

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have access to a LobeHub Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have access to a ${BRANDING_NAME} Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
 
 <session_context>
 Current user: {{username}}
@@ -19,7 +21,7 @@ Sandbox mode: {{sandbox_enabled}}
 
 <core_responsibilities>
 1. **Awareness**: Know what credentials the user has configured and suggest relevant ones when needed.
-2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in LobeHub.
+2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in ${BRANDING_NAME}.
 3. **Runtime Integration**: When sandbox mode is enabled, use \`injectCredsToSandbox\` to inject credentials into the sandbox environment.
 4. **Ownership disclosure**: In a workspace, some listed credentials are tagged \`[shared by <name>]\` (a teammate's own credential they chose to share) or \`[workspace credential]\` (owned by the workspace itself). Never present a shared credential as if it belongs to the workspace or to you — when it's relevant, tell the user whose credential is actually being used.
 </core_responsibilities>
@@ -35,7 +37,7 @@ Sandbox mode: {{sandbox_enabled}}
 </tooling>
 
 <oauth_providers>
-LobeHub provides built-in OAuth integrations for the following services:
+${BRANDING_NAME} provides built-in OAuth integrations for the following services:
 - **github**: GitHub repository and code management. Connect to access repositories, create issues, manage pull requests.
 - **linear**: Linear issue tracking and project management. Connect to create/manage issues, track projects.
 - **microsoft**: Microsoft Outlook Calendar. Connect to view/create calendar events, manage meetings.
@@ -48,7 +50,7 @@ When a user mentions they want to use one of these services, use \`initiateOAuth
 <security_guidelines>
 - **Never display credential values** in your responses. Refer to credentials by their key or name only.
 - **Prompt for saving**: When you see users share sensitive information like API keys or tokens, suggest:
-  "I noticed you shared a sensitive credential. Would you like me to save it securely in LobeHub? This way you can reuse it without sharing it again."
+  "I noticed you shared a sensitive credential. Would you like me to save it securely in ${BRANDING_NAME}? This way you can reuse it without sharing it again."
 - **Explain the benefit**: Let users know that saved credentials are encrypted and can be easily reused across conversations.
 </security_guidelines>
 

--- a/packages/builtin-tool-group-agent-builder/package.json
+++ b/packages/builtin-tool-group-agent-builder/package.json
@@ -11,7 +11,8 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@lobechat/agent-manager-runtime": "workspace:*",
-    "@lobechat/builtin-tool-agent-builder": "workspace:*"
+    "@lobechat/builtin-tool-agent-builder": "workspace:*",
+    "@lobechat/business-const": "workspace:*"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-group-agent-builder/src/systemRole.ts
+++ b/packages/builtin-tool-group-agent-builder/src/systemRole.ts
@@ -4,7 +4,9 @@
  * This provides guidance on how to effectively use the group agent builder tools
  * for configuring group chats and managing group members.
  */
-export const systemPrompt = `You are a Group Configuration Assistant integrated into LobeHub. Your role is to help users configure and optimize their multi-agent group chats through natural conversation.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You are a Group Configuration Assistant integrated into ${BRANDING_NAME}. Your role is to help users configure and optimize their multi-agent group chats through natural conversation.
 
 <context_awareness>
 **Important**: The current group's configuration, metadata, member agents, and available tools are automatically injected into the conversation context as \`<current_group_context>\`. You can reference this information directly without calling any read APIs.

--- a/packages/builtin-tool-image-generation/package.json
+++ b/packages/builtin-tool-image-generation/package.json
@@ -10,6 +10,7 @@
   },
   "main": "./src/index.ts",
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "model-bank": "workspace:*"
   },
   "devDependencies": {

--- a/packages/builtin-tool-image-generation/src/client/Render/GenerateImage.tsx
+++ b/packages/builtin-tool-image-generation/src/client/Render/GenerateImage.tsx
@@ -7,6 +7,7 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { GenerationCostBadge } from '@/components/GenerationCostBadge';
 import { useClientDataSWR } from '@/libs/swr';
 import { imageKeys } from '@/libs/swr/keys';
 import { normalizeAsyncError } from '@/libs/swr/normalizeError';
@@ -88,6 +89,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillTertiary};
   `,
   tile: css`
+    position: relative;
+
     overflow: hidden;
 
     aspect-ratio: 1;
@@ -194,6 +197,7 @@ const GenerationTile = memo<{ index: number; task: GeneratedImageTask }>(({ inde
     task.status ||
     (isLoading ? 'processing' : 'pending');
   const url = getTaskAssetUrl(task) || getAssetUrl(data);
+  const costUsd = data?.generation?.asset?.costUsd ?? task.asset?.costUsd;
   const errorDetail =
     error instanceof Error ? error.message : getTaskErrorDetail(task) || getErrorDetail(data);
   const canRetry = Boolean(error) && normalizeAsyncError(error).retryable;
@@ -225,6 +229,7 @@ const GenerationTile = memo<{ index: number; task: GeneratedImageTask }>(({ inde
           )}
         </div>
       )}
+      <GenerationCostBadge costUsd={costUsd} />
     </div>
   );
 });

--- a/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.test.ts
@@ -69,8 +69,8 @@ describe('ImageGenerationExecutor', () => {
     mocks.enabledImageModelList.mockReturnValue([
       {
         children: [{ id: 'image-model-1' }],
-        id: 'provider-1',
-        name: 'Provider 1',
+        id: 'openrouter',
+        name: 'OpenRouter',
       },
     ]);
     mocks.loadDefaultHiddenBuiltinModels.mockResolvedValue([]);
@@ -89,7 +89,7 @@ describe('ImageGenerationExecutor', () => {
       {
         model: 'image-model-1',
         prompt: 'A shared workspace illustration',
-        provider: 'provider-1',
+        provider: 'openrouter',
         waitUntilComplete: false,
       },
       {
@@ -109,8 +109,8 @@ describe('ImageGenerationExecutor', () => {
   it('does not expose hidden models while the store model list is hydrating', async () => {
     mocks.enabledImageModelList.mockReturnValue([]);
     mocks.getAiProviderRuntimeState.mockResolvedValue({
-      enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
-      hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'lobehub' }],
+      enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
+      hiddenBuiltinModels: [{ id: 'hidden-image', providerId: 'openrouter' }],
     });
     mocks.getAiProviderModelList.mockImplementation(
       async (_providerId: string, options: { limit?: number }) => {
@@ -122,14 +122,14 @@ describe('ImageGenerationExecutor', () => {
 
     const result = await imageGenerationExecutor.listImageModels({
       limit: 1,
-      provider: 'lobehub',
+      provider: 'openrouter',
     });
 
     expect(result).toMatchObject({
       state: {
         providers: [
           {
-            id: 'lobehub',
+            id: 'openrouter',
             models: [{ id: 'visible-image' }],
           },
         ],
@@ -142,10 +142,10 @@ describe('ImageGenerationExecutor', () => {
   it('uses the client default blocklist with an older runtime-state response', async () => {
     mocks.enabledImageModelList.mockReturnValue([]);
     mocks.getAiProviderRuntimeState.mockResolvedValue({
-      enabledImageAiProviders: [{ id: 'lobehub', name: 'LobeHub' }],
+      enabledImageAiProviders: [{ id: 'openrouter', name: 'OpenRouter' }],
     });
     mocks.loadDefaultHiddenBuiltinModels.mockResolvedValue([
-      { id: 'hidden-image', providerId: 'lobehub' },
+      { id: 'hidden-image', providerId: 'openrouter' },
     ]);
     mocks.getAiProviderModelList.mockResolvedValue([
       { id: 'hidden-image' },
@@ -154,12 +154,37 @@ describe('ImageGenerationExecutor', () => {
 
     const result = await imageGenerationExecutor.listImageModels({
       limit: 1,
-      provider: 'lobehub',
+      provider: 'openrouter',
     });
 
     expect(result).toMatchObject({
       state: {
-        providers: [{ id: 'lobehub', models: [{ id: 'visible-image' }] }],
+        providers: [{ id: 'openrouter', models: [{ id: 'visible-image' }] }],
+        totalModels: 1,
+      },
+      success: true,
+    });
+  });
+
+  it('omits unmanaged image providers from the chat tool list', async () => {
+    mocks.enabledImageModelList.mockReturnValue([
+      {
+        children: [{ id: 'gemini-image' }],
+        id: 'google',
+        name: 'Google',
+      },
+      {
+        children: [{ id: 'or-image' }],
+        id: 'openrouter',
+        name: 'OpenRouter',
+      },
+    ]);
+
+    const result = await imageGenerationExecutor.listImageModels({ limit: 10 });
+
+    expect(result).toMatchObject({
+      state: {
+        providers: [{ id: 'openrouter', models: [{ id: 'or-image' }] }],
         totalModels: 1,
       },
       success: true,
@@ -175,7 +200,7 @@ describe('ImageGenerationExecutor', () => {
 
     const result = await imageGenerationExecutor.listImageModels({
       limit: 1,
-      provider: 'lobehub',
+      provider: 'openrouter',
     });
 
     expect(result).toMatchObject({

--- a/packages/builtin-tool-image-generation/src/client/executor/index.ts
+++ b/packages/builtin-tool-image-generation/src/client/executor/index.ts
@@ -6,6 +6,7 @@ import type {
 import { BaseExecutor } from '@lobechat/types';
 import type { AiModelForSelect, AiProviderModelListItem } from 'model-bank';
 
+import { filterAicoManagedProviders } from '@/features/AicoBilling/isManagedRuntimeProvider';
 import { aiModelService } from '@/services/aiModel';
 import { aiProviderService } from '@/services/aiProvider';
 import { generationService } from '@/services/generation';
@@ -68,7 +69,9 @@ const createClientImageGenerationRuntime = (topicVisibility?: 'private' | 'publi
       };
     },
     listImageModels: async ({ provider, limit }) => {
-      const storeProviders = aiProviderSelectors.enabledImageModelList(getAiInfraStoreState());
+      const storeProviders = filterAicoManagedProviders(
+        aiProviderSelectors.enabledImageModelList(getAiInfraStoreState()),
+      );
       const filteredStoreProviders = provider
         ? storeProviders.filter((item) => item.id === provider)
         : storeProviders;
@@ -102,9 +105,11 @@ const createClientImageGenerationRuntime = (topicVisibility?: 'private' | 'publi
         return { providers: [], totalModels: 0 };
       }
 
-      const enabledProviders = provider
-        ? runtimeState.enabledImageAiProviders.filter((item) => item.id === provider)
-        : runtimeState.enabledImageAiProviders;
+      const enabledProviders = filterAicoManagedProviders(
+        provider
+          ? runtimeState.enabledImageAiProviders.filter((item) => item.id === provider)
+          : runtimeState.enabledImageAiProviders,
+      );
 
       const providers = await Promise.all(
         enabledProviders.map(async (item) => {

--- a/packages/builtin-tool-image-generation/src/systemRole.ts
+++ b/packages/builtin-tool-image-generation/src/systemRole.ts
@@ -1,4 +1,8 @@
-export const systemPrompt = `You can generate images through LobeHub's built-in image generation pipeline.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You can generate images through ${BRANDING_NAME}'s built-in image generation pipeline.
+
+This tool generates **photos/images only**. It cannot generate video. If the user asks for a video, tell them to open Create → Video at /video. Do not activate skills, the \`lh\` CLI, skill-store, or a sandbox to work around this.
 
 Choose APIs based on the request:
 - For a straightforward image request with no model-specific requirements, call generateImage directly and omit provider/model so the runtime can select an available model.

--- a/packages/builtin-tool-memory/package.json
+++ b/packages/builtin-tool-memory/package.json
@@ -12,6 +12,7 @@
   "main": "./src/index.ts",
   "scripts": {},
   "dependencies": {
+    "@lobechat/business-const": "workspace:*",
     "@lobechat/memory-user-memory": "workspace:*",
     "@lobechat/prompts": "workspace:*"
   },

--- a/packages/builtin-tool-memory/src/systemRole.ts
+++ b/packages/builtin-tool-memory/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have a LobeHub Memory Tool. This tool is to recognise, retrieve, and coordinate high-quality user memories so downstream extractors can persist them accurately.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have a ${BRANDING_NAME} Memory Tool. This tool is to recognise, retrieve, and coordinate high-quality user memories so downstream extractors can persist them accurately.
 
 <session_context>
 Current user: {{username}}

--- a/packages/builtin-tool-message/package.json
+++ b/packages/builtin-tool-message/package.json
@@ -10,6 +10,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   },

--- a/packages/builtin-tool-message/src/systemRole.ts
+++ b/packages/builtin-tool-message/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/business-const';
+
 export const systemPrompt = `You have access to a Message tool that provides unified messaging and bot management capabilities across multiple platforms.
 
 <supported_platforms>
@@ -25,13 +27,13 @@ export const systemPrompt = `You have access to a Message tool that provides uni
 The send APIs (\`sendMessage\`, \`sendDirectMessage\`, \`replyToThread\`) can deliver through **two sources** — both use the same underlying platform clients (so attachments / formatting / rate behavior are identical), but they come from different lists:
 
 - **Per-agent bot** (pass \`botId\`) — the agent's own credentials, configured via \`createBot\`. Listed by \`listBots\`. Messages appear with the per-agent bot's identity.
-- **System Bot installation** (pass \`messengerInstallationId\`) — the LobeHub shared bot, connected by the user via Settings → Messenger. Listed by \`listMessengers\`. Messages appear with the LobeHub System Bot identity.
+- **System Bot installation** (pass \`messengerInstallationId\`) — the ${BRANDING_NAME} shared bot, connected by the user via Settings → Messenger. Listed by \`listMessengers\`. Messages appear with the ${BRANDING_NAME} System Bot identity.
 
 **Two-step routing rule — apply in order:**
 
 1. **Call \`listBots\`.** If any entry has \`platform: "<target>"\` → use its \`botId\` on the send API. Done.
 2. **Otherwise call \`listMessengers\`.** If any entry has \`platform: "<target>"\` → use its \`id\` as \`messengerInstallationId\` on the send API. Done.
-3. **Neither has the platform → do NOT pick a different platform.** Tell the user: "I can't reach <platform> for you yet. You can either provision a dedicated bot for this agent with \`createBot\`, or install the LobeHub System Bot via Settings → Messenger." Stop.
+3. **Neither has the platform → do NOT pick a different platform.** Tell the user: "I can't reach <platform> for you yet. You can either provision a dedicated bot for this agent with \`createBot\`, or install the ${BRANDING_NAME} System Bot via Settings → Messenger." Stop.
 
 Per-agent bots always win because they're purpose-built for the current agent and use identity the user explicitly configured. Only fall back to System Bot when the agent has nothing for the platform. If the user **explicitly** asks to route through their System Bot install even when a per-agent bot exists, honor that and call \`listMessengers\` directly.
 
@@ -39,7 +41,7 @@ The send APIs accept **exactly one** of \`botId\` / \`messengerInstallationId\` 
 </outbound_routing>
 
 <system_bot_management>
-The **System Bot** is the LobeHub-owned shared bot the user connects via \`Settings → Messenger\`. It's separate from per-agent bots (\`createBot\` / \`listBots\`). This API surface mirrors the per-agent CRUD but operates on \`messenger_installations\` (workspace installs) and \`messenger_account_links\` (per-user routing plus user-owned WeChat credentials).
+The **System Bot** is the ${BRANDING_NAME}-owned shared bot the user connects via \`Settings → Messenger\`. It's separate from per-agent bots (\`createBot\` / \`listBots\`). This API surface mirrors the per-agent CRUD but operates on \`messenger_installations\` (workspace installs) and \`messenger_account_links\` (per-user routing plus user-owned WeChat credentials).
 
 **Platform coverage** — System Bot supports **Slack, Discord, Telegram, and WeChat**. Slack / Discord use workspace install flows, Telegram uses a global bot, and WeChat uses a user-owned QR connection. For Feishu / Lark / QQ the user must use a per-agent bot via \`createBot\`. \`listMessengerPlatforms\` returns the currently-enabled subset on this deployment.
 
@@ -55,8 +57,8 @@ The **System Bot** is the LobeHub-owned shared bot the user connects via \`Setti
 7. **setMessengerActiveAgent** — Change which agent receives inbound IM on a link. Pass \`agentId: null\` to clear the active agent. Scope to one workspace via \`tenantId\`; omit for single-link platforms (Telegram / WeChat). The agent must belong to the current user — server rejects cross-user ids.
 
 **Critical disambiguation — \`uninstallMessenger\` vs \`unlinkMessenger\`:**
-- "remove my account from Slack" / "stop receiving DMs from this workspace on my LobeHub" → \`unlinkMessenger\`
-- "uninstall the LobeHub bot from my workspace" / "remove the integration for everyone" → \`uninstallMessenger\` (workspace-admin level decision)
+- "remove my account from Slack" / "stop receiving DMs from this workspace on my ${BRANDING_NAME}" → \`unlinkMessenger\`
+- "uninstall the ${BRANDING_NAME} bot from my workspace" / "remove the integration for everyone" → \`uninstallMessenger\` (workspace-admin level decision)
 
 When in doubt, ask. Defaulting to the destructive option (\`uninstallMessenger\`) when the user only wanted \`unlinkMessenger\` will affect colleagues.
 

--- a/packages/builtin-tool-self-iteration/package.json
+++ b/packages/builtin-tool-self-iteration/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/context-engine": "workspace:*",
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-self-iteration/src/systemRole.ts
+++ b/packages/builtin-tool-self-iteration/src/systemRole.ts
@@ -1,4 +1,6 @@
-export const systemPrompt = `You have access to the Self Feedback Intent tool. It is a high-recall side channel for telling LobeHub that the running agent has found a concrete opportunity to improve its future memory, skills, workflow, or system behavior.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have access to the Self Feedback Intent tool. It is a high-recall side channel for telling ${BRANDING_NAME} that the running agent has found a concrete opportunity to improve its future memory, skills, workflow, or system behavior.
 
 <core_contract>
 - **declareSelfFeedbackIntent** records advisory intent only. It does not directly mutate user memory, skills, prompts, documents, or product configuration.

--- a/packages/builtin-tool-skill-store/package.json
+++ b/packages/builtin-tool-skill-store/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/business-const": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   },

--- a/packages/builtin-tool-skill-store/src/systemRole.ts
+++ b/packages/builtin-tool-skill-store/src/systemRole.ts
@@ -1,30 +1,32 @@
-export const systemPrompt = `You have access to a Skill Store tool that allows you to search, discover, and install skill packages from the LobeHub Marketplace.
+import { BRANDING_NAME } from '@lobechat/business-const';
+
+export const systemPrompt = `You have access to a Skill Store tool that allows you to search, discover, and install skill packages from the ${BRANDING_NAME} Marketplace.
 
 <core_capabilities>
-1. Search for skills in the LobeHub Market (searchSkill)
-2. Import/install a skill directly from the LobeHub Market (importFromMarket)
+1. Search for skills in the ${BRANDING_NAME} Market (searchSkill)
+2. Import/install a skill directly from the ${BRANDING_NAME} Market (importFromMarket)
 3. Import/install a skill from a URL, GitHub link, or ZIP package (importSkill)
 </core_capabilities>
 
 <workflow>
-1. When the user wants to find/discover skills, use searchSkill to search the LobeHub Market
+1. When the user wants to find/discover skills, use searchSkill to search the ${BRANDING_NAME} Market
 2. When the user wants to install a skill from search results, use importFromMarket with the skill identifier
 3. When the user wants to install/import a skill from a URL, call importSkill with the URL
 </workflow>
 
 <tool_selection_guidelines>
-- **searchSkill**: Call this to search for skills in the LobeHub Market
+- **searchSkill**: Call this to search for skills in the ${BRANDING_NAME} Market
   - Provide a search query to find relevant skills
   - Returns a list of matching skills with name, description, author, and identifier
   - Use this when the user wants to discover or find new skills
   - After finding a skill, use importFromMarket to install it
 
-- **importFromMarket**: Call this to install a skill directly from the LobeHub Market
+- **importFromMarket**: Call this to install a skill directly from the ${BRANDING_NAME} Market
   - Provide the skill identifier (obtained from searchSkill results)
   - Downloads and installs the skill from the market
   - Requires user confirmation before installation
   - Returns the skill name and import status (created/updated/unchanged)
-  - Preferred over importSkill when the skill is available in the LobeHub Market
+  - Preferred over importSkill when the skill is available in the ${BRANDING_NAME} Market
 
 - **importSkill**: Call this to import/install a skill from a URL
   - Provide the URL and the type ("url" for SKILL.md or GitHub links, "zip" for ZIP packages)
@@ -36,6 +38,6 @@ export const systemPrompt = `You have access to a Skill Store tool that allows y
 
 <best_practices>
 - Use searchSkill to help users discover skills when they describe a task but don't know a specific skill
-- Prefer importFromMarket over importSkill when the skill is available in the LobeHub Market
+- Prefer importFromMarket over importSkill when the skill is available in the ${BRANDING_NAME} Market
 </best_practices>
 `;

--- a/packages/builtin-tool-skills/src/systemRole.ts
+++ b/packages/builtin-tool-skills/src/systemRole.ts
@@ -1,3 +1,5 @@
+import { BRANDING_NAME } from '@lobechat/const';
+
 export const systemPrompt = `You have access to a Skills tool that can activate skills and execute their instructions. Skills are reusable instruction packages that extend your capabilities.
 
 <core_capabilities>
@@ -31,7 +33,7 @@ export const systemPrompt = `You have access to a Skills tool that can activate 
 
 - **runCommand**: Call this to execute shell commands in the cloud sandbox
   - Use for general CLI commands, platform tools (e.g., \`lh\` CLI), and ad-hoc operations
-  - If \`lobe-local-system\` runCommand is also available, default shell execution to it — use this sandbox runCommand only when the task needs LobeHub-managed credentials, isolation, or a tool missing on the local device
+  - If \`lobe-local-system\` runCommand is also available, default shell execution to it — use this sandbox runCommand only when the task needs ${BRANDING_NAME}-managed credentials, isolation, or a tool missing on the local device
   - Provide the command to execute and a clear description of what it does
   - Returns the command output (stdout/stderr) and exit code
   - Requires user confirmation before execution
@@ -55,7 +57,7 @@ export const systemPrompt = `You have access to a Skills tool that can activate 
 
 - **runCommand (default of the two)**:
   - Use for general shell commands and CLI tools (e.g., \`lh kb list\`, \`npm install\`)
-  - Use for platform tool commands (LobeHub CLI, etc.)
+  - Use for platform tool commands (${BRANDING_NAME} CLI, etc.)
   - No skill context needed — just provide the command
   - Best for: CLI operations, system commands, tool invocations
 

--- a/packages/locales/src/default/image.ts
+++ b/packages/locales/src/default/image.ts
@@ -49,6 +49,7 @@ export default {
   'generation.actions.seedApplyFailed': 'Failed to Apply Seed',
   'generation.actions.seedCopied': 'Seed Copied to Clipboard',
   'generation.actions.seedCopyFailed': 'Failed to Copy Seed',
+  'generation.cost': 'Cost',
   'generation.metadata.by': 'by {{name}}',
   'generation.metadata.count': '{{count}} Images',
   'generation.metadata.createdAt': 'Created at {{time}}',

--- a/packages/locales/src/default/video.ts
+++ b/packages/locales/src/default/video.ts
@@ -21,6 +21,7 @@ export default {
   'generation.actions.errorCopied': 'Error Message Copied to Clipboard',
   'generation.actions.errorCopyFailed': 'Failed to Copy Error Message',
   'generation.actions.generate': 'Generate',
+  'generation.cost': 'Cost',
   'generation.freeQuota.exhausted': '🎁 Free quota used up, credits will be consumed',
   'generation.freeQuota.remaining': '🎁 {{remaining}} free videos today',
   'generation.validation.endFrameRequiresStartFrame':

--- a/packages/model-runtime/src/providers/openrouter/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/createVideo.test.ts
@@ -95,6 +95,24 @@ describe('pollOpenRouterVideoStatus', () => {
     });
   });
 
+  it('persists OpenRouter usage.cost as costUsd on success', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      json: async () => ({
+        status: 'completed',
+        unsigned_urls: ['https://storage.example.com/out.mp4'],
+        usage: { cost: 0.042 },
+      }),
+      ok: true,
+    });
+
+    await expect(
+      pollOpenRouterVideoStatus('video-job-1', { apiKey: 'test-api-key' }),
+    ).resolves.toMatchObject({
+      costUsd: 0.042,
+      status: 'success',
+    });
+  });
+
   it('returns pending while the job is still running', async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       json: async () => ({ status: 'processing' }),

--- a/packages/model-runtime/src/providers/openrouter/createVideo.ts
+++ b/packages/model-runtime/src/providers/openrouter/createVideo.ts
@@ -18,6 +18,7 @@ interface OpenRouterVideoJob {
   status?: string;
   unsigned_urls?: string[] | null;
   url?: string | null;
+  usage?: { cost?: number } | null;
 }
 
 const openRouterHeaders = (apiKey: string) => ({
@@ -58,7 +59,12 @@ export const pollOpenRouterVideoStatus = async (
     // point at provider CDNs (GCS, etc.) that fail with undici "fetch failed"
     // from networks where only openrouter.ai is reachable.
     const origin = baseURL.replace(/\/$/, '');
+    const costUsd =
+      typeof data.usage?.cost === 'number' && Number.isFinite(data.usage.cost)
+        ? data.usage.cost
+        : undefined;
     return {
+      ...(typeof costUsd === 'number' ? { costUsd } : {}),
       headers: { Authorization: `Bearer ${options.apiKey}` },
       status: 'success',
       videoUrl: `${origin}/videos/${inferenceId}/content`,

--- a/packages/model-runtime/src/types/video.ts
+++ b/packages/model-runtime/src/types/video.ts
@@ -34,6 +34,7 @@ export type CreateVideoResponse =
 
 export type PollVideoStatusResult =
   | {
+      costUsd?: number;
       headers?: Record<string, string>;
       status: 'success';
       videoUrl: string;

--- a/packages/types/src/generation/index.ts
+++ b/packages/types/src/generation/index.ts
@@ -18,6 +18,11 @@ export interface ImageGenerationTopic {
 }
 
 export interface BaseGenerationAsset {
+  /**
+   * Billed USD cost for this generation when the provider reported it
+   * (e.g. OpenRouter `usage.cost`). Omitted when unknown.
+   */
+  costUsd?: number;
   type: string;
 }
 

--- a/src/components/GenerationCostBadge.tsx
+++ b/src/components/GenerationCostBadge.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { formatMessageCostUsd } from '@/features/Conversation/Messages/components/resolveMessageCost';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  badge: css`
+    position: absolute;
+    z-index: 5;
+    inset-block-end: 8px;
+    inset-inline-start: 8px;
+
+    padding-block: 2px;
+    padding-inline: 6px;
+    border-radius: 6px;
+
+    font-size: 11px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorBgElevated};
+  `,
+}));
+
+export const GenerationCostBadge = memo<{ costUsd?: number; namespace?: 'image' | 'video' }>(
+  ({ costUsd, namespace = 'image' }) => {
+    const { t } = useTranslation(namespace);
+    if (typeof costUsd !== 'number' || !Number.isFinite(costUsd)) return null;
+
+    return (
+      <span className={styles.badge} title={t('generation.cost')}>
+        {formatMessageCostUsd(costUsd)}
+      </span>
+    );
+  },
+);
+
+GenerationCostBadge.displayName = 'GenerationCostBadge';

--- a/src/features/AicoPanels/panelStyles.test.ts
+++ b/src/features/AicoPanels/panelStyles.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+describe('aicoPanelStyles tableScroll', () => {
+  const source = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), 'panelStyles.ts'),
+    'utf8',
+  );
+
+  it('contains wide tables inside the panel instead of growing the page', () => {
+    expect(source).toContain('tableScroll:');
+    expect(source).toMatch(/tableScroll:[\s\S]*min-width:\s*0/);
+    expect(source).toMatch(/tableScroll:[\s\S]*max-width:\s*100%/);
+    expect(source).toMatch(/\.ant-table-wrapper[\s\S]*max-width:\s*100%/);
+  });
+
+  it('pins cell fills with inset 0 so RTL does not shift the background', () => {
+    expect(source).toContain('.ant-table-cell::before');
+    expect(source).toContain('inset: 0');
+    expect(source).not.toContain('inset-inline: auto');
+  });
+});

--- a/src/features/AicoPanels/panelStyles.ts
+++ b/src/features/AicoPanels/panelStyles.ts
@@ -76,10 +76,24 @@ export const aicoPanelStyles = createStaticStyles(({ css, cssVar }) => ({
   `,
   tableScroll: css`
     overflow-x: auto;
+
     width: 100%;
     min-width: 0;
+    max-width: 100%;
 
     -webkit-overflow-scrolling: touch;
+
+    .ant-table-wrapper,
+    .ant-table {
+      width: 100%;
+      max-width: 100%;
+    }
+
+    /* antd paints hover/header fills via physical left/right ::before; under RTL
+       that fill sits on the wrong edge. inset:0 pins all four edges. */
+    .ant-table-cell::before {
+      inset: 0 !important;
+    }
   `,
   tabs: css`
     width: 100%;

--- a/src/features/AicoPanels/useAicoPanelContainerProps.test.ts
+++ b/src/features/AicoPanels/useAicoPanelContainerProps.test.ts
@@ -13,7 +13,7 @@ describe('useAicoPanelContainerProps', () => {
     vi.mocked(useIsMobile).mockReset();
   });
 
-  it('uses compact padding and horizontal overflow on mobile', () => {
+  it('uses compact padding and hides page-level horizontal overflow on mobile', () => {
     vi.mocked(useIsMobile).mockReturnValue(true);
 
     const props = useAicoPanelContainerProps(1100);
@@ -21,7 +21,8 @@ describe('useAicoPanelContainerProps', () => {
     expect(props.maxWidth).toBe(1100);
     expect(props.paddingBlock).toBe('16px 32px');
     expect(props.paddingInline).toBe(12);
-    expect(props.style.overflowX).toBe('auto');
+    expect(props.style.overflowX).toBe('hidden');
+    expect(props.style.minWidth).toBe(0);
   });
 
   it('uses desktop padding when not mobile', () => {

--- a/src/features/AicoPanels/useAicoPanelContainerProps.ts
+++ b/src/features/AicoPanels/useAicoPanelContainerProps.ts
@@ -9,6 +9,6 @@ export const useAicoPanelContainerProps = (maxWidth: number = 960) => {
     maxWidth,
     paddingBlock: mobile ? ('16px 32px' as const) : ('24px 48px' as const),
     paddingInline: mobile ? 12 : 24,
-    style: { minHeight: 0, overflowX: 'auto' as const },
+    style: { minHeight: 0, minWidth: 0, overflowX: 'hidden' as const },
   };
 };

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -23,6 +23,7 @@ import {
   FxTopupFields,
   type FxTopupFormValues,
 } from '@/features/AicoBilling/FxTopupFields';
+import { AICO_TABLE_SCROLL, aicoPanelStyles } from '@/features/AicoPanels';
 import { buildPhoneVerifyRedirectUrl } from '@/libs/better-auth/phone';
 import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
@@ -30,21 +31,6 @@ import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  grid: css`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 12px;
-  `,
-  page: css`
-    width: 100%;
-    max-width: 960px;
-  `,
-  section: css`
-    padding: 16px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusLG};
-    background: ${cssVar.colorBgContainer};
-  `,
   sourceActive: css`
     border-color: ${cssVar.colorBorder};
     background: ${cssVar.colorFillTertiary};
@@ -70,11 +56,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       border-color: ${cssVar.colorBorder};
       background: ${cssVar.colorFillQuaternary};
     }
-  `,
-  sourceGrid: css`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 12px;
   `,
 }));
 
@@ -116,7 +97,7 @@ export const AicoWallet = () => {
   const { canSwitch, data: billingSources, isSelected, selectSource } = useAicoBillingSources();
 
   return (
-    <Flexbox className={styles.page} gap={20}>
+    <Flexbox className={aicoPanelStyles.page} gap={20}>
       <Flexbox gap={4}>
         <Flexbox horizontal align="center" gap={8}>
           <Text strong as="h1" style={{ fontSize: 22, margin: 0 }}>
@@ -127,7 +108,7 @@ export const AicoWallet = () => {
         <Text type="secondary">{t('wallet.subtitle')}</Text>
       </Flexbox>
 
-      <div className={styles.grid}>
+      <div className={aicoPanelStyles.grid}>
         <StatisticCard
           statistic={{ value: `$${Number(wallet?.balanceUsd ?? 0).toFixed(4)}` }}
           title={t('wallet.balanceUsd')}
@@ -148,11 +129,11 @@ export const AicoWallet = () => {
       </div>
 
       {billingSources && billingSources.sources.length > 0 ? (
-        <Block className={styles.section} variant="outlined">
+        <Block className={aicoPanelStyles.section} variant="outlined">
           <Flexbox gap={12}>
             <Text strong>{t('billing.sourcesTitle')}</Text>
             <Text type="secondary">{t('billing.selectHint')}</Text>
-            <div className={styles.sourceGrid}>
+            <div className={aicoPanelStyles.sourceGrid}>
               {billingSources.sources.map((source) => {
                 const ctx = sourceToContext(source);
                 const selected = isSelected(ctx);
@@ -200,7 +181,7 @@ export const AicoWallet = () => {
         </Block>
       ) : null}
 
-      <Block className={styles.section} variant="outlined">
+      <Block className={aicoPanelStyles.section} variant="outlined">
         <Flexbox gap={16}>
           <Flexbox horizontal align="center" gap={8}>
             <Text strong>{t('wallet.onlineTopupTitle')}</Text>
@@ -224,7 +205,7 @@ export const AicoWallet = () => {
         </Flexbox>
       </Block>
 
-      <Block className={styles.section} variant="outlined">
+      <Block className={aicoPanelStyles.section} variant="outlined">
         <Flexbox gap={12}>
           <Text strong>{t('wallet.trialTitle')}</Text>
           {trial && !trial.config.enabled ? (
@@ -285,7 +266,7 @@ export const AicoWallet = () => {
         </Flexbox>
       </Block>
 
-      <Block className={styles.section} variant="outlined">
+      <Block className={aicoPanelStyles.section} variant="outlined">
         <Flexbox gap={12}>
           <Text strong>{t('wallet.upgradeTitle')}</Text>
           <Text type="secondary">{t('wallet.upgradeDesc')}</Text>
@@ -295,32 +276,35 @@ export const AicoWallet = () => {
         </Flexbox>
       </Block>
 
-      <Block className={styles.section} variant="outlined">
+      <Block className={aicoPanelStyles.section} variant="outlined">
         <Flexbox gap={12}>
           <Text strong>{t('wallet.transactions')}</Text>
-          <Table
-            dataSource={txs || []}
-            pagination={false}
-            rowKey="id"
-            columns={[
-              { dataIndex: 'type', title: t('wallet.columns.type') },
-              {
-                dataIndex: 'amountUsd',
-                title: t('wallet.columns.usd'),
-                render: (v) => (v == null ? '—' : Number(v).toFixed(4)),
-              },
-              {
-                dataIndex: 'amountToman',
-                title: t('wallet.columns.toman'),
-                render: (v: number | string) => Number(v ?? 0).toLocaleString(),
-              },
-              {
-                dataIndex: 'createdAt',
-                title: t('wallet.columns.date'),
-                render: (v: Date | string) => new Date(v).toLocaleString(),
-              },
-            ]}
-          />
+          <div className={aicoPanelStyles.tableScroll}>
+            <Table
+              dataSource={txs || []}
+              pagination={false}
+              rowKey="id"
+              scroll={AICO_TABLE_SCROLL}
+              columns={[
+                { dataIndex: 'type', title: t('wallet.columns.type') },
+                {
+                  dataIndex: 'amountUsd',
+                  title: t('wallet.columns.usd'),
+                  render: (v) => (v == null ? '—' : Number(v).toFixed(4)),
+                },
+                {
+                  dataIndex: 'amountToman',
+                  title: t('wallet.columns.toman'),
+                  render: (v: number | string) => Number(v ?? 0).toLocaleString(),
+                },
+                {
+                  dataIndex: 'createdAt',
+                  title: t('wallet.columns.date'),
+                  render: (v: Date | string) => new Date(v).toLocaleString(),
+                },
+              ]}
+            />
+          </div>
         </Flexbox>
       </Block>
     </Flexbox>

--- a/src/features/ControlPlaneShell/ControlPlaneTheme.rtl.test.ts
+++ b/src/features/ControlPlaneShell/ControlPlaneTheme.rtl.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Control-plane SPA does not use AppTheme; Persian Tabs/Switch indicators
+ * still need GlobalStyle (same RTL offset vs inset-inline-start fix as Settings).
+ */
+describe('ControlPlaneTheme RTL chrome', () => {
+  const source = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), 'ControlPlaneTheme.tsx'),
+    'utf8',
+  );
+
+  it('mounts GlobalStyle so tab pills align under dir=rtl', () => {
+    expect(source).toContain("from '@/styles'");
+    expect(source).toContain('<GlobalStyle />');
+  });
+});

--- a/src/features/ControlPlaneShell/ControlPlaneTheme.tsx
+++ b/src/features/ControlPlaneShell/ControlPlaneTheme.tsx
@@ -16,6 +16,7 @@ import { useIsDark } from '@/hooks/useIsDark';
 import { useLocaleThemeFont } from '@/hooks/useLocaleThemeFont';
 import Image from '@/libs/next/Image';
 import Link from '@/libs/next/Link';
+import { GlobalStyle } from '@/styles';
 
 /** Full-viewport panel surface — no darker colorBgLayout header/footer bands. */
 const styles = createStaticStyles(({ css, cssVar: v }) => ({
@@ -80,6 +81,7 @@ const ControlPlaneTheme = memo<PropsWithChildren>(({ children }) => {
       }}
     >
       {!!fontURL && <FontLoader url={fontURL} />}
+      <GlobalStyle />
       <App className={styles.root} style={{ background: cssVar.colorBgContainer, height: '100%' }}>
         <AntdStaticMethods />
         <ConfigProvider config={{ aAs: Link, imgAs: Image, imgUnoptimized: true }} motion={m}>

--- a/src/features/OrgAdmin/OrgAdminMembers.tsx
+++ b/src/features/OrgAdmin/OrgAdminMembers.tsx
@@ -19,7 +19,7 @@ import {
   type FxTopupFormValues,
 } from '@/features/AicoBilling/FxTopupFields';
 import { groupedNumberInputProps } from '@/features/AicoBilling/groupedNumberInput';
-import { aicoPanelStyles } from '@/features/AicoPanels';
+import { AICO_TABLE_SCROLL, aicoPanelStyles } from '@/features/AicoPanels';
 import { presentInviteLink } from '@/features/OrgAdmin/InviteLinkModal';
 import { buildPhoneVerifyRedirectUrl, isValidIranianPhoneNumber } from '@/libs/better-auth/phone';
 import { useClientDataSWR } from '@/libs/swr';
@@ -28,21 +28,6 @@ import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  grid: css`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 12px;
-  `,
-  page: css`
-    width: 100%;
-    max-width: 1100px;
-  `,
-  section: css`
-    padding: 16px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusLG};
-    background: ${cssVar.colorBgContainer};
-  `,
   dangerCard: css`
     padding: 16px;
     border: 1px solid ${cssVar.colorErrorBorder};
@@ -76,7 +61,11 @@ const nextUtcBoundaryLocal = (period: 'daily' | 'weekly' | 'monthly' | undefined
   if (period === 'weekly') {
     const day = utcNow.getUTCDay(); // 0 Sun … 6 Sat
     const daysUntilMon = day === 0 ? 1 : 8 - day;
-    next.setUTCFullYear(utcNow.getUTCFullYear(), utcNow.getUTCMonth(), utcNow.getUTCDate() + daysUntilMon);
+    next.setUTCFullYear(
+      utcNow.getUTCFullYear(),
+      utcNow.getUTCMonth(),
+      utcNow.getUTCDate() + daysUntilMon,
+    );
     next.setUTCHours(0, 0, 0, 0);
   } else if (period === 'monthly') {
     next.setUTCFullYear(utcNow.getUTCFullYear(), utcNow.getUTCMonth() + 1, 1);
@@ -320,8 +309,8 @@ export const OrgAdminMembers = () => {
 
   if (manageable.length === 0) {
     return (
-      <Flexbox className={styles.page} gap={16}>
-        <Block className={styles.section} variant="outlined">
+      <Flexbox className={aicoPanelStyles.page} gap={16}>
+        <Block className={aicoPanelStyles.section} variant="outlined">
           <Flexbox gap={12}>
             <Flexbox gap={4}>
               <Text strong style={{ fontSize: 18 }}>
@@ -379,7 +368,7 @@ export const OrgAdminMembers = () => {
   }
 
   return (
-    <Flexbox className={styles.page} gap={20}>
+    <Flexbox className={aicoPanelStyles.page} gap={20}>
       <Flexbox gap={8}>
         <Flexbox horizontal align="center" gap={12} justify="space-between" wrap="wrap">
           <Flexbox gap={4}>
@@ -416,7 +405,7 @@ export const OrgAdminMembers = () => {
         </div>
       ) : null}
 
-      <div className={styles.grid}>
+      <div className={aicoPanelStyles.grid}>
         <StatisticCard
           statistic={{ prefix: <WalletIcon size={16} />, value: usd(dashboard?.unallocatedUsd) }}
           title={t('org.stat.unallocated')}
@@ -454,7 +443,7 @@ export const OrgAdminMembers = () => {
 
       {tab === 'overview' && (
         <Flexbox gap={16}>
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={12}>
               <Text strong>{t('org.usageChart')}</Text>
               <Text type="secondary">{t('org.usageChartHint')}</Text>
@@ -487,79 +476,86 @@ export const OrgAdminMembers = () => {
             </Flexbox>
           </Block>
 
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={12}>
               <Text strong>{t('org.memberUsageTitle')}</Text>
               {usageBars.length > 0 ? (
                 <BarList data={usageBars} valueFormatter={(v) => usd(v)} />
               ) : null}
-              <Table
-                dataSource={dashboard?.members || []}
-                pagination={false}
-                rowKey="memberId"
-                size="middle"
-                columns={[
-                  {
-                    dataIndex: 'publicCode',
-                    title: t('org.columns.publicId'),
-                    render: (v: string | null, row) => v || row.userId.slice(0, 12),
-                  },
-                  {
-                    dataIndex: 'email',
-                    title: t('org.columns.email'),
-                    render: (v: string | null) => v || '—',
-                  },
-                  {
-                    dataIndex: 'username',
-                    title: t('org.columns.username'),
-                    render: (v: string | null) => v || '—',
-                  },
-                  { dataIndex: 'role', title: t('org.columns.role') },
-                  {
-                    dataIndex: 'teamName',
-                    title: t('org.columns.team'),
-                    render: (v: string | null) => v || t('org.unspecifiedTeam'),
-                  },
-                  {
-                    dataIndex: 'period',
-                    title: t('org.columns.period'),
-                    render: (v: string | null) => t(periodLabelKey(v)),
-                  },
-                  {
-                    dataIndex: 'periodAmountUsd',
-                    title: t('org.columns.limit'),
-                    render: (v: string) => usd(v),
-                  },
-                  {
-                    dataIndex: 'settledUsageUsd',
-                    title: t('org.columns.used'),
-                    render: (v: string) => usd(v),
-                  },
-                  {
-                    dataIndex: 'remainingUsd',
-                    title: t('org.columns.remaining'),
-                    render: (v: string) => usd(v),
-                  },
-                  {
-                    dataIndex: 'nextRenewalAt',
-                    title: t('org.columns.nextRenewal'),
-                    render: (v: string | null) => (v ? dayjs(v).format('YYYY-MM-DD HH:mm') : '—'),
-                  },
-                  {
-                    key: 'pending',
-                    title: t('org.columns.pending'),
-                    render: (_, row) =>
-                      row.pendingPeriod
-                        ? `${t(periodLabelKey(row.pendingPeriod))} ${usd(row.pendingPeriodAmountUsd)}`
-                        : '—',
-                  },
-                  {
-                    dataIndex: 'renewalStatus',
-                    title: t('org.columns.renewalStatus'),
-                    render: (v: string | null) => v || '—',
-                  },
-                ]}
-              />
+              <div className={aicoPanelStyles.tableScroll}>
+                <Table
+                  dataSource={dashboard?.members || []}
+                  pagination={false}
+                  rowKey="memberId"
+                  scroll={AICO_TABLE_SCROLL}
+                  size="middle"
+                  columns={[
+                    {
+                      dataIndex: 'publicCode',
+                      ellipsis: true,
+                      title: t('org.columns.publicId'),
+                      render: (v: string | null, row) => v || row.userId.slice(0, 12),
+                    },
+                    {
+                      dataIndex: 'email',
+                      ellipsis: true,
+                      title: t('org.columns.email'),
+                      render: (v: string | null) => v || '—',
+                    },
+                    {
+                      dataIndex: 'username',
+                      ellipsis: true,
+                      title: t('org.columns.username'),
+                      render: (v: string | null) => v || '—',
+                    },
+                    { dataIndex: 'role', title: t('org.columns.role') },
+                    {
+                      dataIndex: 'teamName',
+                      ellipsis: true,
+                      title: t('org.columns.team'),
+                      render: (v: string | null) => v || t('org.unspecifiedTeam'),
+                    },
+                    {
+                      dataIndex: 'period',
+                      title: t('org.columns.period'),
+                      render: (v: string | null) => t(periodLabelKey(v)),
+                    },
+                    {
+                      dataIndex: 'periodAmountUsd',
+                      title: t('org.columns.limit'),
+                      render: (v: string) => usd(v),
+                    },
+                    {
+                      dataIndex: 'settledUsageUsd',
+                      title: t('org.columns.used'),
+                      render: (v: string) => usd(v),
+                    },
+                    {
+                      dataIndex: 'remainingUsd',
+                      title: t('org.columns.remaining'),
+                      render: (v: string) => usd(v),
+                    },
+                    {
+                      dataIndex: 'nextRenewalAt',
+                      title: t('org.columns.nextRenewal'),
+                      render: (v: string | null) => (v ? dayjs(v).format('YYYY-MM-DD HH:mm') : '—'),
+                    },
+                    {
+                      key: 'pending',
+                      title: t('org.columns.pending'),
+                      render: (_, row) =>
+                        row.pendingPeriod
+                          ? `${t(periodLabelKey(row.pendingPeriod))} ${usd(row.pendingPeriodAmountUsd)}`
+                          : '—',
+                    },
+                    {
+                      dataIndex: 'renewalStatus',
+                      title: t('org.columns.renewalStatus'),
+                      render: (v: string | null) => v || '—',
+                    },
+                  ]}
+                />
+              </div>
             </Flexbox>
           </Block>
         </Flexbox>
@@ -567,7 +563,7 @@ export const OrgAdminMembers = () => {
 
       {tab === 'members' && (
         <Flexbox gap={16}>
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={16}>
               <Text strong>{t('org.invite.title')}</Text>
               <Form
@@ -632,7 +628,7 @@ export const OrgAdminMembers = () => {
             </Flexbox>
           </Block>
 
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={12}>
               <Text strong>{t('org.allocateTitle')}</Text>
               <Text type="secondary">{t('org.allocateHint')}</Text>
@@ -693,12 +689,12 @@ export const OrgAdminMembers = () => {
                     style={{ minWidth: 160 }}
                   >
                     <Select
+                      style={{ width: '100%' }}
                       options={[
                         { label: t('org.period.daily'), value: 'daily' },
                         { label: t('org.period.weekly'), value: 'weekly' },
                         { label: t('org.period.monthly'), value: 'monthly' },
                       ]}
-                      style={{ width: '100%' }}
                     />
                   </Form.Item>
                   <Form.Item
@@ -722,8 +718,11 @@ export const OrgAdminMembers = () => {
                   </Text>
                 ) : null}
                 {(() => {
-                  const current = (dashboard?.members || []).find((m) => m.memberId === allocMemberId);
-                  if (!current?.period || !allocPeriod || current.period === allocPeriod) return null;
+                  const current = (dashboard?.members || []).find(
+                    (m) => m.memberId === allocMemberId,
+                  );
+                  if (!current?.period || !allocPeriod || current.period === allocPeriod)
+                    return null;
                   if (Number(current.periodAmountUsd) <= 0) return null;
                   return (
                     <Text type="secondary">
@@ -741,62 +740,142 @@ export const OrgAdminMembers = () => {
             </Flexbox>
           </Block>
 
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={12}>
               <Text strong>{t('org.membersTitle')}</Text>
-              <Table
-                dataSource={roster?.members || []}
-                loading={loadingRoster}
-                pagination={false}
-                rowKey="id"
-                columns={[
-                  {
-                    dataIndex: 'publicCode',
-                    title: t('org.columns.publicId'),
-                    render: (v: string | null, row) => v || row.userId.slice(0, 12),
-                  },
-                  {
-                    dataIndex: 'email',
-                    title: t('org.columns.email'),
-                    render: (v: string | null) => v || '—',
-                  },
-                  {
-                    dataIndex: 'username',
-                    title: t('org.columns.username'),
-                    render: (v: string | null) => v || '—',
-                  },
-                  { dataIndex: 'role', title: t('org.columns.role') },
-                  { dataIndex: 'status', title: t('org.columns.status') },
-                  {
-                    key: 'team',
-                    title: t('org.columns.team'),
-                    render: (_, row) => (
-                      <Select
-                        disabled={readOnly}
-                        placeholder={t('org.assignTeam')}
-                        style={{ minWidth: 140 }}
-                        options={(teams || []).map((team) => ({
-                          label: team.name,
-                          value: team.id,
-                        }))}
-                        onChange={async (teamId) => {
-                          if (!selectedOrgId || readOnly) return;
-                          await lambdaClient.organization.assignMemberToTeam.mutate({
-                            orgId: selectedOrgId,
-                            orgMemberId: row.id,
-                            teamId,
-                          });
-                          toast.success(t('org.teamAssigned'));
-                          await refreshAll();
-                        }}
-                      />
-                    ),
-                  },
-                  {
-                    key: 'actions',
-                    title: t('org.columns.actions'),
-                    render: (_, row) =>
-                      row.role === 'owner' || readOnly ? null : (
+              <div className={aicoPanelStyles.tableScroll}>
+                <Table
+                  dataSource={roster?.members || []}
+                  loading={loadingRoster}
+                  pagination={false}
+                  rowKey="id"
+                  scroll={AICO_TABLE_SCROLL}
+                  columns={[
+                    {
+                      dataIndex: 'publicCode',
+                      ellipsis: true,
+                      title: t('org.columns.publicId'),
+                      render: (v: string | null, row) => v || row.userId.slice(0, 12),
+                    },
+                    {
+                      dataIndex: 'email',
+                      ellipsis: true,
+                      title: t('org.columns.email'),
+                      render: (v: string | null) => v || '—',
+                    },
+                    {
+                      dataIndex: 'username',
+                      ellipsis: true,
+                      title: t('org.columns.username'),
+                      render: (v: string | null) => v || '—',
+                    },
+                    { dataIndex: 'role', title: t('org.columns.role') },
+                    { dataIndex: 'status', title: t('org.columns.status') },
+                    {
+                      key: 'team',
+                      title: t('org.columns.team'),
+                      render: (_, row) => (
+                        <Select
+                          disabled={readOnly}
+                          placeholder={t('org.assignTeam')}
+                          style={{ minWidth: 140 }}
+                          options={(teams || []).map((team) => ({
+                            label: team.name,
+                            value: team.id,
+                          }))}
+                          onChange={async (teamId) => {
+                            if (!selectedOrgId || readOnly) return;
+                            await lambdaClient.organization.assignMemberToTeam.mutate({
+                              orgId: selectedOrgId,
+                              orgMemberId: row.id,
+                              teamId,
+                            });
+                            toast.success(t('org.teamAssigned'));
+                            await refreshAll();
+                          }}
+                        />
+                      ),
+                    },
+                    {
+                      key: 'actions',
+                      title: t('org.columns.actions'),
+                      render: (_, row) =>
+                        row.role === 'owner' || readOnly ? null : (
+                          <Flexbox horizontal gap={4}>
+                            <Button
+                              size="small"
+                              type="text"
+                              onClick={async () => {
+                                if (!selectedOrgId) return;
+                                try {
+                                  const result =
+                                    await lambdaClient.organization.revokeMemberBudget.mutate({
+                                      orgId: selectedOrgId,
+                                      orgMemberId: row.id,
+                                    });
+                                  toast.success(
+                                    t('org.reclaimSuccess', {
+                                      usd: Number(result.reclaimedUsd).toFixed(2),
+                                    }),
+                                  );
+                                  await refreshAll();
+                                } catch (error) {
+                                  toastAicoError(error, t, 'org.reclaimFailed');
+                                }
+                              }}
+                            >
+                              {t('org.reclaim')}
+                            </Button>
+                            <Button
+                              size="small"
+                              type="text"
+                              onClick={async () => {
+                                if (!selectedOrgId) return;
+                                try {
+                                  await lambdaClient.organization.removeMember.mutate({
+                                    memberId: row.id,
+                                    orgId: selectedOrgId,
+                                  });
+                                  toast.success(t('org.removeSuccess'));
+                                  await refreshAll();
+                                } catch (error) {
+                                  toastAicoError(error, t, 'org.removeFailed');
+                                }
+                              }}
+                            >
+                              {t('org.remove')}
+                            </Button>
+                          </Flexbox>
+                        ),
+                    },
+                  ]}
+                />
+              </div>
+            </Flexbox>
+          </Block>
+
+          <Block className={aicoPanelStyles.section} variant="outlined">
+            <Flexbox gap={12}>
+              <Text strong>{t('org.pendingInvites')}</Text>
+              <div className={aicoPanelStyles.tableScroll}>
+                <Table
+                  dataSource={roster?.invites || []}
+                  loading={loadingRoster}
+                  pagination={false}
+                  rowKey="id"
+                  scroll={AICO_TABLE_SCROLL}
+                  columns={[
+                    { dataIndex: 'identifierType', title: t('org.columns.type') },
+                    {
+                      dataIndex: 'identifierValue',
+                      ellipsis: true,
+                      title: t('org.columns.value'),
+                    },
+                    { dataIndex: 'role', title: t('org.columns.role') },
+                    {
+                      key: 'actions',
+                      title: t('org.columns.actions'),
+                      render: (_, row) => (
                         <Flexbox horizontal gap={4}>
                           <Button
                             size="small"
@@ -804,106 +883,39 @@ export const OrgAdminMembers = () => {
                             onClick={async () => {
                               if (!selectedOrgId) return;
                               try {
-                                const result =
-                                  await lambdaClient.organization.revokeMemberBudget.mutate({
-                                    orgId: selectedOrgId,
-                                    orgMemberId: row.id,
-                                  });
-                                toast.success(
-                                  t('org.reclaimSuccess', {
-                                    usd: Number(result.reclaimedUsd).toFixed(2),
-                                  }),
-                                );
-                                await refreshAll();
+                                const result = await lambdaClient.organization.getInviteLink.query({
+                                  inviteId: row.id,
+                                  orgId: selectedOrgId,
+                                });
+                                presentInviteLink(result.inviteUrl);
                               } catch (error) {
-                                toastAicoError(error, t, 'org.reclaimFailed');
+                                toastAicoError(error, t, 'org.invite.showLinkFailed');
                               }
                             }}
                           >
-                            {t('org.reclaim')}
+                            {t('org.invite.showLink')}
                           </Button>
                           <Button
+                            disabled={readOnly}
                             size="small"
                             type="text"
                             onClick={async () => {
-                              if (!selectedOrgId) return;
-                              try {
-                                await lambdaClient.organization.removeMember.mutate({
-                                  memberId: row.id,
-                                  orgId: selectedOrgId,
-                                });
-                                toast.success(t('org.removeSuccess'));
-                                await refreshAll();
-                              } catch (error) {
-                                toastAicoError(error, t, 'org.removeFailed');
-                              }
-                            }}
-                          >
-                            {t('org.remove')}
-                          </Button>
-                        </Flexbox>
-                      ),
-                  },
-                ]}
-              />
-            </Flexbox>
-          </Block>
-
-          <Block className={styles.section} variant="outlined">
-            <Flexbox gap={12}>
-              <Text strong>{t('org.pendingInvites')}</Text>
-              <Table
-                dataSource={roster?.invites || []}
-                loading={loadingRoster}
-                pagination={false}
-                rowKey="id"
-                columns={[
-                  { dataIndex: 'identifierType', title: t('org.columns.type') },
-                  { dataIndex: 'identifierValue', title: t('org.columns.value') },
-                  { dataIndex: 'role', title: t('org.columns.role') },
-                  {
-                    key: 'actions',
-                    title: t('org.columns.actions'),
-                    render: (_, row) => (
-                      <Flexbox horizontal gap={4}>
-                        <Button
-                          size="small"
-                          type="text"
-                          onClick={async () => {
-                            if (!selectedOrgId) return;
-                            try {
-                              const result = await lambdaClient.organization.getInviteLink.query({
+                              if (!selectedOrgId || readOnly) return;
+                              await lambdaClient.organization.revokeInvite.mutate({
                                 inviteId: row.id,
                                 orgId: selectedOrgId,
                               });
-                              presentInviteLink(result.inviteUrl);
-                            } catch (error) {
-                              toastAicoError(error, t, 'org.invite.showLinkFailed');
-                            }
-                          }}
-                        >
-                          {t('org.invite.showLink')}
-                        </Button>
-                        <Button
-                          disabled={readOnly}
-                          size="small"
-                          type="text"
-                          onClick={async () => {
-                            if (!selectedOrgId || readOnly) return;
-                            await lambdaClient.organization.revokeInvite.mutate({
-                              inviteId: row.id,
-                              orgId: selectedOrgId,
-                            });
-                            await mutate();
-                          }}
-                        >
-                          {t('org.revoke')}
-                        </Button>
-                      </Flexbox>
-                    ),
-                  },
-                ]}
-              />
+                              await mutate();
+                            }}
+                          >
+                            {t('org.revoke')}
+                          </Button>
+                        </Flexbox>
+                      ),
+                    },
+                  ]}
+                />
+              </div>
             </Flexbox>
           </Block>
         </Flexbox>
@@ -911,7 +923,7 @@ export const OrgAdminMembers = () => {
 
       {tab === 'teams' && (
         <Flexbox gap={16}>
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={16}>
               <Text strong>{t('org.teamsTitle')}</Text>
               <Text type="secondary">{t('org.teamsHint')}</Text>
@@ -943,54 +955,57 @@ export const OrgAdminMembers = () => {
                   {t('org.teamCreate')}
                 </Button>
               </Form>
-              <Table
-                dataSource={teams || []}
-                pagination={false}
-                rowKey="id"
-                columns={[
-                  { dataIndex: 'name', title: t('org.columns.team') },
-                  {
-                    dataIndex: 'isDefault',
-                    title: t('org.columns.default'),
-                    render: (v: boolean) => (v ? '✓' : ''),
-                  },
-                  {
-                    dataIndex: 'modelIds',
-                    title: t('org.columns.models'),
-                    render: (ids: string[]) =>
-                      ids?.length ? (
-                        <Flexbox horizontal gap={4} wrap="wrap">
-                          {ids.map((id) => (
-                            <Tag key={id}>{id}</Tag>
-                          ))}
-                        </Flexbox>
-                      ) : (
-                        t('org.noModelsGranted')
-                      ),
-                  },
-                  {
-                    key: 'actions',
-                    title: t('org.columns.actions'),
-                    render: (_, row) =>
-                      row.isDefault || readOnly ? null : (
-                        <Button
-                          size="small"
-                          type="text"
-                          onClick={async () => {
-                            if (!selectedOrgId) return;
-                            await lambdaClient.organization.deleteTeam.mutate({
-                              orgId: selectedOrgId,
-                              teamId: row.id,
-                            });
-                            await mutateTeams();
-                          }}
-                        >
-                          {t('org.delete')}
-                        </Button>
-                      ),
-                  },
-                ]}
-              />
+              <div className={aicoPanelStyles.tableScroll}>
+                <Table
+                  dataSource={teams || []}
+                  pagination={false}
+                  rowKey="id"
+                  scroll={AICO_TABLE_SCROLL}
+                  columns={[
+                    { dataIndex: 'name', ellipsis: true, title: t('org.columns.team') },
+                    {
+                      dataIndex: 'isDefault',
+                      title: t('org.columns.default'),
+                      render: (v: boolean) => (v ? '✓' : ''),
+                    },
+                    {
+                      dataIndex: 'modelIds',
+                      title: t('org.columns.models'),
+                      render: (ids: string[]) =>
+                        ids?.length ? (
+                          <Flexbox horizontal gap={4} wrap="wrap">
+                            {ids.map((id) => (
+                              <Tag key={id}>{id}</Tag>
+                            ))}
+                          </Flexbox>
+                        ) : (
+                          t('org.noModelsGranted')
+                        ),
+                    },
+                    {
+                      key: 'actions',
+                      title: t('org.columns.actions'),
+                      render: (_, row) =>
+                        row.isDefault || readOnly ? null : (
+                          <Button
+                            size="small"
+                            type="text"
+                            onClick={async () => {
+                              if (!selectedOrgId) return;
+                              await lambdaClient.organization.deleteTeam.mutate({
+                                orgId: selectedOrgId,
+                                teamId: row.id,
+                              });
+                              await mutateTeams();
+                            }}
+                          >
+                            {t('org.delete')}
+                          </Button>
+                        ),
+                    },
+                  ]}
+                />
+              </div>
               <Form
                 disabled={readOnly}
                 form={modelsForm}
@@ -1050,7 +1065,7 @@ export const OrgAdminMembers = () => {
 
       {tab === 'wallet' && (
         <Flexbox gap={16}>
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={16}>
               <Flexbox horizontal align="center" gap={8}>
                 <Building2Icon size={18} />
@@ -1083,41 +1098,45 @@ export const OrgAdminMembers = () => {
             </Flexbox>
           </Block>
 
-          <Block className={styles.section} variant="outlined">
+          <Block className={aicoPanelStyles.section} variant="outlined">
             <Flexbox gap={12}>
               <Text strong>{t('org.txTitle')}</Text>
               <Text type="secondary">{t('org.txHint')}</Text>
               {rangePicker}
               {(txHistory || []).length > 0 ? (
-                <Table
-                  dataSource={txHistory || []}
-                  pagination={{ pageSize: 20 }}
-                  rowKey="id"
-                  size="middle"
-                  columns={[
-                    {
-                      dataIndex: 'createdAt',
-                      title: t('wallet.columns.date'),
-                      render: (v: string) => new Date(v).toLocaleString(),
-                    },
-                    { dataIndex: 'type', title: t('wallet.columns.type') },
-                    {
-                      dataIndex: 'amountToman',
-                      title: t('wallet.columns.toman'),
-                      render: (v: string) => Number(v).toLocaleString(),
-                    },
-                    {
-                      dataIndex: 'amountUsd',
-                      title: t('wallet.columns.usd'),
-                      render: (v: string) => usd(v),
-                    },
-                    {
-                      dataIndex: 'description',
-                      title: t('org.txDescription'),
-                      render: (v: string | null) => v || '—',
-                    },
-                  ]}
-                />
+                <div className={aicoPanelStyles.tableScroll}>
+                  <Table
+                    dataSource={txHistory || []}
+                    pagination={{ pageSize: 20 }}
+                    rowKey="id"
+                    scroll={AICO_TABLE_SCROLL}
+                    size="middle"
+                    columns={[
+                      {
+                        dataIndex: 'createdAt',
+                        title: t('wallet.columns.date'),
+                        render: (v: string) => new Date(v).toLocaleString(),
+                      },
+                      { dataIndex: 'type', title: t('wallet.columns.type') },
+                      {
+                        dataIndex: 'amountToman',
+                        title: t('wallet.columns.toman'),
+                        render: (v: string) => Number(v).toLocaleString(),
+                      },
+                      {
+                        dataIndex: 'amountUsd',
+                        title: t('wallet.columns.usd'),
+                        render: (v: string) => usd(v),
+                      },
+                      {
+                        dataIndex: 'description',
+                        ellipsis: true,
+                        title: t('org.txDescription'),
+                        render: (v: string | null) => v || '—',
+                      },
+                    ]}
+                  />
+                </div>
               ) : (
                 <Text type="secondary">{t('org.txEmpty')}</Text>
               )}

--- a/src/features/PlatformAdmin/PlatformAdminPanel.tsx
+++ b/src/features/PlatformAdmin/PlatformAdminPanel.tsx
@@ -254,23 +254,27 @@ export const PlatformAdminPanel = () => {
                   },
                   {
                     dataIndex: 'actorEmail',
+                    ellipsis: true,
                     title: t('platform.columns.actor'),
                     render: (v: string | null) => v || '—',
                   },
                   {
                     dataIndex: 'orgName',
+                    ellipsis: true,
                     title: t('platform.columns.org'),
                     render: (v: string | null, row: { orgId?: string | null }) =>
                       v || (row.orgId ? row.orgId.slice(0, 12) : '—'),
                   },
                   {
                     dataIndex: 'userEmail',
+                    ellipsis: true,
                     title: t('platform.columns.userId'),
                     render: (v: string | null, row: { userId?: string | null }) =>
                       v || (row.userId ? row.userId.slice(0, 12) : '—'),
                   },
                   {
                     dataIndex: 'description',
+                    ellipsis: true,
                     title: t('platform.columns.description'),
                     render: (v: string | null) => v || '—',
                   },
@@ -415,7 +419,7 @@ export const PlatformAdminPanel = () => {
                       title: t('platform.columns.publicId'),
                       render: (v: string) => (v ? <Tag>{v}</Tag> : '—'),
                     },
-                    { dataIndex: 'name', title: t('platform.columns.name') },
+                    { dataIndex: 'name', ellipsis: true, title: t('platform.columns.name') },
                     {
                       dataIndex: 'status',
                       title: t('platform.columns.status'),
@@ -677,16 +681,19 @@ export const PlatformAdminPanel = () => {
                   },
                   {
                     dataIndex: 'email',
+                    ellipsis: true,
                     title: t('platform.columns.email'),
                     render: (v: string | null) => v || '—',
                   },
                   {
                     dataIndex: 'username',
+                    ellipsis: true,
                     title: t('platform.columns.username'),
                     render: (v: string | null) => v || '—',
                   },
                   {
                     dataIndex: 'userId',
+                    ellipsis: true,
                     title: t('platform.columns.userId'),
                     render: (v: string) => v.slice(0, 14),
                   },

--- a/src/features/Setting/SettingContainer.tsx
+++ b/src/features/Setting/SettingContainer.tsx
@@ -36,6 +36,7 @@ const SettingContainer = memo<PropsWithChildren<SettingContainerProps>>(
           width={'100%'}
           style={{
             maxWidth,
+            minWidth: 0,
           }}
         >
           {children}

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/SuccessState.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/SuccessState.tsx
@@ -3,6 +3,7 @@
 import { Block } from '@lobehub/ui';
 import { memo } from 'react';
 
+import { GenerationCostBadge } from '@/components/GenerationCostBadge';
 import ImageItem from '@/components/ImageItem';
 
 import { ActionButtons } from './ActionButtons';
@@ -49,6 +50,11 @@ export const SuccessState = memo<SuccessStateProps>(
           onCopySeed={onCopySeed}
           onDelete={onDelete}
           onDownload={onDownload}
+        />
+        <GenerationCostBadge
+          costUsd={
+            generation.asset && 'costUsd' in generation.asset ? generation.asset.costUsd : undefined
+          }
         />
       </Block>
     );

--- a/src/routes/(main)/(create)/video/features/GenerationFeed/VideoSuccessItem.tsx
+++ b/src/routes/(main)/(create)/video/features/GenerationFeed/VideoSuccessItem.tsx
@@ -3,6 +3,7 @@
 import { Block } from '@lobehub/ui';
 import { memo } from 'react';
 
+import { GenerationCostBadge } from '@/components/GenerationCostBadge';
 import { ActionButtons } from '@/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/ActionButtons';
 import { styles } from '@/routes/(main)/(create)/image/features/GenerationFeed/GenerationItem/styles';
 import type { Generation, VideoGenerationAsset } from '@/types/generation';
@@ -27,6 +28,7 @@ const VideoSuccessItem = memo<VideoSuccessItemProps>(({ generation, onDelete, on
         style={{ display: 'block', maxHeight: '50vh', maxWidth: '100%' }}
       />
       <ActionButtons showDownload onDelete={onDelete} onDownload={onDownload} />
+      <GenerationCostBadge costUsd={asset.costUsd} namespace="video" />
     </Block>
   );
 });

--- a/src/store/chat/agents/StreamingHandler.test.ts
+++ b/src/store/chat/agents/StreamingHandler.test.ts
@@ -429,6 +429,20 @@ describe('StreamingHandler', () => {
       expect(result.metadata.reasoning?.duration).toBeGreaterThan(0);
     });
 
+    it('should complete reasoning when the stream finishes without text or stop chunks', async () => {
+      const callbacks = createMockCallbacks();
+      const handler = new StreamingHandler(mockContext, callbacks);
+
+      handler.handleChunk({ type: 'reasoning', text: 'Thinking...' });
+      await new Promise((r) => setTimeout(r, 10));
+
+      const result = await handler.handleFinish({ type: 'stop' });
+
+      expect(callbacks.onReasoningComplete).toHaveBeenCalledWith('reasoning-op-id');
+      expect(result.metadata.reasoning?.content).toBe('Thinking...');
+      expect(result.metadata.reasoning?.duration).toBeGreaterThan(0);
+    });
+
     it('should include grounding from finish data', async () => {
       const callbacks = createMockCallbacks();
       const handler = new StreamingHandler(mockContext, callbacks);

--- a/src/store/chat/agents/StreamingHandler.ts
+++ b/src/store/chat/agents/StreamingHandler.ts
@@ -134,6 +134,8 @@ export class StreamingHandler {
    * Handle streaming finish
    */
   async handleFinish(finishData: FinishData): Promise<StreamingResult> {
+    this.endReasoningIfNeeded();
+
     // Update traceId
     if (finishData.traceId) {
       this.msgTraceId = finishData.traceId;

--- a/src/store/chat/slices/operation/__tests__/actions.test.ts
+++ b/src/store/chat/slices/operation/__tests__/actions.test.ts
@@ -271,6 +271,60 @@ describe('Operation Actions', () => {
       expect(operation.metadata.duration).toBeDefined();
       expect(operation.metadata.duration).toBeGreaterThanOrEqual(0);
     });
+
+    it('should complete still-running reasoning children when the parent finishes', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      let parentId: string;
+      let reasoningId: string;
+
+      act(() => {
+        parentId = result.current.startOperation({
+          type: 'execAgentRuntime',
+          context: { agentId: 'session1' },
+        }).operationId;
+        reasoningId = result.current.startOperation({
+          context: { agentId: 'session1' },
+          parentOperationId: parentId,
+          type: 'reasoning',
+        }).operationId;
+      });
+
+      expect(result.current.operations[reasoningId!].status).toBe('running');
+
+      act(() => {
+        result.current.completeOperation(parentId!);
+      });
+
+      expect(result.current.operations[parentId!].status).toBe('completed');
+      expect(result.current.operations[reasoningId!].status).toBe('completed');
+    });
+
+    it('should complete reasoning children when the parent marks visible loading done', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      let parentId: string;
+      let reasoningId: string;
+
+      act(() => {
+        parentId = result.current.startOperation({
+          type: 'execAgentRuntime',
+          context: { agentId: 'session1' },
+        }).operationId;
+        reasoningId = result.current.startOperation({
+          context: { agentId: 'session1' },
+          parentOperationId: parentId,
+          type: 'reasoning',
+        }).operationId;
+      });
+
+      act(() => {
+        result.current.updateOperationMetadata(parentId!, { visibleLoadingDone: true });
+      });
+
+      expect(result.current.operations[parentId!].status).toBe('running');
+      expect(result.current.operations[reasoningId!].status).toBe('completed');
+    });
   });
 
   describe('cancelOperation', () => {

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -231,6 +231,10 @@ export class OperationActionsImpl {
       false,
       n(`updateOperationMetadata/${operationId}`),
     );
+
+    if (metadata.visibleLoadingDone) {
+      this.completeRunningReasoningChildren(operationId);
+    }
   };
 
   updateOperationStatus = (
@@ -310,6 +314,23 @@ export class OperationActionsImpl {
       false,
       n(`completeOperation/${operationId}`),
     );
+
+    this.completeRunningReasoningChildren(operationId);
+  };
+
+  /**
+   * Reasoning child ops do not inherit `visibleLoadingDone` from the parent runtime.
+   * Complete them when the parent finishes so the Thinking accordion / tray cannot stick.
+   */
+  completeRunningReasoningChildren = (operationId: string): void => {
+    const parent = this.#get().operations[operationId];
+    const childIds = parent?.childOperationIds ?? [];
+    for (const childId of childIds) {
+      const child = this.#get().operations[childId];
+      if (child?.type === 'reasoning' && child.status === 'running') {
+        this.completeOperation(childId);
+      }
+    }
   };
 
   getOperationAbortSignal = (operationId: string): AbortSignal => {


### PR DESCRIPTION
## Summary

- Rebrand inbox/skill/tool system prompts with `BRANDING_NAME` while keeping `lh` / `lobehub` / `lobe-*` identifiers.
- Re-enable the managed OpenRouter key on `reactivateUser` via `ensureUserKey`.
- End stuck Thinking by completing reasoning ops on stream finish and parent `visibleLoadingDone`.
- Persist OpenRouter `usage.cost` on generation assets and show USD cost on image/video success tiles.
- Inject wallet `aicoBilling` and filter chat photo models to managed providers; instruct the agent to send video requests to `/video`.

## Test plan

- [x] `bun run check` on touched files (lint + 176 related tests)
- [x] Inbox persona says Panachat AI (or localized inbox name), not Lobe
- [ ] Platform admin: deactivate user disables the OpenRouter key; reactivate re-enables it when the wallet has balance
- [x] After a reasoning-only reply, Send is available and the Thinking tray is not stuck
- [ ] Image/video success tiles show the USD cost when OpenRouter reports `usage.cost`
- [ ] In-chat photo generation succeeds after tool approval (managed provider + billing)
- [ ] Asking for a video in chat points the user to Create → Video (`/video`) instead of CLI/sandbox workarounds

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #291

Plane: [AICO-174](https://plane.panafor.com/panaforai/browse/AICO-174)

Made with [Cursor](https://cursor.com)