### PR TITLE
🐛 fix(generation): let users pick a wallet in image and video generation

### DIFF
--- a/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
+++ b/src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx
@@ -70,3 +70,9 @@ export const getBusinessChatInputSendAreaPrefix = (sendAreaPrefix?: ReactNode): 
 };
 
 export const useBusinessChatInputSendAreaPrefix = getBusinessChatInputSendAreaPrefix;
+
+/**
+ * Image / video generation inputs reuse the chat wallet switcher so users can pick
+ * which wallet (personal or team) funds a generation, just like in chat.
+ */
+export const getBusinessGenerationSendAreaPrefix = getBusinessChatInputSendAreaPrefix;

--- a/src/business/client/hooks/useBusinessGenerationSendAreaPrefix.test.ts
+++ b/src/business/client/hooks/useBusinessGenerationSendAreaPrefix.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { isValidElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const BillingSourceSwitcher = () => null;
+
+vi.mock('@/features/AicoBilling', () => ({
+  BillingSourceSwitcher,
+  useAicoBillingChatGate: () => ({ blockReason: undefined, blocked: false, showTrialCta: false }),
+}));
+
+vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
+  useWorkspaceAwareNavigate: () => vi.fn(),
+}));
+
+const { getBusinessGenerationSendAreaPrefix } =
+  await import('./useBusinessChatInputSendAreaPrefix');
+
+const readPromptInput = (mode: 'image' | 'video') =>
+  readFileSync(
+    path.join(process.cwd(), `src/routes/(main)/(create)/${mode}/features/PromptInput/index.tsx`),
+    'utf8',
+  );
+
+describe('getBusinessGenerationSendAreaPrefix', () => {
+  it('provides the wallet switcher so generations can pick a billing source', () => {
+    const node = getBusinessGenerationSendAreaPrefix();
+
+    expect(isValidElement(node)).toBe(true);
+    expect((node as { type: unknown }).type).toBe(BillingSourceSwitcher);
+  });
+
+  it('keeps any existing prefix content alongside the wallet switcher', () => {
+    const extra = { type: 'span' };
+    const node = getBusinessGenerationSendAreaPrefix(extra as never) as {
+      props: { children: unknown[] };
+    };
+
+    expect(node.props.children[0]).toMatchObject({ type: BillingSourceSwitcher });
+    expect(node.props.children[1]).toBe(extra);
+  });
+
+  it.each(['image', 'video'] as const)('%s prompt input mounts the wallet switcher', (mode) => {
+    expect(readPromptInput(mode)).toContain('getBusinessGenerationSendAreaPrefix()');
+  });
+});

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -8,6 +8,7 @@ import { Images } from 'lucide-react';
 import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { getBusinessGenerationSendAreaPrefix } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
 import { loginRequired } from '@/components/Error/loginRequiredNotification';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
@@ -418,6 +419,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
               visibility={displayVisibility}
               onChange={setNewGenerationTopicVisibility}
             />
+            {getBusinessGenerationSendAreaPrefix()}
           </>
         }
         onGenerate={handleGenerate}

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -9,6 +9,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import VideoFreeQuotaInfo from '@/business/client/features/VideoFreeQuotaInfo';
+import { getBusinessGenerationSendAreaPrefix } from '@/business/client/hooks/useBusinessChatInputSendAreaPrefix';
 import { loginRequired } from '@/components/Error/loginRequiredNotification';
 import Action from '@/features/ChatInput/ActionBar/components/Action';
 import ModelSwitchPanel from '@/features/ModelSwitchPanel';
@@ -663,6 +664,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
                 visibility={displayVisibility}
                 onChange={setNewGenerationTopicVisibility}
               />
+              {getBusinessGenerationSendAreaPrefix()}
             </>
           }
           onGenerate={handleGenerate}


### PR DESCRIPTION
The image and video generation inputs had no wallet switcher, so users could not choose between their personal wallet and a team wallet the way they can in regular chat. The generation was silently billed to whichever wallet chat happened to have selected last.

The billing plumbing was already in place — `imageService` (`src/services/image.ts`) and `videoService` (`src/services/video.ts`) both call `assertAicoBillingAllowsChat`, which resolves and enforces the stored billing preference. Only the UI control was missing: `BillingSourceSwitcher` was mounted solely through the chat input's send-area prefix.

**Changes**

- `src/business/client/hooks/useBusinessChatInputSendAreaPrefix.tsx` — export `getBusinessGenerationSendAreaPrefix`, reusing the exact composition chat uses.
- `src/routes/(main)/(create)/image/features/PromptInput/index.tsx` and `.../video/features/PromptInput/index.tsx` — render it in `rightActions`, immediately before the generate button, matching chat's placement next to the send button.

**Notes for reviewers**

- The switcher persists through `setBillingPreference`, so the choice is shared with chat in both directions — picking the team wallet on `/image` keeps it selected in chat.
- It only renders as a dropdown when the user actually has more than one billing source (i.e. belongs to an org); otherwise it renders as a read-only balance chip, same as in chat.
- No server-side change is needed; generation requests already honour the selected context.

| Before | After |
| ------ | ----- |
| No wallet control in the image/video composer — generations bill to whatever chat last selected. | Wallet switcher sits left of the generate button, same control and behaviour as chat. |

#### Test

- New regression test `src/business/client/hooks/useBusinessGenerationSendAreaPrefix.test.ts` (4 cases): asserts the helper yields the wallet switcher, that it composes with an existing prefix, and that both generation prompt inputs mount it. The last two cases fail without the wiring in this PR.
- `bun run check` on the touched files: lint clean, tests passing. The repo-wide `--type` run has pre-existing failures elsewhere (better-auth plugins, `settings/about`, `services/message`); none are in the files touched here.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
