### PR TITLE
🐛 fix(deploy): preview stack infra — shared-S3 endpoint, backup env isolation, SMTP network path

### DIFF
--- a/.env.example.preview
+++ b/.env.example.preview
@@ -41,3 +41,5 @@ SSRF_ALLOW_PRIVATE_IP_ADDRESS=0
 # S3_BUCKET=lobe
 # S3_ENABLE_PATH_STYLE=1
 # S3_SET_ACL=0
+# When reusing the prod S3 endpoint, keep S3_BUCKET distinct (e.g. panachat-preview);
+# the infra env (.env.preview) pins both S3_ENDPOINT and S3_INTERNAL_ENDPOINT to it.

--- a/docker-compose/deploy/.env.example.preview
+++ b/docker-compose/deploy/.env.example.preview
@@ -27,6 +27,12 @@ RUSTFS_ACCESS_KEY=admin
 RUSTFS_SECRET_KEY=change-me-preview-rustfs-secret
 RUSTFS_LOBE_BUCKET=lobe
 S3_ENDPOINT=https://s3-preview.example.com
+# Reuse-prod-S3 mode (no extra DNS): point BOTH endpoints at the prod public
+# endpoint, set RUSTFS_ACCESS_KEY/RUSTFS_SECRET_KEY to the PROD credentials,
+# and use a dedicated bucket (e.g. RUSTFS_LOBE_BUCKET=panachat-preview).
+# The compose override keeps server-side SDK calls on the same store as
+# browser presigned uploads — without this they would split across stacks.
+# S3_INTERNAL_ENDPOINT=https://s3.panafor.com
 RUSTFS_CORS_ALLOWED_ORIGINS=*
 
 JWKS_KEY={"keys":[{"kty":"RSA","kid":"replace-me-preview","use":"sig","alg":"RS256","n":"replace-me","e":"AQAB","d":"replace-me","p":"replace-me","q":"replace-me","dp":"replace-me","dq":"replace-me","qi":"replace-me"}]}

--- a/docker-compose/deploy/docker-compose.panachat.yml
+++ b/docker-compose/deploy/docker-compose.panachat.yml
@@ -55,8 +55,9 @@ services:
     env_file:
       - ${PANACHAT_APP_ENV_FILE:-../../.env}
       - ${PANACHAT_INFRA_ENV_FILE:-.env}
-    extra_hosts:
-      - 'mailer.panafor.com:host-gateway'
+    # SMTP reaches the stalwart container directly: the deploy attaches it to
+    # this network with the alias "mailer.panafor.com" (TLS cert hostname).
+    # Never re-add extra_hosts:host-gateway — cross-bridge hairpin drops data.
     networks:
       - panachat-network
     restart: unless-stopped
@@ -101,8 +102,9 @@ services:
     env_file:
       - ${PANACHAT_APP_ENV_FILE:-../../.env}
       - ${PANACHAT_INFRA_ENV_FILE:-.env}
-    extra_hosts:
-      - 'mailer.panafor.com:host-gateway'
+    # SMTP reaches the stalwart container directly: the deploy attaches it to
+    # this network with the alias "mailer.panafor.com" (TLS cert hostname).
+    # Never re-add extra_hosts:host-gateway — cross-bridge hairpin drops data.
     networks:
       - panachat-network
     restart: unless-stopped

