### PR TITLE
💄 style(chat): show the model name in the message cost hover card

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Actions/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Actions/index.tsx
@@ -83,7 +83,9 @@ export const AssistantActionsBar = memo<AssistantActionsBarProps>(({ actionsConf
           {showCost ? (
             <MessageCostBadge
               metadata={data.metadata}
+              model={data.model}
               performance={data.performance}
+              provider={data.provider}
               usage={data.usage}
             />
           ) : null}

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -86,7 +86,9 @@ export const GroupActionsBar = memo<GroupActionsProps>(
             <ReactionPicker messageId={id} />
             <MessageCostBadge
               metadata={data.metadata}
+              model={data.model}
               performance={data.performance}
+              provider={data.provider}
               usage={data.usage}
             />
           </>

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -6,11 +6,14 @@ import { CoinsIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { formatNumber } from '@/utils/format';
 
 import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
+import { resolveMessageModelName } from './resolveMessageModelName';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -47,6 +50,24 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-weight: 500;
     font-variant-numeric: tabular-nums;
     color: ${cssVar.colorText};
+  `,
+  modelName: css`
+    overflow: hidden;
+
+    font-size: 12px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  modelRow: css`
+    display: flex;
+    gap: 6px;
+    align-items: center;
+
+    min-width: 0;
+    padding-block-end: 8px;
+    border-block-end: 1px solid ${cssVar.colorSplit};
   `,
   sectionTitle: css`
     margin-block-end: 4px;
@@ -112,56 +133,81 @@ const buildUsageDetailRows = (
 
 interface MessageCostBadgeProps {
   metadata?: Record<string, unknown> | null;
+  model?: string | null;
   performance?: ModelPerformance;
+  provider?: string | null;
   usage?: ModelUsage;
 }
 
-const MessageCostBadge = memo<MessageCostBadgeProps>(({ usage, metadata, performance }) => {
-  const { t } = useTranslation('chat');
-  const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
+const MessageCostBadge = memo<MessageCostBadgeProps>(
+  ({ usage, metadata, performance, model, provider }) => {
+    const { t } = useTranslation('chat');
+    const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
+    const modelCard = useAiInfraStore(aiModelSelectors.getModelCard(model ?? '', provider ?? ''));
 
-  const cost = useMemo(() => resolveMessageCost(usage, metadata), [usage, metadata]);
-  const detailRows = useMemo(
-    () => buildUsageDetailRows(usage, performance, t),
-    [usage, performance, t],
-  );
+    const cost = useMemo(() => resolveMessageCost(usage, metadata), [usage, metadata]);
+    const detailRows = useMemo(
+      () => buildUsageDetailRows(usage, performance, t),
+      [usage, performance, t],
+    );
 
-  if (isShowCredit) return null;
-  if (cost === undefined || cost <= 0) return null;
+    if (isShowCredit) return null;
+    if (cost === undefined || cost <= 0) return null;
 
-  const amount = formatMessageCostUsd(cost);
-  const label = t('messageAction.cost');
+    const amount = formatMessageCostUsd(cost);
+    const label = t('messageAction.cost');
 
-  return (
-    <Popover
-      placement="top"
-      trigger="hover"
-      content={
-        <Flexbox gap={12} style={{ minWidth: 220, padding: 4 }}>
-          <div>
-            <div className={styles.sectionTitle}>{label}</div>
-            <div className={styles.costValue}>{amount}</div>
-          </div>
+    const { name: modelName, showIcon } = resolveMessageModelName({
+      displayName: modelCard?.displayName,
+      model,
+      provider,
+    });
 
-          {detailRows.length > 0 && (
-            <Flexbox gap={6}>
-              {detailRows.map((row) => (
-                <div className={styles.detailRow} key={row.key}>
-                  <span>{row.label}</span>
-                  <span className={styles.detailValue}>{row.value}</span>
-                </div>
-              ))}
-            </Flexbox>
-          )}
-        </Flexbox>
-      }
-    >
-      <Center horizontal aria-label={`${label}: ${amount}`} className={styles.chip}>
-        <Icon icon={CoinsIcon} size={14} />
-      </Center>
-    </Popover>
-  );
-});
+    return (
+      <Popover
+        placement="top"
+        trigger="hover"
+        content={
+          <Flexbox gap={12} style={{ minWidth: 220, padding: 4 }}>
+            {/* The model heads the card: it names what produced this reply, and
+                every number below is only meaningful once you know which model
+                they belong to. */}
+            {modelName && (
+              <div className={styles.modelRow}>
+                {showIcon && <BrandedModelIcon model={model!} size={16} type={'mono'} />}
+                <span className={styles.modelName}>{modelName}</span>
+              </div>
+            )}
+
+            <div>
+              <div className={styles.sectionTitle}>{label}</div>
+              <div className={styles.costValue}>{amount}</div>
+            </div>
+
+            {detailRows.length > 0 && (
+              <Flexbox gap={6}>
+                {detailRows.map((row) => (
+                  <div className={styles.detailRow} key={row.key}>
+                    <span>{row.label}</span>
+                    <span className={styles.detailValue}>{row.value}</span>
+                  </div>
+                ))}
+              </Flexbox>
+            )}
+          </Flexbox>
+        }
+      >
+        <Center
+          horizontal
+          aria-label={modelName ? `${label}: ${amount} · ${modelName}` : `${label}: ${amount}`}
+          className={styles.chip}
+        >
+          <Icon icon={CoinsIcon} size={14} />
+        </Center>
+      </Popover>
+    );
+  },
+);
 
 MessageCostBadge.displayName = 'MessageCostBadge';
 

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.test.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMessageModelName } from './resolveMessageModelName';
+
+describe('resolveMessageModelName', () => {
+  it('prefers the model card display name', () => {
+    expect(
+      resolveMessageModelName({ displayName: 'GPT-5', model: 'gpt-5', provider: 'openai' }),
+    ).toEqual({ name: 'GPT-5', showIcon: true });
+  });
+
+  it('falls back to the raw model id when the card is unknown', () => {
+    expect(resolveMessageModelName({ model: 'gpt-5', provider: 'openai' })).toEqual({
+      name: 'gpt-5',
+      showIcon: true,
+    });
+  });
+
+  it('uses the brand label and drops the icon for remote platform agents', () => {
+    expect(resolveMessageModelName({ model: null, provider: 'openclaw' })).toEqual({
+      name: 'OpenClaw',
+      showIcon: false,
+    });
+  });
+
+  it('keeps the real model for local CLI agents that report one', () => {
+    expect(
+      resolveMessageModelName({
+        displayName: 'Claude Opus 4',
+        model: 'claude-opus-4',
+        provider: 'claude-code',
+      }),
+    ).toEqual({ name: 'Claude Opus 4', showIcon: true });
+  });
+
+  it('returns no name when the message has no model at all', () => {
+    expect(resolveMessageModelName({ model: null, provider: null })).toEqual({
+      name: undefined,
+      showIcon: false,
+    });
+  });
+});

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.ts
@@ -1,0 +1,36 @@
+import {
+  HETEROGENEOUS_TYPE_LABELS,
+  isRemoteHeterogeneousType,
+} from '@lobechat/heterogeneous-agents';
+
+interface MessageModelNameInput {
+  /** `displayName` of the resolved model card, when the model is known locally. */
+  displayName?: string;
+  model?: string | null;
+  provider?: string | null;
+}
+
+interface MessageModelName {
+  name?: string;
+  /** Remote platform agents have no model id, so there is no icon to draw. */
+  showIcon: boolean;
+}
+
+/**
+ * Model identity for the cost hover card: the friendly display name when the
+ * model card is known, the raw id otherwise. Remote platform agents (openclaw,
+ * hermes) never expose a real model id and fall back to their brand label —
+ * the same rule the inline Usage row applies.
+ */
+export const resolveMessageModelName = ({
+  displayName,
+  model,
+  provider,
+}: MessageModelNameInput): MessageModelName => {
+  if (provider && isRemoteHeterogeneousType(provider)) {
+    const brand = HETEROGENEOUS_TYPE_LABELS[provider];
+    if (brand) return { name: brand, showIcon: false };
+  }
+
+  return { name: displayName || model || undefined, showIcon: !!model };
+};


### PR DESCRIPTION
Nothing after an assistant reply names the model for ordinary users. The inline `Usage` row that renders the model (`Messages/Assistant/Extra/index.tsx`) is gated behind `isDevMode`, so what most users see is the cost hover card — a price and a token breakdown with no indication of which model produced them.

This leads that card with the model: mono model icon + display name, separated from the numbers by a hairline rule.

**Why the top, and not a detail row** — the figures below are only interpretable once you know the model; listing it among the token rows would read as just one more metric rather than the identity the rest of the card describes.

**Changes**

- `MessageCostBadge.tsx` — new optional `model` / `provider` props; renders the model row at the head of the popover, and includes the model in the chip's `aria-label` (`Cost: $0.0123 · GPT-5`).
- `resolveMessageModelName.ts` (new) — pure resolver for the fallback chain: model card `displayName` → raw model id → remote platform brand label. Remote platform agents (openclaw, hermes) expose no real model id, so they show the brand label and drop the icon — the same rule the inline `Usage` row already applies. Local CLI agents (claude-code, codex) keep their reported model.
- `Assistant/Actions/index.tsx`, `AssistantGroup/Actions/index.tsx` — pass `data.model` / `data.provider` through.

**Notes for reviewers**

- No behaviour change to when the badge appears: it is still hidden in credit display mode (`isShowCredit`) and when cost is zero. Users in credit mode therefore still get no model name — deliberately out of scope here, happy to follow up if you want that covered.
- The dev-mode inline `Usage` row is untouched; this only fills the gap for non-dev users.

| Before | After |
| ------ | ----- |
| Hover cost card shows `Cost` + amount + token/speed rows — no model. | Same card, now headed by the model icon and display name above a hairline rule. |

#### Test

- New unit test `src/features/Conversation/Messages/components/resolveMessageModelName.test.ts` (5 cases): display-name preference, raw-id fallback, remote-brand fallback with icon suppressed, local CLI agent keeping its real model, and the no-model case.
- `bun run check` on the touched files: lint clean, 8 tests passing.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A — no open issue matches this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
