### PR TITLE
🐛 fix: surface managed billing errors and restore file-upload ability

### DIFF
--- a/apps/server/src/routers/async/imageError.ts
+++ b/apps/server/src/routers/async/imageError.ts
@@ -1,6 +1,8 @@
 import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
 import { AsyncTaskError, AsyncTaskErrorType } from '@lobechat/types';
 
+import { AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
+
 import { CONTENT_POLICY_ERROR_MESSAGE, getContentPolicyErrorMessage } from './contentPolicyError';
 
 const IMAGE_EDITING_NO_IMAGE_MESSAGE = [
@@ -88,6 +90,13 @@ export const categorizeImageGenerationError = ({
   if (error.errorType === AgentRuntimeErrorType.PermissionDenied) {
     return {
       errorMessage: error.error?.message || error.message || AgentRuntimeErrorType.PermissionDenied,
+      errorType: AsyncTaskErrorType.InvalidProviderAPIKey,
+    };
+  }
+
+  if (error instanceof AicoManagedPolicyError) {
+    return {
+      errorMessage: error.code || error.message || 'Billing or authorization error',
       errorType: AsyncTaskErrorType.InvalidProviderAPIKey,
     };
   }

--- a/apps/server/src/routers/lambda/userMemories.ts
+++ b/apps/server/src/routers/lambda/userMemories.ts
@@ -22,6 +22,7 @@ import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
+import { AicoBillingModel } from '@/database/models/aicoBilling';
 import {
   type IdentityEntryBasePayload,
   type IdentityEntryPayload,
@@ -46,6 +47,7 @@ import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { resolvePreferredGenerationBilling } from '@/server/services/aico/generationBilling';
 import type { UserMemoryEmbeddingRuntime } from '@/server/services/memory/userMemory/embedding';
 import { embedUserMemoryTexts } from '@/server/services/memory/userMemory/embedding';
 import { normalizeSearchMemoryParams } from '@/server/services/memory/userMemory/searchParams';
@@ -123,7 +125,14 @@ const searchUserMemories = async (
   const normalizedInput = normalizeSearchMemoryParams(input);
   const { provider, model: embeddingModel } =
     getServerDefaultFilesConfig().embeddingModel || DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM;
-  const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId, provider);
+  const billingModel = new AicoBillingModel(ctx.serverDB);
+  const billingContext = await resolvePreferredGenerationBilling(
+    (userId) => billingModel.getUserWallet(userId),
+    ctx.userId,
+  );
+  const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId, provider, undefined, {
+    billingContext,
+  });
   const normalizedQueries = [
     ...new Set((normalizedInput.queries ?? []).map((query) => query.trim()).filter(Boolean)),
   ];
@@ -164,12 +173,15 @@ const searchUserMemories = async (
 const getEmbeddingRuntime = async (serverDB: LobeChatDatabase, userId: string) => {
   const { provider, model: embeddingModel } =
     getServerDefaultFilesConfig().embeddingModel || DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM;
-  // Read user's provider config from database
-  const agentRuntime = await initModelRuntimeFromDB(
-    serverDB,
+  const resolvedProvider = ENABLE_BUSINESS_FEATURES ? BRANDING_PROVIDER : provider;
+  const billingModel = new AicoBillingModel(serverDB);
+  const billingContext = await resolvePreferredGenerationBilling(
+    (uid) => billingModel.getUserWallet(uid),
     userId,
-    ENABLE_BUSINESS_FEATURES ? BRANDING_PROVIDER : provider,
   );
+  const agentRuntime = await initModelRuntimeFromDB(serverDB, userId, resolvedProvider, undefined, {
+    billingContext,
+  });
 
   return { agentRuntime, embeddingModel };
 };

--- a/apps/server/src/routers/lambda/video/error.ts
+++ b/apps/server/src/routers/lambda/video/error.ts
@@ -1,10 +1,22 @@
+import { AicoManagedPolicyError } from '@/server/services/aico/managedPolicy';
 import { AsyncTaskError, AsyncTaskErrorType } from '@/types/asyncTask';
 
-export const createVideoTaskSubmitError = (error: unknown, providerContentPolicyMessage?: string) =>
-  new AsyncTaskError(
+export const createVideoTaskSubmitError = (
+  error: unknown,
+  providerContentPolicyMessage?: string,
+) => {
+  if (error instanceof AicoManagedPolicyError) {
+    return new AsyncTaskError(
+      AsyncTaskErrorType.InvalidProviderAPIKey,
+      error.code || error.message || 'Billing or authorization error',
+    );
+  }
+
+  return new AsyncTaskError(
     providerContentPolicyMessage
       ? AsyncTaskErrorType.ProviderContentModeration
       : AsyncTaskErrorType.TaskTriggerError,
     providerContentPolicyMessage ??
       'Failed to submit video task: ' + (error instanceof Error ? error.message : 'Unknown error'),
   );
+};

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -75,7 +75,7 @@ export interface ModelAbilities {
 
 const AiModelAbilitiesSchema = z.object({
   audio: z.boolean().optional(),
-  // files: z.boolean().optional(),
+  files: z.boolean().optional(),
   functionCall: z.boolean().optional(),
   imageOutput: z.boolean().optional(),
   reasoning: z.boolean().optional(),

--- a/src/hooks/useModelSupportFiles.ts
+++ b/src/hooks/useModelSupportFiles.ts
@@ -1,0 +1,5 @@
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+export const useModelSupportFiles = (model: string, provider: string) => {
+  return useAiInfraStore(aiModelSelectors.isModelSupportFiles(model, provider));
+};

--- a/src/hooks/useVisualMediaUploadAbility.ts
+++ b/src/hooks/useVisualMediaUploadAbility.ts
@@ -1,4 +1,5 @@
 import { useModelSupportAudio } from '@/hooks/useModelSupportAudio';
+import { useModelSupportFiles } from '@/hooks/useModelSupportFiles';
 import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
 import { useModelSupportVideo } from '@/hooks/useModelSupportVideo';
 import { useModelSupportVision } from '@/hooks/useModelSupportVision';
@@ -11,6 +12,7 @@ export const useVisualMediaUploadAbility = (model: string, provider: string, age
   const supportVision = useModelSupportVision(model, provider);
   const supportVideo = useModelSupportVideo(model, provider);
   const supportAudio = useModelSupportAudio(model, provider);
+  const supportFiles = useModelSupportFiles(model, provider);
   const supportToolUse = useModelSupportToolUse(model, provider);
   const enableVisualUnderstanding = useServerConfigStore(
     serverConfigSelectors.enableVisualUnderstanding,
@@ -40,11 +42,19 @@ export const useVisualMediaUploadAbility = (model: string, provider: string, age
   );
 
   if (bypassMediaGate) {
-    return { canUploadAudio: true, canUploadImage: true, canUploadVideo: true };
+    return {
+      canUploadAudio: true,
+      canUploadDocument: true,
+      canUploadImage: true,
+      canUploadVideo: true,
+    };
   }
 
   return {
     canUploadAudio: supportAudio,
+    // Default true — RAG handles document extraction for all models.
+    // Only block when model explicitly declares files: false.
+    canUploadDocument: supportFiles !== false,
     canUploadImage: supportVision || (canUseVisualUnderstanding && fallbackSupportVision),
     canUploadVideo: supportVideo || (canUseVisualUnderstanding && fallbackSupportVideo),
   };

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
@@ -192,14 +192,14 @@ const ModelConfigForm = memo<ModelConfigFormProps>(
               placeholder={t('providerModels.item.modelConfig.type.placeholder')}
             />
           </Form.Item>
-          {/*<Form.Item*/}
-          {/*  extra={t('providerModels.item.modelConfig.files.extra')}*/}
-          {/*  label={t('providerModels.item.modelConfig.files.title')}*/}
-          {/*  name={['abilities', 'files']}*/}
-          {/*  valuePropName={'checked'}*/}
-          {/*>*/}
-          {/*  <Checkbox />*/}
-          {/*</Form.Item>*/}
+          <Form.Item
+            extra={t('providerModels.item.modelConfig.files.extra')}
+            label={t('providerModels.item.modelConfig.files.title')}
+            name={['abilities', 'files']}
+            valuePropName={'checked'}
+          >
+            <Checkbox />
+          </Form.Item>
         </Form>
       </div>
     );


### PR DESCRIPTION
Replaces #302, rebased onto post-revert `canary`.

## Why a new PR
#302 was branched from pre-revert `canary` and conflicted directly inside `createImage.ts`. The incoming side of that conflict was image cost/usage extraction built entirely on #301 primitives (`extractImageUrlFromChatMessage`, `provider === 'openrouter'` routing, the `computeImageCost` fallback) — the exact code #307 reverted. Taking the incoming side would have resurrected the revert; taking ours would have gutted the hunk's purpose.

The other 7 files in #302 are independent of the revert and merge cleanly. This PR carries those; the `createImage.ts` hunk is intentionally left out.

## What this does
- Map `AicoManagedPolicyError` to `InvalidProviderAPIKey` for image and video task submission, so billing/authorization failures surface instead of being reported as generic task-trigger errors.
- Thread `billingContext` through the user-memory embedding runtimes.
- Re-enable the `files` model ability (schema + settings form checkbox) and expose `canUploadDocument` from `useVisualMediaUploadAbility`, keyed on a new `useModelSupportFiles` hook. Defaults to allowed; only an explicit `files: false` blocks upload, since RAG extracts documents for all models.

## Deliberately excluded
The image cost/usage extraction hunk. It has no foundation on current `canary`. If that pricing work is still wanted, it should come back as its own PR on top of a decision about whether #301 returns — not smuggled in through a conflict resolution.

## Test plan
- [x] All referenced symbols verified present on current `canary` (`AicoManagedPolicyError`, `resolvePreferredGenerationBilling`, `AicoBillingModel.getUserWallet`, `initModelRuntimeFromDB` options param, `isModelSupportFiles` selector, `providerModels.item.modelConfig.files.*` i18n keys)
- [x] Lint clean (formatting auto-fixed)
- [x] Merges cleanly into `canary`; reintroduces no reverted code
- [ ] CI type-check (full local run exceeds practical time here)

Note: `apps/server` vitest currently fails to resolve `@/locales/default/chat` from `tests/setup.ts`. Reproduced on clean `canary` — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)