--- a/scripts/panachat-deploy-remote.guard.test.ts
+++ b/scripts/panachat-deploy-remote.guard.test.ts
@@ -35,7 +35,7 @@ describe('control-plane CI/CD wiring', () => {
     expect(compose).not.toMatch(
       /panachat-control-plane:[\s\S]*?volumes:[\t\v\f\r \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF]*\n\s*-\s+\.\.:\/app/,
     );
-    expect(compose).toContain('S3_INTERNAL_ENDPOINT=http://rustfs:9000');
+    expect(compose).toContain("'S3_INTERNAL_ENDPOINT=${S3_INTERNAL_ENDPOINT:-http://rustfs:9000}'");
     expect(compose).toContain('RUSTFS_CORS_ALLOWED_ORIGINS=${RUSTFS_CORS_ALLOWED_ORIGINS:-*}');
     expect(compose).toContain('pull_policy: always');
 

--- a/scripts/panachat-deploy-remote.guard.test.ts
+++ b/scripts/panachat-deploy-remote.guard.test.ts
@@ -77,6 +77,19 @@ describe('control-plane CI/CD wiring', () => {
     expect(nginx).toContain('not object authorization');
   });
 
+  it('backs up the active stack, never prod state during preview deploys', () => {
+    const script = read('scripts/panachat-deploy-remote.sh');
+    const backup = read('scripts/panachat-backup.sh');
+
+    // Deploy script pins the backup to this stack's infra env…
+    expect(script).toContain(
+      'export PANACHAT_INFRA_ENV_FILE="${PANACHAT_INFRA_ENV_FILE:-$INFRA_ENV_FILE}"',
+    );
+    // …and the backup script must not hardcode the prod $DEPLOY_DIR/.env.
+    expect(backup).toContain('local envf="${PANACHAT_INFRA_ENV_FILE:-$DEPLOY_DIR/.env}"');
+    expect(backup).not.toContain('"$DEPLOY_DIR/.env" 2>/dev/null | cut -d= -f2-');
+  });
+
   it('keeps the S3 bucket private so raw object URLs are not world-readable', () => {
     const compose = read('docker-compose/deploy/docker-compose.panachat.yml');
     const deployCompose = read('docker-compose/deploy/docker-compose.yml');


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Preview deploys failed on backup fingerprint guard; browser/server S3 writes split across two RustFS stacks; every app email died with `Unexpected socket close` | Preview deploys run clean end-to-end; both S3 paths hit the same store; SMTP reaches Stalwart over the local docker bridge in ~6 ms |

#### Test

- [x] Tested locally
- [x] Added/updated tests (`panachat-deploy-remote.guard.test.ts`, 6 passing)
- [ ] No tests needed

#### 🔗 Related Issue

Related to #258 (preview CI/CD), #281 (SMTP/Stalwart wiring), #204 (pre-deploy backups)

#### Description of Change

Three fixes found while bringing the preview staging stack live on the same VPS:

1. **Parameterize `S3_INTERNAL_ENDPOINT`** (default unchanged: `http://rustfs:9000`).
   When preview reuses the prod public S3 endpoint with a dedicated bucket, server-side SDK calls and browser presigned URLs must hit the *same* store — previously the hardcoded internal endpoint sent them to different RustFS volumes.

2. **Backup script honors `PANACHAT_INFRA_ENV_FILE`.**
   `load_deploy_env()` hardcoded `$DEPLOY_DIR/.env` (prod), so a preview pre-deploy backup compared preview's live user count against prod's DB fingerprint and refused every deploy ("live users=0 but last healthy fingerprint had 2 users"). The deploy script now exports its own infra env for the backup to read.

3. **Reach SMTP over the shared docker network.**
   `extra_hosts: mailer.panafor.com:host-gateway` routed app SMTP through the published-port DNAT across two docker bridges — cross-bridge hairpin connects but never delivers data. Removed; the deploy attaches `stalwart` to the panachat networks with the alias `mailer.panafor.com` (matches the LE cert hostname), documented in the compose file so it isn't re-added.

Also documents the shared-S3 mode in `.env.example.preview`.

#### How to Test

- `bunx vitest run scripts/panachat-deploy-remote.guard.test.ts`
- On the VPS: push to `preview` → workflow deploys green/blue cleanly (verified live: build ✓ SSH blue-green ✓ backup ✓ control-plane ✓)
- From an app container: SMTP banner on `mailer.panafor.com:587` in ms; authenticated send queues via STARTTLS (verified: message id `484474d24600000`)