### PR TITLE
🐛 fix(org): make Auto model always available on the org wallet

### DIFF
--- a/apps/server/src/services/aico/managedPolicy.test.ts
+++ b/apps/server/src/services/aico/managedPolicy.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { OPENROUTER_AUTO_MODEL_ID } from '@lobechat/business-const';
+import type { LobeChatDatabase } from '@lobechat/database';
+import { getTestDB } from '@lobechat/database/test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OrganizationModel } from '@/database/models/organization';
+import { users } from '@/database/schemas';
+import {
+  modelAccessRules,
+  organizationMembers,
+  organizations,
+  organizationTeamMembers,
+  organizationTeams,
+} from '@/database/schemas/aicoOrganization';
 
 import { parseAicoBillingContext } from './billingContext';
 import { AicoManagedPolicy, AicoManagedPolicyError } from './managedPolicy';
@@ -40,5 +53,67 @@ describe('explicit billing context + managed policy', () => {
     await expect(
       policy.authorize({ billing: { source: 'personal' }, modelId: '   ', userId: 'u1' }),
     ).rejects.toMatchObject({ code: 'MODEL_ID_REQUIRED' });
+  });
+});
+
+describe('org wallet: Auto model is not gated by the team allow-list', () => {
+  let db: LobeChatDatabase;
+  let orgModel: OrganizationModel;
+  const ownerId = 'auto-bypass-owner';
+
+  const cleanup = async () => {
+    await db.delete(modelAccessRules);
+    await db.delete(organizationTeamMembers);
+    await db.delete(organizationTeams);
+    await db.delete(organizationMembers);
+    await db.delete(organizations);
+    await db.delete(users);
+  };
+
+  beforeEach(async () => {
+    db = await getTestDB();
+    orgModel = new OrganizationModel(db);
+    await cleanup();
+    await db.insert(users).values([{ email: 'owner@example.com', id: ownerId }]);
+  });
+
+  afterEach(cleanup);
+
+  it('lets Auto through even when the team allow-list omits it, but still blocks other unlisted models', async () => {
+    const org = await orgModel.createOrganization({ name: 'Bypass Org', ownerUserId: ownerId });
+    const teams = await orgModel.listTeams(org.id);
+    // Admin explicitly restricted the team to a non-Auto model.
+    await orgModel.setTeamModelAccess({
+      modelIds: ['openai/gpt-4o-mini'],
+      orgId: org.id,
+      teamId: teams[0].id,
+    });
+
+    const policy = new AicoManagedPolicy(db, async () => null);
+    const billing = parseAicoBillingContext({ organizationId: org.id, source: 'organization' });
+
+    // Auto clears the allow-list gate and fails later (no budget provisioned) —
+    // never MODEL_NOT_ALLOWED, which is what a missing allow-list row used to throw.
+    await expect(
+      policy.authorize({ billing, modelId: OPENROUTER_AUTO_MODEL_ID, userId: ownerId }),
+    ).rejects.toMatchObject({ code: 'MEMBER_BUDGET_INACTIVE' });
+
+    // A model that genuinely isn't granted is still rejected.
+    await expect(
+      policy.authorize({ billing, modelId: 'openai/gpt-4o', userId: ownerId }),
+    ).rejects.toMatchObject({ code: 'MODEL_NOT_ALLOWED:openai/gpt-4o' });
+  });
+
+  it('lets Auto through even when the team is locked to zero models', async () => {
+    const org = await orgModel.createOrganization({ name: 'Locked Org', ownerUserId: ownerId });
+    const teams = await orgModel.listTeams(org.id);
+    await orgModel.setTeamModelAccess({ modelIds: [], orgId: org.id, teamId: teams[0].id });
+
+    const policy = new AicoManagedPolicy(db, async () => null);
+    const billing = parseAicoBillingContext({ organizationId: org.id, source: 'organization' });
+
+    await expect(
+      policy.authorize({ billing, modelId: OPENROUTER_AUTO_MODEL_ID, userId: ownerId }),
+    ).rejects.toMatchObject({ code: 'MEMBER_BUDGET_INACTIVE' });
   });
 });

--- a/apps/server/src/services/aico/managedPolicy.ts
+++ b/apps/server/src/services/aico/managedPolicy.ts
@@ -1,3 +1,4 @@
+import { OPENROUTER_AUTO_MODEL_ID } from '@lobechat/business-const';
 import { ChatErrorType, type ErrorType } from '@lobechat/types';
 
 import { AicoBillingModel } from '@/database/models/aicoBilling';
