### PR TITLE
✨ feat(model-runtime): support multiple reference images in chat-model image editing

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
@@ -228,6 +228,93 @@ describe('createOpenAICompatibleImage', () => {
           `Failed to process image URL: TypeError: Currently we don't support image url: ${mockInvalidUrl}`,
         );
       });
+
+      it('should send multiple reference images from imageUrls', async () => {
+        vi.spyOn(uriParserModule, 'parseDataUri').mockReturnValue({
+          type: 'base64',
+          base64: 'someBase64Data',
+          mimeType: null,
+        });
+
+        const mockChatResponse = {
+          choices: [
+            {
+              message: {
+                images: [
+                  {
+                    image_url: {
+                      url: 'data:image/png;base64,multi',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        };
+
+        vi.mocked(mockClient.chat.completions.create).mockResolvedValue(mockChatResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'test-model:image',
+          params: {
+            prompt: 'Combine these images',
+            imageUrls: ['data:image/png;base64,one', 'data:image/png;base64,two'],
+          },
+        };
+
+        const result = await createOpenAICompatibleImage(mockClient, payload, 'test-provider');
+
+        expect(result.imageUrl).toBe('data:image/png;base64,multi');
+
+        const callArgs = vi.mocked(mockClient.chat.completions.create).mock.calls[0][0] as any;
+        // text prompt + 2 reference images
+        expect(callArgs.messages[0].content).toHaveLength(3);
+        expect(callArgs.messages[0].content[1].type).toBe('image_url');
+        expect(callArgs.messages[0].content[2].type).toBe('image_url');
+      });
+
+      it('should combine imageUrl and imageUrls as reference images', async () => {
+        vi.spyOn(uriParserModule, 'parseDataUri').mockReturnValue({
+          type: 'base64',
+          base64: 'someBase64Data',
+          mimeType: null,
+        });
+
+        const mockChatResponse = {
+          choices: [
+            {
+              message: {
+                images: [
+                  {
+                    image_url: {
+                      url: 'data:image/png;base64,combined',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        };
+
+        vi.mocked(mockClient.chat.completions.create).mockResolvedValue(mockChatResponse as any);
+
+        const payload: CreateImagePayload = {
+          model: 'test-model:image',
+          params: {
+            prompt: 'Edit with reference',
+            imageUrl: 'data:image/png;base64,main',
+            imageUrls: ['data:image/png;base64,ref'],
+          },
+        };
+
+        const result = await createOpenAICompatibleImage(mockClient, payload, 'test-provider');
+
+        expect(result.imageUrl).toBe('data:image/png;base64,combined');
+
+        const callArgs = vi.mocked(mockClient.chat.completions.create).mock.calls[0][0] as any;
+        // text prompt + imageUrl + imageUrls entry
+        expect(callArgs.messages[0].content).toHaveLength(3);
+      });
     });
 
     describe('generateByChatModel function', () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -194,11 +194,22 @@ async function generateByChatModel(
     },
   ];
 
-  // Add image for editing mode if provided
+  // Add image(s) for editing mode if provided
+  // Support both single imageUrl and multiple imageUrls
+  const referenceImages: string[] = [];
+
   if (params.imageUrl && params.imageUrl !== null) {
-    log('Processing image URL for editing mode: %s', params.imageUrl);
+    referenceImages.push(params.imageUrl);
+  }
+  if (Array.isArray(params.imageUrls) && params.imageUrls.length > 0) {
+    referenceImages.push(...params.imageUrls);
+  }
+
+  // Process all reference images
+  for (const imageUrl of referenceImages) {
+    log('Processing image URL for editing mode: %s', imageUrl);
     try {
-      const processedImageUrl = await processImageUrlForChat(params.imageUrl);
+      const processedImageUrl = await processImageUrlForChat(imageUrl);
       content.push({
         image_url: {
           url: processedImageUrl,


### PR DESCRIPTION
Replaces #303, rebased onto post-revert `canary`.

## Why a new PR
#303 was branched from pre-revert `canary`, so its history carried the commits removed by #307. Its `createImage.ts` change auto-merged **without a conflict marker** but silently dropped `extractImageUrlFromChatMessage`, while its test file conflicted and still imported that now-deleted helper — resolving that conflict the obvious way would have landed a broken merge.

## What this does
`generateByChatModel` only forwarded `params.imageUrl`, so multi-reference editing silently dropped every extra image. Reference images from `imageUrl` and `imageUrls` are now collected into a single list and each attached as an `image_url` content part.

`imageUrls` is a pre-existing runtime param in `model-bank`, so this fix stands on its own and does not depend on the reverted work.

## Tests
The original tests exercised OpenRouter chat routing and multimodal-content extraction — both introduced by #301 and removed by the revert — so they could not pass on current `canary`. They are rewritten against the routing `canary` actually has (`:image` suffix, `message.images` response shape).

Verified as genuine regression tests: both fail on `canary` without the source fix and pass with it. Full file: 27/27 passing.

## Test plan
- [x] `createImage.test.ts` — 27 passed
- [x] New tests fail without the fix, pass with it
- [x] Merges cleanly into `canary`; reintroduces no reverted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)