### PR TITLE
🐛 fix(sandbox): hide the Cloud Sandbox tool when no sandbox backend is configured

### DIFF
--- a/apps/server/src/globalConfig/index.ts
+++ b/apps/server/src/globalConfig/index.ts
@@ -13,6 +13,7 @@ import { langfuseEnv } from '@/envs/langfuse';
 import { toolsEnv } from '@/envs/tools';
 import { parseSSOProviders } from '@/libs/better-auth/utils/server';
 import { parseSystemAgent } from '@/server/globalConfig/parseSystemAgent';
+import { isCloudSandboxConfigured } from '@/server/services/sandbox/config';
 import { type GlobalServerConfig } from '@/types/serverConfig';
 import { cleanObject } from '@/utils/object';
 
@@ -109,6 +110,7 @@ export const getServerGlobalConfig = async () => {
     disableEmailPassword: authEnv.AUTH_DISABLE_EMAIL_PASSWORD,
     enableBusinessFeatures: ENABLE_BUSINESS_FEATURES,
     enableEmailVerification: authEnv.AUTH_EMAIL_VERIFICATION,
+    enableCloudSandbox: isCloudSandboxConfigured(),
     enableComposio: !!composioEnv.COMPOSIO_API_KEY,
     enableGatewayMode:
       ENABLE_BUSINESS_FEATURES || (!!appEnv.ENABLE_AGENT_GATEWAY && !!appEnv.AGENT_GATEWAY_URL),

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { GroupAgentBuilderManifest } from '@lobechat/builtin-tool-group-agent-builder';
 import { GroupManagementManifest } from '@lobechat/builtin-tool-group-management';
 import { ImageGenerationManifest } from '@lobechat/builtin-tool-image-generation';
@@ -11,10 +12,21 @@ import { SkillsApiName, SkillsManifest } from '@lobechat/builtin-tool-skills';
 import { WebBrowsingManifest } from '@lobechat/builtin-tool-web-browsing';
 import { builtinTools } from '@lobechat/builtin-tools';
 import { ToolsEngine } from '@lobechat/context-engine';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createServerAgentToolsEngine, createServerToolsEngine } from '../index';
 import { type InstalledPlugin, type ServerAgentToolsContext } from '../types';
