### PR TITLE
🐛 fix(aico): mirror RTL Tabs/Segmented indicators with right-edge offsets

### DIFF
--- a/src/styles/global.rtl.test.ts
+++ b/src/styles/global.rtl.test.ts
@@ -21,13 +21,29 @@ describe('global RTL control fixes', () => {
     expect(source).toContain('direction: ltr');
   });
 
-  it('forces LTR on Tabs/Segmented indicators so inset-inline-start matches physical left', () => {
-    expect(source).toContain("[role='tablist'] > [role='presentation']");
-    expect(source).toContain("[data-orientation] > [aria-hidden='true']:first-of-type");
-    expect(source).toMatch(/\[role='tablist'\] > \[role='presentation'\][\s\S]*?direction:\s*ltr/);
-    // Prior broken approaches (inset-inline:auto wiped left under RTL)
+  it('feeds Tabs indicators the right-edge offset under RTL', () => {
+    expect(source).toContain(":dir(rtl) [role='tablist'] > [role='presentation']");
+    expect(source).toContain("html[dir='rtl'] [role='tablist'] > [role='presentation']");
+    // Must override the inline-styled var, hence !important.
+    expect(source).toContain('--active-tab-left: var(--active-tab-right) !important;');
+  });
+
+  it('mirrors Segmented indicators against the list padding box under RTL', () => {
+    expect(source).toContain(
+      "html[dir='rtl'] [data-orientation='horizontal'] > [aria-hidden='true']:first-of-type",
+    );
+    expect(source).toContain(
+      'inset-inline-start: calc(100% - var(--active-item-left) - var(--active-item-width));',
+    );
+  });
+
+  it('does not rely on approaches that cannot work for absolutely positioned indicators', () => {
+    // `direction: ltr` on the indicator itself is ignored: logical insets map
+    // through the containing block's direction.
+    expect(source).not.toMatch(
+      /\[role='tablist'\] > \[role='presentation'\][\s\S]*?direction:\s*ltr/,
+    );
+    // inset-inline: auto wiped the physical left offset under RTL.
     expect(source).not.toContain('inset-inline: auto');
-    expect(source).not.toContain('var(--active-tab-right)');
-    expect(source).not.toContain('(var(--active-tab-width) - 100%)');
   });
 });

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -82,14 +82,21 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
    * control LTR (standard toggle UX) under RTL documents.
    *
    * Tabs / Segmented indicators (Settings → Appearance animation, platform/org
-   * admin tabs, etc.): JS writes physical offsetLeft into --active-tab-left /
-   * --active-item-left, but component CSS binds logical inset-inline-start.
-   * Under document RTL that places the pill from the wrong edge.
+   * admin tabs, etc.): JS measures a physical left offset into
+   * --active-tab-left / --active-item-left, but the component CSS binds it to
+   * the logical inset-inline-start. For an absolutely positioned box the
+   * logical inset maps through the *containing block's* direction (the tab
+   * list), not the indicator's own, so a direction:ltr rule on the indicator does
+   * nothing — under RTL the pill lands mirrored (picking the first tab
+   * highlights the last one).
    *
-   * Fix: force direction:ltr on the indicator so inset-inline-start resolves to
-   * physical left (matching the JS offset). Do not fight with left +
-   * inset-inline overrides — inset-inline:auto after left wipes the offset
-   * under RTL (inline-end maps to left), which left the pill on the wrong tab.
+   * Fix: feed the indicator the mirrored (right-edge) distance under RTL.
+   * - Tabs: Base UI already publishes --active-tab-right inline, so remap the
+   *   var with !important (inline styles otherwise win). All variants derive
+   *   from it, so the dot variant stays centered too.
+   * - Segmented: only a left offset is published, so mirror it against the
+   *   list's padding box, which is what both offsetLeft and inset percentages
+   *   resolve against.
    */
   :dir(rtl) [role='switch'],
   html[dir='rtl'] [role='switch'] {
@@ -98,9 +105,14 @@ const genGlobalStyle = ({ token }: { prefixCls: string; token: Theme }) => css`
     direction: ltr;
   }
 
-  [role='tablist'] > [role='presentation'],
-  [data-orientation] > [aria-hidden='true']:first-of-type {
-    direction: ltr;
+  :dir(rtl) [role='tablist'] > [role='presentation'],
+  html[dir='rtl'] [role='tablist'] > [role='presentation'] {
+    --active-tab-left: var(--active-tab-right) !important;
+  }
+
+  :dir(rtl) [data-orientation='horizontal'] > [aria-hidden='true']:first-of-type,
+  html[dir='rtl'] [data-orientation='horizontal'] > [aria-hidden='true']:first-of-type {
+    inset-inline-start: calc(100% - var(--active-item-left) - var(--active-item-width));
   }
 `;
 


### PR DESCRIPTION
## Problem

In Persian (RTL), the sliding highlight in option groups lands on the mirrored item. E.g. **Settings → Appearance → General**: selecting **Off** for the response animation moves the pill onto **Beautiful**.

## Cause

The Tabs / Segmented indicators are absolutely positioned with `inset-inline-start`, but the value published by JS (`--active-tab-left`, `--active-item-left`) is a **physical left** offset. Under `dir=rtl` that logical inset measures from the right edge, so the pill is mirrored.

Previous attempts set `direction: ltr` on the indicator element itself, which doesn't change the mapping — the logical inset resolves through the containing tab list, not the indicator.

## Fix

Feed the indicator the mirrored right-edge distance under RTL (`src/styles/global.ts`):

- **Tabs** — Base UI already publishes `--active-tab-right` inline, so remap `--active-tab-left` to it with `!important` (inline styles otherwise win). All three variants (rounded / square / point) derive from that var, so the dot stays centered too.
- **Segmented** — only a left offset is published, so mirror it against the list's padding box: `calc(100% - var(--active-item-left) - var(--active-item-width))`. Both `offsetLeft` and inset percentages resolve against that box.

The Switch RTL fix is unchanged.

## Test

`src/styles/global.rtl.test.ts` updated: asserts the new right-edge rules and keeps guards against the earlier approaches that could not work (`direction: ltr` on the indicator, `inset-inline: auto`).

```bash
bun run check src/styles/global.ts src/styles/global.rtl.test.ts
```

Note for the reviewer: the RTL inset-mirroring behavior was verified in a standalone browser probe, not in the running app (no dev server available) — a manual look at Settings → Appearance in Persian before merge is worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)