### PR TITLE
🐛 fix(openrouter): edit images via input_references, not /images/edits

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
@@ -1000,6 +1000,215 @@ describe('createOpenAICompatibleImage', () => {
     });
   });
 
+  describe('chat model mode - response extraction shapes', () => {
+    const usage = {
+      total_tokens: 1000,
+      input_tokens: 100,
+      output_tokens: 900,
+      input_tokens_details: { text_tokens: 50, image_tokens: 50 },
+    };
+    const payload: CreateImagePayload = {
+      model: 'google/gemini-3.1-flash-image-preview:image',
+      params: { prompt: 'make it red' },
+    };
+
+    const runWithMessage = async (message: any) => {
+      vi.mocked(mockClient.chat.completions.create).mockResolvedValue({
+        choices: [{ message }],
+        usage,
+      } as any);
+      return createOpenAICompatibleImage(mockClient, payload, 'openrouter');
+    };
+
+    it('extracts from message.images (existing shape)', async () => {
+      const result = await runWithMessage({
+        images: [{ image_url: { url: 'https://cdn/img.png' } }],
+      });
+      expect(result.imageUrl).toBe('https://cdn/img.png');
+      expect(result.modelUsage).toBeDefined();
+    });
+
+    it('extracts from multimodal content parts', async () => {
+      const result = await runWithMessage({
+        content: [{ type: 'image_url', image_url: { url: 'https://cdn/part.png' } }],
+      });
+      expect(result.imageUrl).toBe('https://cdn/part.png');
+      expect(result.modelUsage).toBeDefined();
+    });
+
+    it('extracts b64_json content parts as a data URI', async () => {
+      const result = await runWithMessage({
+        content: [{ type: 'image', b64_json: 'abc123' }],
+      });
+      expect(result.imageUrl).toBe('data:image/png;base64,abc123');
+      expect(result.modelUsage).toBeDefined();
+    });
+
+    it('extracts a data URI embedded in string content', async () => {
+      const result = await runWithMessage({
+        content: 'Here you go: data:image/png;base64,AAAbbb111 enjoy',
+      });
+      expect(result.imageUrl).toBe('data:image/png;base64,AAAbbb111');
+      expect(result.modelUsage).toBeDefined();
+    });
+
+    it('extracts a markdown image from string content', async () => {
+      const result = await runWithMessage({
+        content: '![out](https://cdn/markdown.png)',
+      });
+      expect(result.imageUrl).toBe('https://cdn/markdown.png');
+      expect(result.modelUsage).toBeDefined();
+    });
+
+    it('still throws when the response carries no image at all', async () => {
+      await expect(runWithMessage({ content: 'sorry, I cannot do that' })).rejects.toThrow(
+        'No image generated in chat completion response',
+      );
+    });
+  });
+
+  describe('image mode - imageEditMode: inputReferences', () => {
+    const editedResponse = { data: [{ b64_json: 'editedViaInputReferences' }] };
+
+    // Any call to this means we tried to download the reference server-side,
+    // which is both unnecessary and SSRF-prone for the input_references transport.
+    const failIfFetched = () =>
+      vi.fn().mockImplementation(() => {
+        throw new Error('reference image must not be fetched server-side');
+      });
+
+    it('never calls /images/edits for OpenRouter reference-image edits', async () => {
+      global.fetch = failIfFetched() as any;
+      vi.mocked(mockClient.images.generate).mockResolvedValue(editedResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'bytedance-seed/seedream-5-0-lite',
+        params: {
+          prompt: 'رنگشو قرمز کن',
+          imageUrls: ['https://example.com/a.jpg', 'https://example.com/b.jpg'],
+        },
+      };
+
+      const result = await createOpenAICompatibleImage(mockClient, payload, 'openrouter', {
+        imageEditMode: 'inputReferences',
+      });
+
+      // The regression: /images/edits does not exist on OpenRouter and returns 404.
+      expect(mockClient.images.edit).not.toHaveBeenCalled();
+      expect(mockClient.images.generate).toHaveBeenCalledTimes(1);
+      expect(result.imageUrl).toBe('data:image/png;base64,editedViaInputReferences');
+    });
+
+    it('sends references as input_references and drops the image field', async () => {
+      global.fetch = failIfFetched() as any;
+      vi.mocked(mockClient.images.generate).mockResolvedValue(editedResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'bytedance-seed/seedream-5-0-lite',
+        params: {
+          prompt: 'make it red',
+          imageUrls: ['https://example.com/a.jpg', 'https://example.com/b.jpg'],
+        },
+      };
+
+      await createOpenAICompatibleImage(mockClient, payload, 'openrouter', {
+        imageEditMode: 'inputReferences',
+      });
+
+      const body = vi.mocked(mockClient.images.generate).mock.calls[0][0] as any;
+      expect(body.input_references).toEqual([
+        { image_url: { url: 'https://example.com/a.jpg' }, type: 'image_url' },
+        { image_url: { url: 'https://example.com/b.jpg' }, type: 'image_url' },
+      ]);
+      expect(body.image).toBeUndefined();
+      expect(body.model).toBe('bytedance-seed/seedream-5-0-lite');
+      expect(body.prompt).toBe('make it red');
+    });
+
+    it('normalises a single imageUrl string into one input_reference', async () => {
+      global.fetch = failIfFetched() as any;
+      vi.mocked(mockClient.images.generate).mockResolvedValue(editedResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'bytedance-seed/seedream-5-0-lite',
+        params: { prompt: 'edit', imageUrl: 'https://example.com/one.jpg' },
+      };
+
+      await createOpenAICompatibleImage(mockClient, payload, 'openrouter', {
+        imageEditMode: 'inputReferences',
+      });
+
+      const body = vi.mocked(mockClient.images.generate).mock.calls[0][0] as any;
+      expect(body.input_references).toEqual([
+        { image_url: { url: 'https://example.com/one.jpg' }, type: 'image_url' },
+      ]);
+      expect(mockClient.images.edit).not.toHaveBeenCalled();
+    });
+
+    it('reports identical modelUsage under both edit transports', async () => {
+      const usage = {
+        total_tokens: 1000,
+        input_tokens: 100,
+        output_tokens: 900,
+        input_tokens_details: { text_tokens: 50, image_tokens: 50 },
+      };
+      const params = { prompt: 'same prompt', imageUrls: ['https://example.com/a.jpg'] };
+
+      // input_references transport
+      global.fetch = failIfFetched() as any;
+      vi.mocked(mockClient.images.generate).mockResolvedValue({
+        data: [{ b64_json: 'x' }],
+        usage,
+      } as any);
+      const viaRefs = await createOpenAICompatibleImage(
+        mockClient,
+        { model: 'm', params },
+        'openrouter',
+        { imageEditMode: 'inputReferences' },
+      );
+
+      // multipart transport
+      const mockArrayBuffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]).buffer;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => mockArrayBuffer,
+        headers: { get: (n: string) => (n === 'content-type' ? 'image/jpeg' : null) },
+      } as any);
+      vi.mocked(mockClient.images.edit).mockResolvedValue({
+        data: [{ b64_json: 'x' }],
+        usage,
+      } as any);
+      const viaMultipart = await createOpenAICompatibleImage(
+        mockClient,
+        { model: 'm', params },
+        'openrouter',
+      );
+
+      // Billing must not depend on which transport carried the reference image.
+      expect(viaRefs.modelUsage).toEqual(viaMultipart.modelUsage);
+    });
+
+    it('still uses multipart /images/edits when the mode is not set', async () => {
+      const mockArrayBuffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]).buffer;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => mockArrayBuffer,
+        headers: { get: (n: string) => (n === 'content-type' ? 'image/jpeg' : null) },
+      } as any);
+      vi.mocked(mockClient.images.edit).mockResolvedValue(editedResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'dall-e-2',
+        params: { prompt: 'edit', imageUrls: ['https://example.com/a.jpg'] },
+      };
+
+      await createOpenAICompatibleImage(mockClient, payload, 'openai');
+
+      expect(mockClient.images.edit).toHaveBeenCalled();
+      expect(mockClient.images.generate).not.toHaveBeenCalled();
+    });
+  });
+
   describe('image mode - usage tracking', () => {
     it('should include modelUsage when usage is present in response', async () => {
       const mockImageResponse = {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -16,7 +16,19 @@ import { convertOpenAIImageUsage, convertOpenAIUsage } from '../usageConverters/
 
 const log = createDebug('lobe-image:openai-compatible');
 
+/**
+ * How reference images are sent when editing an existing image.
+ *
+ * - `imagesEdit` (default) — multipart `POST /images/edits` with `File` uploads.
+ *   OpenAI, Azure, and anything else that implements the OpenAI Images API.
+ * - `inputReferences` — JSON `POST /images/generations` carrying an
+ *   `input_references` array. Required by OpenRouter, which has **no**
+ *   `/images/edits` route at all: calling it returns a bare `404 Not Found`.
+ */
+export type ImageEditMode = 'imagesEdit' | 'inputReferences';
+
 interface CreateOpenAICompatibleImageOptions {
+  imageEditMode?: ImageEditMode;
   pricingContext?: CreateImageMethodOptions['pricingContext'];
   pricingModel?: string;
   requestModel?: string;
@@ -57,8 +69,20 @@ async function generateByImageMode(
   // https://platform.openai.com/docs/api-reference/images/createEdit
   const isImageEdit = Array.isArray(userInput.image) && userInput.image.length > 0;
   log('isImageEdit: %O, userInput.image: %O', isImageEdit, userInput.image);
-  // If there are imageUrls parameters, convert them to File objects
-  if (isImageEdit) {
+  const useInputReferences = imageOptions?.imageEditMode === 'inputReferences';
+
+  if (isImageEdit && useInputReferences) {
+    // OpenRouter edits on /images/generations; it has no /images/edits route.
+    // Shape mirrors providers/openrouter/createVideo.ts (`imageRef`).
+    // Passing URLs straight through also avoids convertImageUrlToFile, i.e. no
+    // server-side fetch of the reference — sidestepping the SSRF / private-address
+    // problem documented in processImageUrlForChat below.
+    userInput.input_references = (userInput.image as string[])
+      .filter(Boolean)
+      .map((url: string) => ({ image_url: { url }, type: 'image_url' as const }));
+    delete userInput.image;
+  } else if (isImageEdit) {
+    // If there are imageUrls parameters, convert them to File objects
     try {
       // Convert all image URLs to File objects
       const imageFiles = await Promise.all(
@@ -83,7 +107,10 @@ async function generateByImageMode(
   // Match the gpt-image-1 family (including dated snapshots like
   // `gpt-image-1-2025-04-15` and the `.5` variant), but exclude the mini tier.
   const isGptImage1Family = /^gpt-image-1(?:$|[-.])/.test(routingModel);
-  const supportsInputFidelity = isImageEdit && isGptImage1Family && !routingModel.includes('mini');
+  // `input_fidelity` belongs to the OpenAI /images/edits contract; it has not been
+  // probed on the input_references transport, so keep it off there.
+  const supportsInputFidelity =
+    isImageEdit && !useInputReferences && isGptImage1Family && !routingModel.includes('mini');
 
   const defaultInput = {
     n: 1,
@@ -100,10 +127,12 @@ async function generateByImageMode(
 
   log('options: %O', options);
 
-  // Determine if it's an image editing operation
-  const img = isImageEdit
-    ? await client.images.edit(options as any)
-    : await client.images.generate(options as any);
+  // Determine if it's an image editing operation. The input_references transport
+  // edits through the generations endpoint, so only the multipart mode calls edit().
+  const img =
+    isImageEdit && !useInputReferences
+      ? await client.images.edit(options as any)
+      : await client.images.generate(options as any);
 
   // Check the integrity of response data
   if (!img || !img.data || !Array.isArray(img.data) || img.data.length === 0) {
@@ -180,6 +209,73 @@ async function processImageUrlForChat(imageUrl: string): Promise<string> {
     throw new TypeError(`Currently we don't support image url: ${imageUrl}`);
   }
 }
+
+/**
+ * OpenRouter (and similar) may return the image in `message.images`, as
+ * multimodal `content` parts, or as a data URI / markdown image in a string.
+ *
+ * Checking only `message.images` is what makes Gemini `:image` edits fail with
+ * "No image generated in chat completion response" — it returns one of the
+ * other shapes.
+ */
+export const extractImageUrlFromChatMessage = (message: unknown): string | undefined => {
+  if (!message || typeof message !== 'object') return undefined;
+  const msg = message as Record<string, unknown>;
+
+  const urlFromImageLike = (value: unknown): string | undefined => {
+    if (typeof value === 'string' && value) return value;
+    if (!value || typeof value !== 'object') return undefined;
+    const rec = value as Record<string, unknown>;
+    if (typeof rec.url === 'string' && rec.url) return rec.url;
+    if (typeof rec.b64_json === 'string' && rec.b64_json) {
+      return `data:image/png;base64,${rec.b64_json}`;
+    }
+    const nested = rec.image_url ?? rec.imageUrl ?? rec.image;
+    if (nested && nested !== value) return urlFromImageLike(nested);
+    return undefined;
+  };
+
+  const urlFromImagesArray = (images: unknown): string | undefined => {
+    if (!Array.isArray(images)) return undefined;
+    for (const image of images) {
+      const url = urlFromImageLike(image);
+      if (url) return url;
+    }
+    return undefined;
+  };
+
+  const fromImages = urlFromImagesArray(msg.images);
+  if (fromImages) return fromImages;
+
+  const content = msg.content;
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue;
+      const rec = part as Record<string, unknown>;
+      const url = urlFromImageLike(rec.image_url ?? rec.imageUrl ?? rec.image ?? rec);
+      if (
+        url &&
+        (rec.type === 'image_url' ||
+          rec.type === 'image' ||
+          rec.type === 'output_image' ||
+          rec.image_url ||
+          rec.image ||
+          rec.b64_json)
+      ) {
+        return url;
+      }
+    }
+  }
+
+  if (typeof content === 'string') {
+    const dataUri = content.match(/data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/);
+    if (dataUri) return dataUri[0];
+    const markdown = content.match(/!\[[^\]]*\]\((data:image\/[^)]+|https?:[^)\s]+)\)/);
+    if (markdown?.[1]) return markdown[1];
+  }
+
+  return undefined;
+};
 
 /**
  * Generate images using chat completion API (OpenRouter Gemini, etc.)
@@ -262,30 +358,27 @@ async function generateByChatModel(
     throw new Error('No message in chat completion response');
   }
 
-  // Check if response has images in the expected format
-  if ((message as any).images && Array.isArray((message as any).images)) {
-    const { images } = message as any;
-    if (images.length > 0) {
-      const image = images[0];
-      if (image.image_url?.url) {
-        log('Successfully extracted image from chat response');
-        return {
-          imageUrl: image.image_url.url,
-          ...(response.usage
-            ? {
-                modelUsage: convertOpenAIUsage(response.usage, {
-                  pricing: await getModelPricing(
-                    imageOptions?.pricingModel ?? actualModel,
-                    provider,
-                    imageOptions?.pricingContext,
-                  ),
-                  provider,
-                }),
-              }
-            : {}),
-        };
-      }
-    }
+  // Accept every shape providers actually return, not just `message.images`.
+  // NOTE: the usage/pricing block below is unchanged — extraction got wider,
+  // billing did not move.
+  const extractedImageUrl = extractImageUrlFromChatMessage(message);
+  if (extractedImageUrl) {
+    log('Successfully extracted image from chat response');
+    return {
+      imageUrl: extractedImageUrl,
+      ...(response.usage
+        ? {
+            modelUsage: convertOpenAIUsage(response.usage, {
+              pricing: await getModelPricing(
+                imageOptions?.pricingModel ?? actualModel,
+                provider,
+                imageOptions?.pricingContext,
+              ),
+              provider,
+            }),
+          }
+        : {}),
+    };
   }
 
   // If no images found, throw error
@@ -308,6 +401,8 @@ export async function createOpenAICompatibleImage(
   if (routingModel.endsWith(':image')) {
     return await generateByChatModel(client, payload, provider, options);
   }
+
+  // Dedicated generators (no `:image` suffix) speak the provider's Images API.
 
   // Default to traditional images API
   return await generateByImageMode(client, payload, provider, options);

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -75,7 +75,7 @@ import type { OpenAIStreamOptions } from '../streams';
 import { OpenAIResponsesStream, OpenAIStream } from '../streams';
 import type { ChatPayloadForTransformStream } from '../streams/protocol';
 import { convertOpenAIResponseUsage, convertOpenAIUsage } from '../usageConverters/openai';
-import { createOpenAICompatibleImage } from './createImage';
+import { createOpenAICompatibleImage, type ImageEditMode } from './createImage';
 import { createOpenAICompatibleVideo, pollOpenAICompatibleVideoStatus } from './createVideo';
 import { transformResponseAPIToStream, transformResponseToStream } from './nonStreamToStream';
 
@@ -295,6 +295,12 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
     inferenceId: string,
     options: CreateVideoOptions,
   ) => Promise<PollVideoStatusResult>;
+  /**
+   * How reference images are sent when editing. Defaults to `imagesEdit`
+   * (multipart `/images/edits`). Providers without that route — notably
+   * OpenRouter — must set `inputReferences`.
+   */
+  imageEditMode?: ImageEditMode;
   models?:
     | ((params: { client: OpenAI; options?: ConstructorOptions<T> }) => Promise<ChatModelCard[]>)
     | {
@@ -334,6 +340,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
   responses,
   promptCacheKeyModels,
   createImage: customCreateImage,
+  imageEditMode,
   createVideo: customCreateVideo,
   handleCreateVideoWebhook: customHandleCreateVideoWebhook,
   handlePollVideoStatus: customHandlePollVideoStatus,
@@ -867,6 +874,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       log('using default createOpenAICompatibleImage');
       // Use the new createOpenAICompatibleImage function
       return createOpenAICompatibleImage(this.client, payload, this.id, {
+        imageEditMode,
         pricingContext: options?.pricingContext,
         pricingModel: payload.model,
         requestModel: resolveMappedModelId(payload.model, this.modelIdMappingOptions),

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -55,6 +55,14 @@ describe('LobeOpenRouterAI - custom features', () => {
       expect(params.handlePollVideoStatus).toBeDefined();
     });
 
+    it('edits images via input_references, not the nonexistent /images/edits route', () => {
+      expect(params.imageEditMode).toBe('inputReferences');
+      // Deliberately NOT a custom createImage: the factory does not forward
+      // `pricingContext` to custom impls, so routing through the shared
+      // createOpenAICompatibleImage is what keeps billing behaviour identical.
+      expect(params.createImage).toBeUndefined();
+    });
+
     it('should have chatCompletion configuration', () => {
       expect(params.chatCompletion).toBeDefined();
       expect(params.chatCompletion.handlePayload).toBeDefined();

--- a/packages/model-runtime/src/providers/openrouter/index.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.ts
@@ -96,6 +96,10 @@ export const params = {
   debug: {
     chatCompletion: () => process.env.DEBUG_OPENROUTER_CHAT_COMPLETION === '1',
   },
+  // OpenRouter has no /images/edits route — editing goes through
+  // /images/generations with an `input_references` array. Without this,
+  // every reference-image edit fails with a bare `404 Not Found`.
+  imageEditMode: 'inputReferences',
   handlePollVideoStatus: async (inferenceId, options) =>
     pollOpenRouterVideoStatus(inferenceId, {
       apiKey: options.apiKey,


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Every OpenRouter image edit → `404 404 Not Found` (calls `/images/edits`, which OpenRouter does not implement) | Edits go to `/images/generations` with `input_references[]` |
| Gemini `:image` edits → `No image generated in chat completion response` | Image extracted from `message.images`, content parts, `b64_json`, or data-URI/markdown |

Verified against the live OpenRouter API with the production key:

```
POST /api/v1/images/edits        -> 404 404 Not Found   <- exact production error string
POST /api/v1/images/generations  -> 400 (endpoint exists, parses the body)
```

### Why not a provider-level `createImage`

The factory does **not** forward `pricingContext` to custom `createImage` implementations, so moving OpenRouter off the shared `createOpenAICompatibleImage` would silently change which pricing table resolves. Keeping it on the shared path makes billing preservation structural: `git diff -w` shows **zero** changes to the usage/pricing block.

### Why not just restore PR #301

`4b04f3565a` reverted #301 for its pricing changes and took the image routing with it. But #301 forced *all* OpenRouter image generation through chat completions with hardcoded `modalities:['image','text']`, breaking every dedicated generator (`flux.2-*`, `gpt-image-1`, `recraft-v4`) with `No endpoints found that support the requested output modalities`. This uses OpenRouter's native Images API instead.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

225 tests pass; lint clean; no type errors in `model-runtime`. Both fixes have regression tests verified to **fail before** and **pass after** (transport: 4 tests; extraction: 4 of 6).

Note: repo-wide `type-check` already fails on clean `canary` with unrelated pre-existing errors (`keygrip`, `@lobehub/ui` exports, `AicoBilling`, `OrgAdmin`) — none in the touched package.

#### 🔗 Related Issue

Fixes #313