### PR TITLE
🐛 fix(openrouter): read chat-style image usage without crashing

### DIFF
--- a/packages/model-runtime/src/core/usageConverters/openai.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.test.ts
@@ -703,4 +703,33 @@ describe('convertOpenAIImageUsage', () => {
 
     expect(convertOpenAIImageUsage(usage, pricing).cost).toBe(0.04);
   });
+
+  // OpenRouter's /images/generations returns chat-style usage with no
+  // `input_tokens_details`. Reading that object directly threw
+  // "Cannot read properties of undefined (reading 'image_tokens')", which
+  // discarded an image the provider had already generated and billed for.
+  it('handles OpenRouter chat-style image usage without input_tokens_details', () => {
+    const usage = {
+      prompt_tokens: 0,
+      completion_tokens: 4175,
+      total_tokens: 4175,
+      cost: 0.04,
+    } as unknown as OpenAI.Images.ImagesResponse.Usage;
+
+    const result = convertOpenAIImageUsage(usage);
+
+    expect(result.totalInputTokens).toBe(0);
+    expect(result.totalOutputTokens).toBe(4175);
+    expect(result.outputImageTokens).toBe(4175);
+    expect(result.totalTokens).toBe(4175);
+    // Provider-reported cost is authoritative for this shape.
+    expect(result.cost).toBe(0.04);
+  });
+
+  it('does not throw when the usage object omits input_tokens_details', () => {
+    const usage = { total_tokens: 10 } as unknown as OpenAI.Images.ImagesResponse.Usage;
+
+    expect(() => convertOpenAIImageUsage(usage)).not.toThrow();
+    expect(convertOpenAIImageUsage(usage).inputImageTokens).toBeUndefined();
+  });
 });

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -225,13 +225,25 @@ export const convertOpenAIImageUsage = (
   usage: OpenAI.Images.ImagesResponse.Usage,
   pricing?: Pricing,
 ): ModelUsage => {
+  // OpenAI's Images API reports `input_tokens` / `output_tokens` plus an
+  // `input_tokens_details` breakdown. OpenRouter's /images/generations instead
+  // returns the chat-style `prompt_tokens` / `completion_tokens` and no details
+  // object at all, so reading `input_tokens_details.image_tokens` directly threw
+  // `Cannot read properties of undefined (reading 'image_tokens')` and discarded
+  // an image the provider had already generated (and billed for).
+  // Read both shapes, and never assume the details object exists.
+  const raw = usage as unknown as Record<string, any>;
+  const inputTokens = raw.input_tokens ?? raw.prompt_tokens;
+  const outputTokens = raw.output_tokens ?? raw.completion_tokens;
+  const inputDetails = raw.input_tokens_details;
+
   const data: ModelTokensUsage = {
-    inputImageTokens: usage.input_tokens_details.image_tokens,
-    inputTextTokens: usage.input_tokens_details.text_tokens,
-    outputImageTokens: usage.output_tokens,
-    totalInputTokens: usage.input_tokens,
-    totalOutputTokens: usage.output_tokens,
-    totalTokens: usage.total_tokens,
+    inputImageTokens: inputDetails?.image_tokens,
+    inputTextTokens: inputDetails?.text_tokens,
+    outputImageTokens: outputTokens,
+    totalInputTokens: inputTokens,
+    totalOutputTokens: outputTokens,
+    totalTokens: raw.total_tokens,
   };
 
   return withPricingOrProviderCost(data as ModelUsage, pricing, usage);


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Image generated + billed by OpenRouter, then discarded with `Cannot read properties of undefined (reading 'image_tokens')` — nothing reaches storage | Usage parsed from either shape; image persists normally |

Follow-up to #314, which fixed the `404` that had been masking this.

`convertOpenAIImageUsage` dereferenced `usage.input_tokens_details` directly, assuming OpenAI's Images API shape. OpenRouter's `/images/generations` returns chat-style usage with no details object:

```json
"usage": { "prompt_tokens": 0, "completion_tokens": 4175, "total_tokens": 4175, "cost": 0.04 }
```

The sibling converters in the same file (lines 113, 185) already guard with `?.image_tokens || 0`; this one was the outlier.

### Billing

Improves rather than shifts. OpenRouter reports a real `cost`, which `withPricingOrProviderCost` already prefers over the pricing estimate. The existing gpt-image-1 tests pass **unchanged**, proving the OpenAI shape still maps identically.

### Evidence this was silent data loss

`generations.file_id` and `generations.asset` are both null for the failed tasks, and RustFS logs are empty — the provider had already produced (and charged for) the image.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

27 tests pass, lint clean. Both new tests verified to fail before the fix with the exact production error string and pass after.

#### 🔗 Related Issue

Fixes #315