@@ -217,6 +218,9 @@ export class AicoManagedPolicy {
       if (!me) {
         throw new AicoManagedPolicyError('ORG_MEMBERSHIP_REQUIRED', ChatErrorType.Forbidden);
       }
+      // Auto is the product's meta-router, not an admin-grantable team model —
+      // always usable on the org wallet regardless of the team's allow-list.
+      if (modelId === OPENROUTER_AUTO_MODEL_ID) return;
       const allowed = await this.orgModel.getAllowedModelsForMember(me.id);
       if (!allowed || allowed.length === 0 || !allowed.includes(modelId)) {
         throw new AicoManagedPolicyError(`MODEL_NOT_ALLOWED:${modelId}`, ChatErrorType.BadRequest);

--- a/src/hooks/useEnabledChatModels.test.ts
+++ b/src/hooks/useEnabledChatModels.test.ts
@@ -131,4 +131,41 @@ describe('useEnabledChatModels', () => {
     expect(result.current[0].id).toBe('openrouter');
     expect(result.current[0].children.map((m) => m.id)).toEqual(['openai/gpt-4o-mini']);
   });
+
+  it('on org wallet always includes Auto even when the team allow-list omits it', async () => {
+    useAicoBillingStore.mockImplementation((selector: any) =>
+      selector({ context: { organizationId: 'org-1', source: 'organization' } }),
+    );
+    useAiInfraStore.mockImplementation((selector: any) => selector({ enabledChatModelList: [] }));
+
+    useClientDataSWR.mockImplementation((key: unknown) => {
+      if (key === 'aico-provider-status') return { data: { managed: true } };
+      if (Array.isArray(key) && key[0] === 'aico-my-allowed-models') {
+        // Team allow-list was never backfilled with Auto.
+        return { data: { modelIds: ['openai/gpt-4o-mini'] } };
+      }
+      if (Array.isArray(key) && key[0] === 'aico-managed-model-catalog') {
+        return {
+          data: [
+            { abilities: {}, displayName: 'Auto', id: 'openrouter/auto', type: 'chat' },
+            {
+              abilities: {},
+              displayName: 'GPT-4o mini',
+              id: 'openai/gpt-4o-mini',
+              type: 'chat',
+            },
+          ],
+        };
+      }
+      return { data: undefined };
+    });
+
+    const { useEnabledChatModels } = await import('./useEnabledChatModels');
+    const { result } = renderHook(() => useEnabledChatModels());
+
+    expect(result.current[0].children.map((m) => m.id)).toEqual([
+      'openrouter/auto',
+      'openai/gpt-4o-mini',
+    ]);
+  });
 });

--- a/src/hooks/useEnabledChatModels.ts
+++ b/src/hooks/useEnabledChatModels.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
+import { DEFAULT_PROVIDER, OPENROUTER_AUTO_MODEL_ID } from '@lobechat/business-const';
 import isEqual from 'fast-deep-equal';
 import { type AiModelForSelect, type AiProviderModelListItem } from 'model-bank';
 import { useMemo } from 'react';
@@ -68,9 +68,15 @@ export const useEnabledChatModels = (): EnabledProviderWithModels[] => {
       return scoped.filter((provider) => !isAicoManagedRuntimeProvider(provider.id));
     }
 
+    // Auto is the product's meta-router, not an admin-grantable team model —
+    // always present in org wallet mode regardless of the team's allow-list.
     const allowSet = new Set(allowed.modelIds);
     const children = catalog
-      .filter((model) => (model.type || 'chat') === 'chat' && allowSet.has(model.id))
+      .filter(
+        (model) =>
+          (model.type || 'chat') === 'chat' &&
+          (model.id === OPENROUTER_AUTO_MODEL_ID || allowSet.has(model.id)),
+      )
       .map(catalogModelToSelect);
 
     if (children.length === 0) {


### PR DESCRIPTION
## Summary
- Follow-up to #319: that fix backfilled `openrouter/auto` (`panachat/auto`) into existing teams' `model_access_rules` via a manual one-off script, but the script was never run against real data, so Auto kept disappearing from the org/team wallet's model picker (and would 400 with `MODEL_NOT_ALLOWED` if selected anyway).
- Reframes Auto as the product's meta-router rather than an admin-grantable team model: it's now always available on the org wallet regardless of the team's `model_access_rules` allow-list, in both places that gate it:
  - `useEnabledChatModels` — the org-wallet model list always includes Auto from the catalog.
  - `AicoManagedPolicy.assertModelAllowed` — the actual chat-request enforcement point now lets Auto through for any active org member before consulting the team allow-list.
- Since `DEFAULT_MODEL` is already `openrouter/auto` globally, it's also the effective default on the org wallet now that it's genuinely present in the list.

## Test plan
- [x] `bun run check` (lint + tests) on all four changed files — clean.
- [x] Added regression tests in both `useEnabledChatModels.test.ts` and `managedPolicy.test.ts`; confirmed each fails against the pre-fix code (`MODEL_NOT_ALLOWED:openrouter/auto` / model missing from picker) and passes after.
- [x] `managedPolicy.test.ts` new cases use a real in-memory (PGlite) DB via `getTestDB` to cover both a team whose allow-list omits Auto and a team explicitly locked to zero models — Auto still gets through in both.

**Note for reviewers**: the org admin's "Add Model" picker (`TeamModelsForm`) and `DEFAULT_TEAM_MODEL_IDS` still treat Auto as a grantable/removable row — an admin could "remove" it there and it would still work, since it's now unconditionally on. Left that alone as out of scope for this fix; flagging in case follow-up cleanup is wanted there.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>