### PR TITLE
feat: support multiple reference imageUrls in OpenRouter image editing

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
@@ -911,5 +911,66 @@ describe('createOpenAICompatibleImage', () => {
       expect(result.imageUrl).toBe('data:image/png;base64,fromImagesApi');
       expect(mockClient.images.generate).toHaveBeenCalled();
     });
+
+    it('sends multiple imageUrls in chat completions for OpenRouter', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: [{ image_url: { url: 'data:image/png;base64,result' }, type: 'image_url' }],
+            },
+          },
+        ],
+      } as any);
+
+      const result = await createOpenAICompatibleImage(
+        mockClient,
+        {
+          model: 'black-forest-labs/flux-2',
+          params: {
+            imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+            prompt: 'combine these images',
+          },
+        },
+        'openrouter',
+      );
+
+      expect(result.imageUrl).toBe('data:image/png;base64,result');
+      const callArgs = vi.mocked(mockClient.chat.completions.create).mock.calls[0][0] as any;
+      expect(callArgs.messages[0].content).toHaveLength(3); // text + 2 images
+      expect(callArgs.messages[0].content[1].type).toBe('image_url');
+      expect(callArgs.messages[0].content[2].type).toBe('image_url');
+    });
+
+    it('combines imageUrl and imageUrls for OpenRouter', async () => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: [
+                { image_url: { url: 'data:image/png;base64,combined' }, type: 'image_url' },
+              ],
+            },
+          },
+        ],
+      } as any);
+
+      const result = await createOpenAICompatibleImage(
+        mockClient,
+        {
+          model: 'black-forest-labs/flux-2',
+          params: {
+            imageUrl: 'https://example.com/main.jpg',
+            imageUrls: ['https://example.com/ref1.jpg'],
+            prompt: 'edit with reference',
+          },
+        },
+        'openrouter',
+      );
+
+      expect(result.imageUrl).toBe('data:image/png;base64,combined');
+      const callArgs = vi.mocked(mockClient.chat.completions.create).mock.calls[0][0] as any;
+      expect(callArgs.messages[0].content).toHaveLength(3); // text + imageUrl + imageUrls
+    });
   });
 });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -257,11 +257,22 @@ async function generateByChatModel(
     },
   ];
 
-  // Add image for editing mode if provided
+  // Add image(s) for editing mode if provided
+  // Support both single imageUrl and multiple imageUrls
+  const referenceImages: string[] = [];
+
   if (params.imageUrl && params.imageUrl !== null) {
-    log('Processing image URL for editing mode: %s', params.imageUrl);
+    referenceImages.push(params.imageUrl);
+  }
+  if (Array.isArray(params.imageUrls) && params.imageUrls.length > 0) {
+    referenceImages.push(...params.imageUrls);
+  }
+
+  // Process all reference images
+  for (const imageUrl of referenceImages) {
+    log('Processing image URL for editing mode: %s', imageUrl);
     try {
-      const processedImageUrl = await processImageUrlForChat(params.imageUrl);
+      const processedImageUrl = await processImageUrlForChat(imageUrl);
       content.push({
         image_url: {
           url: processedImageUrl,


### PR DESCRIPTION
## Summary
- `generateByChatModel` now collects both single `imageUrl` and multiple `imageUrls[]` into one reference list and pushes **every** processed image into the chat-completions content, instead of silently dropping extra references.
- Enables multi-image edit flows (e.g. combining/merging several inputs) on OpenRouter chat-based image models like `black-forest-labs/flux-2`.

## Tests
- New regression test: multi-image `imageUrls` payload produces text + N `image_url` parts.
- New regression test: `imageUrl` + `imageUrls` are combined into a single content array.
- `bun run check`: lint clean, 31 tests passed.