### PR TITLE
🐛 fix(deploy): count operator admins from platform_admin_users

### DIFF
--- a/scripts/panachat-deploy-remote.guard.test.ts
+++ b/scripts/panachat-deploy-remote.guard.test.ts
@@ -53,6 +53,7 @@ describe('control-plane CI/CD wiring', () => {
 
     expect(script).toContain('echo "Users:');
     expect(script).toContain('Platform admins:');
+    expect(script).toContain('FROM platform_admin_users');
     expect(script).toContain('Control plane /health');
 
     for (const yaml of [canary, preview]) {

--- a/scripts/panachat-deploy-remote.sh
+++ b/scripts/panachat-deploy-remote.sh
@@ -242,7 +242,8 @@ postgres_user_count() {
 postgres_admin_count() {
   local container="${POSTGRES_CONTAINER:-${PANACHAT_STACK}-postgres}"
   local db="${LOBE_DB_NAME:-${PANACHAT_DB_NAME:-lobechat}}"
-  docker exec "$container" psql -U postgres -d "$db" -Atc "SELECT count(*) FROM platform_admins;" 2>/dev/null || echo "?"
+  # Operator logins live in platform_admin_users (separate password from chat users).
+  docker exec "$container" psql -U postgres -d "$db" -Atc "SELECT count(*) FROM platform_admin_users;" 2>/dev/null || echo "?"
 }
 
 # Same safety as moz: refuse deploy if live users dropped vs last healthy fingerprint.


### PR DESCRIPTION
<!-- Brief and heads-up -->

Canary `status` counted `platform_admins` (legacy chat-user grants) and printed 0 operators. Control-plane logins live in `platform_admin_users` with a separate password.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check scripts/panachat-deploy-remote.sh scripts/panachat-deploy-remote.guard.test.ts`
- After merge, on kamyar: `PANACHAT_ENV=canary ./scripts/panachat-deploy-remote.sh status` should show operator count from `platform_admin_users` (3 on current prod), not 0.

#### 🔗 Related Issue

Fixes #296

Plane: [AICO-176](https://plane.panafor.com/panaforai/browse/AICO-176)

Made with [Cursor](https://cursor.com)