+
+// The Cloud Sandbox deployment gate reads server env; drive it explicitly so the
+// suite doesn't depend on whatever sandbox credentials the test env happens to
+// carry. Defaults to a configured deployment.
+const { mockIsCloudSandboxConfigured } = vi.hoisted(() => ({
+  mockIsCloudSandboxConfigured: vi.fn(() => true),
+}));
+
+vi.mock('@/server/services/sandbox/config', () => ({
+  isCloudSandboxConfigured: mockIsCloudSandboxConfigured,
+}));
 
 // Mock installed plugins
 const mockInstalledPlugins: InstalledPlugin[] = [
@@ -726,6 +738,56 @@ describe('createServerAgentToolsEngine', () => {
       });
 
       expect(result.enabledToolIds).toContain(MemoryManifest.identifier);
+    });
+  });
+
+  describe('CloudSandbox tool enable rules', () => {
+    // Regression: a deployment with no sandbox backend (no Onlyboxes console, no
+    // Market Trusted Client credentials) 401s on every sandbox call, which the
+    // client surfaces as a LobeHub sign-in popup. The tool must not reach the
+    // model at all in that case.
+    const buildEnabledToolIds = () => {
+      const engine = createServerAgentToolsEngine(createMockContext(), {
+        agentConfig: { agencyConfig: { executionTarget: 'sandbox' } },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      return engine.generateToolsDetailed({
+        model: 'gpt-4',
+        provider: 'openai',
+        toolIds: [CloudSandboxManifest.identifier],
+      }).enabledToolIds;
+    };
+
+    it('should enable CloudSandbox on the cloud runtime when a sandbox backend is configured', () => {
+      mockIsCloudSandboxConfigured.mockReturnValue(true);
+
+      expect(buildEnabledToolIds()).toContain(CloudSandboxManifest.identifier);
+    });
+
+    it('should disable CloudSandbox when the deployment has no sandbox backend', () => {
+      mockIsCloudSandboxConfigured.mockReturnValue(false);
+
+      expect(buildEnabledToolIds()).not.toContain(CloudSandboxManifest.identifier);
+    });
+
+    it('should disable CloudSandbox when the agent is not on the cloud runtime', () => {
+      mockIsCloudSandboxConfigured.mockReturnValue(true);
+
+      const engine = createServerAgentToolsEngine(createMockContext(), {
+        agentConfig: { agencyConfig: { executionTarget: 'none' } },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        model: 'gpt-4',
+        provider: 'openai',
+        toolIds: [CloudSandboxManifest.identifier],
+      });
+
+      expect(result.enabledToolIds).not.toContain(CloudSandboxManifest.identifier);
     });
   });
 

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -45,6 +45,7 @@ import {
   DEVICE_TOOL_IDENTIFIERS,
   REMOTE_DEVICE_TOOL_IDENTIFIERS,
 } from '@/server/services/aiAgent/deviceToolRegistry';
+import { isCloudSandboxConfigured } from '@/server/services/sandbox/config';
 
 import {
   type ServerAgentToolsContext,
@@ -301,7 +302,10 @@ export const createServerAgentToolsEngine = (
     // Always-on builtin tools
     ...Object.fromEntries(alwaysOnToolIds.map((id) => [id, true])),
     // System-level rules (may override user selection for specific tools)
-    [CloudSandboxManifest.identifier]: runtimeMode === 'cloud',
+    // Cloud sandbox: the agent must be on the cloud runtime AND the deployment
+    // must actually have a sandbox backend configured. Without one every call
+    // 401s into a LobeHub sign-in popup, so the tool must never be offered.
+    [CloudSandboxManifest.identifier]: runtimeMode === 'cloud' && isCloudSandboxConfigured(),
     [KnowledgeBaseManifest.identifier]: hasEnabledKnowledgeBases,
     // Local-system: the user must have opted into local runtime
     // (`runtimeMode === 'local'`) AND have an online, auto-activated device

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -159,6 +159,7 @@ import { buildCloudHeteroContext } from '@/server/services/heterogeneousAgent/cl
 import { buildRemoteDeviceHeteroContext } from '@/server/services/heterogeneousAgent/remoteDeviceHeteroContext';
 import { MarketService } from '@/server/services/market';
 import { isResourceAuthorOrAdmin } from '@/server/services/resourcePermission';
+import { isCloudSandboxConfigured } from '@/server/services/sandbox/config';
 import {
   buildConnectorOwnershipPrompt,
   collectBorrowedConnectors,
@@ -3242,12 +3243,16 @@ export class AiAgentService {
       // Effective runtimeMode from the plan's resolved target — same value the
       // engine derives, single derivation point.
       const agentRuntimeMode = executionTargetToRuntimeMode(executionPlan.target);
+      // A `cloud` runtime only counts when the deployment has a sandbox backend
+      // configured; otherwise the tool would be offered, approved by the user,
+      // and then dead-end in a Market 401 / LobeHub sign-in popup.
+      const cloudSandboxAvailable = agentRuntimeMode === 'cloud' && isCloudSandboxConfigured();
       // When sandbox is not the active runtime, remove lobe-cloud-sandbox from the
       // manifest map. The initial seed via getEnabledPluginManifests (which includes
       // defaultToolIds) may have already placed it there, and the allowedBuiltinTools
       // loop below only guards the discoverable-builtin append path. Deleting here
       // covers both sources in a single point.
-      if (agentRuntimeMode !== 'cloud') {
+      if (!cloudSandboxAvailable) {
         delete toolManifestMap[CloudSandboxManifest.identifier];
       }
       // Same single-point deletion for the device tools: a `none` / `sandbox`
@@ -3266,8 +3271,7 @@ export class AiAgentService {
         if (!isManifestIngestAllowed(tool.identifier)) continue;
         // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
         // to 'cloud' (i.e. executionTarget='sandbox').
-        if (tool.identifier === CloudSandboxManifest.identifier && agentRuntimeMode !== 'cloud')
-          continue;
+        if (tool.identifier === CloudSandboxManifest.identifier && !cloudSandboxAvailable) continue;
         // device tools are only activator-discoverable in device-capable sessions
         if (stripDeviceTools && isDeviceToolIdentifier(tool.identifier)) continue;
         if (tool.discoverable !== false && !toolManifestMap[tool.identifier]) {

--- a/apps/server/src/services/sandbox/__tests__/config.test.ts
+++ b/apps/server/src/services/sandbox/__tests__/config.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadConfig = async () => import('../config');
+
+describe('isCloudSandboxConfigured', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  // Regression: with the market provider and no Trusted Client credentials every
+  // sandbox call comes back 401, which the client turns into a LobeHub sign-in
+  // popup. Self-hosted users have no LobeHub account, so the tool must be gated
+  // off instead of dead-ending them at an external login page.
+  it('reports unconfigured for the default market provider without trusted client credentials', async () => {
+    vi.doMock('@/envs/app', () => ({ appEnv: {} }));
+    vi.doMock('@/envs/sandbox', () => ({ sandboxEnv: {} }));
+
+    const { isCloudSandboxConfigured } = await loadConfig();
+
+    expect(isCloudSandboxConfigured()).toBe(false);
+  });
+
+  it('reports configured for the market provider with trusted client credentials', async () => {
+    vi.doMock('@/envs/app', () => ({
+      appEnv: {
+        MARKET_TRUSTED_CLIENT_ID: 'lobechat-com',
+        MARKET_TRUSTED_CLIENT_SECRET: 'trusted-client-secret',
+      },
+    }));
+    vi.doMock('@/envs/sandbox', () => ({ sandboxEnv: { SANDBOX_PROVIDER: 'market' } }));
+
+    const { isCloudSandboxConfigured } = await loadConfig();
+
+    expect(isCloudSandboxConfigured()).toBe(true);
+  });
+
+  it('reports configured for a fully configured onlyboxes console', async () => {
+    vi.doMock('@/envs/app', () => ({ appEnv: {} }));
+    vi.doMock('@/envs/sandbox', () => ({
+      sandboxEnv: {
+        ONLYBOXES_BASE_URL: 'https://onlyboxes.example.com',
+        ONLYBOXES_JIT_SIGNING_KEY: 'jit-signing-key',
+        SANDBOX_PROVIDER: 'onlyboxes',
+      },
+    }));
+
+    const { isCloudSandboxConfigured } = await loadConfig();
+
+    expect(isCloudSandboxConfigured()).toBe(true);
+  });
+
+  it('reports unconfigured for an onlyboxes provider missing its signing key', async () => {
+    vi.doMock('@/envs/app', () => ({ appEnv: {} }));
+    vi.doMock('@/envs/sandbox', () => ({
+      sandboxEnv: {
+        ONLYBOXES_BASE_URL: 'https://onlyboxes.example.com',
+        SANDBOX_PROVIDER: 'onlyboxes',
+      },
+    }));
+
+    const { isCloudSandboxConfigured } = await loadConfig();
+
+    expect(isCloudSandboxConfigured()).toBe(false);
+  });
+});

--- a/apps/server/src/services/sandbox/config.ts
+++ b/apps/server/src/services/sandbox/config.ts
@@ -1,0 +1,37 @@
+import { appEnv } from '@/envs/app';
+import { sandboxEnv } from '@/envs/sandbox';
+
+import type { SandboxProviderKind } from './types';
+
+export const getSandboxProviderKind = (): SandboxProviderKind => {
+  return sandboxEnv.SANDBOX_PROVIDER || 'market';
+};
+
+/**
+ * Whether the deployment actually has a Cloud Sandbox backend it can reach.
+ *
+ * - `onlyboxes`: needs its console URL + JIT signing key, otherwise every call
+ *   fails inside the provider.
+ * - `market`: the Market sandbox authenticates as the current user. Without
+ *   Trusted Client credentials the server has no way to do that, so every call
+ *   comes back 401 and the client turns that into a LobeHub sign-in popup — a
+ *   dead end on a self-hosted deployment whose users have no LobeHub account.
+ *   This mirrors `enableLobehubSkill`, gated on the same credentials.
+ *
+ * Consumers use this to keep the Cloud Sandbox tool out of the model's toolset
+ * entirely, so it is never proposed, approved, and then dead-ended.
+ *
+ * Lives in its own leaf module (env only) so config-level callers don't pull in
+ * the provider implementations and their SDKs.
+ */
+export const isCloudSandboxConfigured = (): boolean => {
+  switch (getSandboxProviderKind()) {
+    case 'onlyboxes': {
+      return !!(sandboxEnv.ONLYBOXES_BASE_URL && sandboxEnv.ONLYBOXES_JIT_SIGNING_KEY);
+    }
+
+    case 'market': {
+      return !!(appEnv.MARKET_TRUSTED_CLIENT_ID && appEnv.MARKET_TRUSTED_CLIENT_SECRET);
+    }
+  }
+};

--- a/apps/server/src/services/sandbox/factory.ts
+++ b/apps/server/src/services/sandbox/factory.ts
@@ -1,18 +1,8 @@
-import { sandboxEnv } from '@/envs/sandbox';
-
+import { getSandboxProviderKind } from './config';
 import { MarketSandboxProvider } from './providers/market';
 import { OnlyboxesSandboxProvider } from './providers/onlyboxes';
 import { SandboxMiddlewareService } from './service';
-import type {
-  SandboxProvider,
-  SandboxProviderKind,
-  SandboxService,
-  SandboxServiceOptions,
-} from './types';
-
-export const getSandboxProviderKind = (): SandboxProviderKind => {
-  return sandboxEnv.SANDBOX_PROVIDER || 'market';
-};
+import type { SandboxProvider, SandboxService, SandboxServiceOptions } from './types';
 
 const createSandboxProvider = (options: SandboxServiceOptions): SandboxProvider => {
   switch (getSandboxProviderKind()) {

--- a/apps/server/src/services/sandbox/index.ts
+++ b/apps/server/src/services/sandbox/index.ts
@@ -1,4 +1,5 @@
-export { createSandboxService, getSandboxProviderKind } from './factory';
+export { getSandboxProviderKind, isCloudSandboxConfigured } from './config';
+export { createSandboxService } from './factory';
 export { MarketSandboxProvider, ServerSandboxService } from './providers/market';
 export { OnlyboxesSandboxProvider } from './providers/onlyboxes';
 export { normalizeSandboxCommandResult, SandboxMiddlewareService } from './service';

--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -95,6 +95,12 @@ export interface GlobalServerConfig {
   defaultAgent?: PartialDeep<UserDefaultAgent>;
   disableEmailPassword?: boolean;
   enableBusinessFeatures?: boolean;
+  /**
+   * Whether the deployment has a reachable Cloud Sandbox backend (a configured
+   * Onlyboxes console, or Market Trusted Client credentials). When false the
+   * Cloud Sandbox tool is kept out of the toolset entirely.
+   */
+  enableCloudSandbox?: boolean;
   enableComposio?: boolean;
   /**
    * @deprecated

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -94,6 +94,31 @@ vi.mock('@/store/tool', () => ({
         type: 'builtin' as const,
       },
       {
+        identifier: 'lobe-cloud-sandbox',
+        manifest: {
+          api: [
+            {
+              description: 'List files in the cloud sandbox',
+              name: 'listFiles',
+              parameters: {
+                properties: {
+                  path: { type: 'string' },
+                },
+                required: ['path'],
+                type: 'object',
+              },
+            },
+          ],
+          identifier: 'lobe-cloud-sandbox',
+          meta: {
+            title: 'Cloud Sandbox',
+            avatar: 'C',
+          },
+          type: 'builtin',
+        } as unknown as ToolManifest,
+        type: 'builtin' as const,
+      },
+      {
         identifier: 'lobe-image-generation',
         manifest: {
           api: [
@@ -150,6 +175,7 @@ vi.mock('../isCanUseFC', () => ({
   isCanUseFC: () => mockIsCanUseFC,
 }));
 
+let mockIsCloudSandboxEnabled = false;
 let mockCurrentAgentPlugins: string[] = [];
 let mockCurrentAgentDisabledPlugins: string[] = [];
 let mockCurrentChatConfig: { enableAgentMode?: boolean; memory?: { enabled?: boolean } } = {};
@@ -167,7 +193,7 @@ vi.mock('@/store/agent/selectors', () => ({
   },
   agentChatConfigSelectors: {
     currentChatConfig: () => mockCurrentChatConfig,
-    isCloudSandboxEnabled: () => false,
+    isCloudSandboxEnabled: () => mockIsCloudSandboxEnabled,
     isLocalSystemEnabled: () => false,
     isMemoryToolEnabled: () => false,
   },
@@ -214,6 +240,8 @@ describe('toolEngineering', () => {
     mockCurrentChatConfig = {};
     mockImageOutputSupport = false;
     mockServerConfig = {};
+    mockIsCloudSandboxEnabled = false;
+    delete (window as any).global_serverConfigStore;
   });
 
   // `TOOL_NAME_MAX_LENGTH` is a server env, but this path generates tool names in
@@ -371,6 +399,53 @@ describe('toolEngineering', () => {
       });
 
       expect(result.enabledToolIds).not.toContain('lobe-image-generation');
+    });
+
+    // Regression: on a deployment with no sandbox backend the Market provider
+    // 401s and the client turns that into a LobeHub sign-in popup — so the tool
+    // must never reach the model in the first place.
+    describe('cloud sandbox deployment gate', () => {
+      const setServerConfig = (serverConfig: Record<string, unknown>) => {
+        (window as any).global_serverConfigStore = { getState: () => ({ serverConfig }) };
+      };
+
+      const buildEnabledToolIds = () => {
+        const toolsEngine = createAgentToolsEngine({ model: 'gpt-4', provider: 'openai' });
+
+        return toolsEngine.generateToolsDetailed({
+          model: 'gpt-4',
+          provider: 'openai',
+          toolIds: [],
+        }).enabledToolIds;
+      };
+
+      it('should drop the cloud sandbox tool when the deployment has no sandbox backend', () => {
+        mockIsCloudSandboxEnabled = true;
+        setServerConfig({ enableCloudSandbox: false });
+
+        expect(buildEnabledToolIds()).not.toContain('lobe-cloud-sandbox');
+      });
+
+      it('should keep the cloud sandbox tool when the deployment has a sandbox backend', () => {
+        mockIsCloudSandboxEnabled = true;
+        setServerConfig({ enableCloudSandbox: true });
+
+        expect(buildEnabledToolIds()).toContain('lobe-cloud-sandbox');
+      });
+
+      it('should stay permissive when the server config has not hydrated yet', () => {
+        mockIsCloudSandboxEnabled = true;
+        setServerConfig({});
+
+        expect(buildEnabledToolIds()).toContain('lobe-cloud-sandbox');
+      });
+
+      it('should still drop the tool when the agent is not on the cloud runtime', () => {
+        mockIsCloudSandboxEnabled = false;
+        setServerConfig({ enableCloudSandbox: true });
+
+        expect(buildEnabledToolIds()).not.toContain('lobe-cloud-sandbox');
+      });
     });
 
     it('should include web browsing tool as default when no tools are provided', () => {

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -234,6 +234,13 @@ export const createAgentToolsEngine = (
     agentChatConfigSelectors.currentChatConfig(agentState).memory?.enabled ??
     settingsSelectors.memoryEnabled(useUserStore.getState());
   const webBrowsingEnabled = searchConfig.useApplicationBuiltinSearchTool;
+  // Deployment-level gate: the server reports `false` when neither an Onlyboxes
+  // console nor Market Trusted Client credentials are configured (see
+  // `isCloudSandboxConfigured`). Only an explicit `false` disables the tool —
+  // `undefined` (config not hydrated yet, or a server that predates the flag)
+  // stays permissive so a working deployment never loses the tool mid-session.
+  const cloudSandboxConfigured =
+    window.global_serverConfigStore?.getState()?.serverConfig?.enableCloudSandbox !== false;
   const imageGenerationEnabled =
     isCanUseFC(workingModel.model, workingModel.provider) &&
     !aiModelSelectors.isModelSupportImageOutput(
@@ -266,7 +273,12 @@ export const createAgentToolsEngine = (
     [BrowserManifest.identifier]:
       agentChatConfigSelectors.isLocalSystemEnabled(agentState) &&
       labPreferSelectors.enableInAppBrowser(useUserStore.getState()),
-    [CloudSandboxManifest.identifier]: agentChatConfigSelectors.isCloudSandboxEnabled(agentState),
+    // Cloud sandbox needs both the agent's cloud runtime AND a sandbox backend
+    // configured on the deployment (`enableCloudSandbox`). Without a backend the
+    // tool would be proposed, approved, and then dead-end in a Market 401 that
+    // the client surfaces as a LobeHub sign-in popup.
+    [CloudSandboxManifest.identifier]:
+      agentChatConfigSelectors.isCloudSandboxEnabled(agentState) && cloudSandboxConfigured,
     [KnowledgeBaseManifest.identifier]: kbEnabled,
     [LocalSystemManifest.identifier]: agentChatConfigSelectors.isLocalSystemEnabled(agentState),
     [MemoryManifest.identifier]: memoryEnabled,

--- a/src/store/serverConfig/selectors.ts
+++ b/src/store/serverConfig/selectors.ts
@@ -7,6 +7,7 @@ export const serverConfigSelectors = {
   enableBusinessFeatures: (s: ServerConfigStore) => s.serverConfig.enableBusinessFeatures || false,
   enableEmailVerification: (s: ServerConfigStore) =>
     s.serverConfig.enableEmailVerification || false,
+  enableCloudSandbox: (s: ServerConfigStore) => s.serverConfig.enableCloudSandbox || false,
   enableComposio: (s: ServerConfigStore) => s.serverConfig.enableComposio || false,
   enableGatewayMode: (s: ServerConfigStore) => s.serverConfig.enableGatewayMode || false,
   enableLobehubSkill: (s: ServerConfigStore) => s.serverConfig.enableLobehubSkill || false,


### PR DESCRIPTION
On a self-hosted deployment, approving a Cloud Sandbox tool call (e.g. `listFiles`) opened a **LobeHub sign-in popup** at `app.lobehub.com/signin` — an account self-hosted users don't have. The tool was effectively unusable and the approval dead-ended at an external login page.

**Root cause:** the sandbox provider defaults to `market`, which calls `market.lobehub.com` on the user's behalf. Without `MARKET_TRUSTED_CLIENT_ID` / `MARKET_TRUSTED_CLIENT_SECRET` the server can't authenticate as the user, so every call 401s. `packages/trpc/src/client/lambda.ts` emits `market-unauthorized`, `MarketAuthProvider` calls `handleUnauthorized('sandbox')`, and that opens the Market OIDC popup, which redirects to LobeHub's sign-in. Nothing gated the tool on whether a sandbox backend existed, so the model was free to propose it.

#### What changed

- **`apps/server/src/services/sandbox/config.ts`** (new leaf module, env only): `isCloudSandboxConfigured()` — true when the Onlyboxes console is fully configured (`ONLYBOXES_BASE_URL` + `ONLYBOXES_JIT_SIGNING_KEY`), or when Market Trusted Client credentials are present. `getSandboxProviderKind` moved here so config-level callers don't pull in the provider SDKs; `factory.ts` / `index.ts` re-export it, so existing import paths are unchanged.
- **`enableCloudSandbox`** added to `GlobalServerConfig` + a store selector, so the client knows whether the deployment can actually run the sandbox.
- All three toolset builders now require the flag **alongside** the agent's cloud runtime:
  - `src/helpers/toolEngineering/index.ts` (client)
  - `apps/server/src/modules/Mecha/AgentToolsEngine/index.ts` (server)
  - `apps/server/src/services/aiAgent/index.ts` (gateway path — manifest-map deletion and the activator-discoverable loop)

This mirrors `enableLobehubSkill`, which already gates the LobeHub skill tools on the same credentials — so LobeHub Cloud (where those vars are set) is unaffected.

#### Reviewer notes

- **Client gate is deliberately permissive on `undefined`**: only an explicit `false` disables the tool. A not-yet-hydrated server config, or a server that predates the flag, keeps the tool available rather than silently losing it mid-session.
- **This does disable the "sign in to LobeHub with your own account" path** for the Market sandbox on self-hosted instances. That's intentional and consistent with `enableLobehubSkill`'s existing precedent; the trade-off is worth flagging.
- **Fixes for affected deployments** are env-only, no code needed: either `SANDBOX_PROVIDER=onlyboxes` with a self-hosted console, or Market Trusted Client credentials. Both are documented in `docs/self-hosting/environment-variables/cloud-sandbox.mdx`.
- **Not covered:** the execution-target picker still offers "Cloud Sandbox" as a target when unconfigured — selecting it now yields no sandbox tools rather than a login popup. Hiding that option is a follow-up.
- No dedicated test for the `aiAgent` gateway site — it reuses the same helper and follows the existing `agentRuntimeMode !== 'cloud'` pattern inside a method that would need the whole service stood up.

#### Test

Both regression tests were confirmed to fail before the fix and pass after it.

- `apps/server/src/services/sandbox/__tests__/config.test.ts` — the four provider/credential combinations.
- `apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts` — `CloudSandbox tool enable rules`: enabled on cloud runtime with a backend, dropped without one, dropped off the cloud runtime.
- `src/helpers/toolEngineering/index.test.ts` — `cloud sandbox deployment gate`, including the permissive-on-unhydrated case.

`bun run check` on the 12 changed files: lint clean, 105 tests passed.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

None — reported directly from the chat.panafor.com deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
