### PR TITLE
🐛 fix(chat): keep a model switch made right after sending the first message

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -7,6 +7,7 @@ import { agentService } from '@/services/agent';
 import { aiChatService } from '@/services/aiChat';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
+import { topicService } from '@/services/topic';
 import * as agentGroupStore from '@/store/agentGroup';
 import { setPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
@@ -703,6 +704,107 @@ describe('ConversationLifecycle actions', () => {
         // or the sidebar spinner sticks forever (the #16745 regression).
         expect(useChatStore.getState().topicLoadingIds).not.toContain(newTopicId);
         expect(useChatStore.getState().topicLoadingIds).not.toContain(optimisticTopicId);
+      });
+
+      it('should keep a model switch made during the optimistic-topic window instead of reverting to the send-time snapshot', async () => {
+        // Regression: switching the model right after hitting send (before the
+        // server confirms the real topicId) used to get silently reverted once
+        // resolveOptimisticTopic ran — it re-applied the stale `optimisticTopic`
+        // snapshot captured at send time, clobbering the interim switch that had
+        // only ever patched the temporary `tmp_topic_*` row client-side.
+        const { result } = renderHook(() => useChatStore());
+        const agentId = TEST_IDS.SESSION_ID;
+        const topicKey = topicMapKey({ agentId });
+        const newTopicId = TEST_IDS.NEW_TOPIC_ID;
+
+        let resolveServerSend!: (value: any) => void;
+        const serverSendPromise = new Promise<any>((resolve) => {
+          resolveServerSend = resolve;
+        });
+
+        act(() => {
+          useChatStore.setState({
+            activeAgentId: agentId,
+            activeTopicId: undefined,
+            executeClientAgent: vi.fn().mockResolvedValue(undefined),
+            summaryTopicTitle: vi.fn().mockResolvedValue(undefined),
+            topicDataMap: {
+              [topicKey]: {
+                currentPage: 0,
+                hasMore: false,
+                isExpandingPageSize: false,
+                isLoadingMore: false,
+                items: [],
+                pageSize: 20,
+                total: 0,
+              },
+            },
+          });
+        });
+
+        const sendMessageInServerSpy = vi
+          .spyOn(aiChatService, 'sendMessageInServer')
+          .mockReturnValue(serverSendPromise);
+        vi.spyOn(topicService, 'updateTopic').mockResolvedValue(undefined as any);
+
+        let sendPromise!: ReturnType<typeof result.current.sendMessage>;
+        act(() => {
+          sendPromise = result.current.sendMessage({
+            context: { agentId, threadId: null, topicId: null },
+            message: 'hello',
+          });
+        });
+
+        await waitFor(() => expect(sendMessageInServerSpy).toHaveBeenCalled());
+
+        const optimisticTopicId = useChatStore.getState().topicDataMap[topicKey]?.items[0]?.id;
+        expect(optimisticTopicId).toMatch(/^tmp_topic_/);
+
+        // The user opens the model switcher and picks a different model while
+        // the topic is still the optimistic placeholder — this is what happens
+        // when someone switches models right after hitting send.
+        await act(async () => {
+          await useChatStore.getState().updateTopicModel(optimisticTopicId!, {
+            model: 'switched-model',
+            provider: 'switched-provider',
+          });
+        });
+
+        expect(
+          useChatStore
+            .getState()
+            .topicDataMap[topicKey]?.items.find((topic) => topic.id === optimisticTopicId)?.model,
+        ).toBe('switched-model');
+
+        // The server now confirms the real topicId for the message sent before
+        // the switch.
+        await act(async () => {
+          resolveServerSend({
+            assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+            isCreateNewTopic: true,
+            messages: [
+              createMockMessage({
+                id: TEST_IDS.USER_MESSAGE_ID,
+                role: 'user',
+                topicId: newTopicId,
+              }),
+              createMockMessage({
+                id: TEST_IDS.ASSISTANT_MESSAGE_ID,
+                role: 'assistant',
+                topicId: newTopicId,
+              }),
+            ],
+            topicId: newTopicId,
+            topics: { items: [{ id: newTopicId, title: 'Server Topic' }], total: 1 },
+            userMessageId: TEST_IDS.USER_MESSAGE_ID,
+          } as any);
+          await sendPromise;
+        });
+
+        const resolvedTopic = useChatStore
+          .getState()
+          .topicDataMap[topicKey]?.items.find((topic) => topic.id === newTopicId);
+        expect(resolvedTopic?.model).toBe('switched-model');
       });
 
       it('should hold the migrated topicLoadingIds owner through a hetero new-topic run and release it at the end', async () => {

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -770,18 +770,50 @@ export class ConversationLifecycleActionImpl {
       );
     };
 
+    // The optimistic topic's model can have been switched (via updateTopicModel)
+    // while it still carried its temporary `tmp_topic_*` id — that write only
+    // ever patches this client's local state, since the server has no such id
+    // to persist against. Read the row's CURRENT model/metadata here instead of
+    // the `optimisticTopic` snapshot captured at send time: reusing that stale
+    // snapshot would re-apply the pre-switch model and silently revert a model
+    // switch made in the gap between hitting send and the server confirming
+    // the real topicId.
+    const getLiveOptimisticTopic = () =>
+      optimisticTopic
+        ? this.#get().topicDataMap[topicMapKey(optimisticTopicScope)]?.items.find(
+            (item) => item.id === optimisticTopic.id,
+          )
+        : undefined;
+
     const resolveOptimisticTopic = (topicId: string, title = optimisticTopic?.title) => {
+      const liveOptimisticTopic = getLiveOptimisticTopic();
+      const metadata = liveOptimisticTopic?.metadata ?? optimisticTopic?.metadata;
+      const model = liveOptimisticTopic?.model ?? optimisticTopic?.model;
+      const provider = liveOptimisticTopic?.provider ?? optimisticTopic?.provider;
+      // A switch made while the topic still carried its temporary id never
+      // reached the server (there was no real id to persist against yet) —
+      // replay it as a genuine `updateTopicModel` below, once `topicId` is real.
+      const switchedDuringPendingWindow =
+        !!model && (model !== optimisticTopic?.model || provider !== optimisticTopic?.provider);
+
+      const persistPendingModelSwitch = () => {
+        if (!switchedDuringPendingWindow || !model) return;
+
+        void this.#get()
+          .updateTopicModel(topicId, { model, provider: provider || '' })
+          .catch((err) => {
+            console.error('[resolveOptimisticTopic] failed to persist mid-send model switch:', err);
+          });
+      };
+
       if (!optimisticTopic || !optimisticTopicActive) {
         addResolvedTopicPlaceholder(
           topicId,
           title || t('defaultTitle', { ns: 'topic' }),
           'sendMessage/reconcileOptimisticTopic/add',
-          {
-            metadata: optimisticTopic?.metadata,
-            model: optimisticTopic?.model,
-            provider: optimisticTopic?.provider,
-          },
+          { metadata, model: model ?? undefined, provider: provider ?? undefined },
         );
+        persistPendingModelSwitch();
         return;
       }
 
@@ -790,14 +822,13 @@ export class ConversationLifecycleActionImpl {
         nextId: topicId,
         previousId: optimisticTopic.id,
         value: {
-          ...(optimisticTopic.metadata ? { metadata: optimisticTopic.metadata } : {}),
-          ...(optimisticTopic.model
-            ? { model: optimisticTopic.model, provider: optimisticTopic.provider }
-            : {}),
+          ...(metadata ? { metadata } : {}),
+          ...(model ? { model, provider } : {}),
           ...(operationContext.groupId ? {} : { sessionId: operationContext.agentId }),
           title: title || t('defaultTitle', { ns: 'topic' }),
         },
       });
+      persistPendingModelSwitch();
       optimisticTopicActive = false;
       optimisticTopicResolved = true;
     };

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -411,6 +411,7 @@ export class ChatTopicActionImpl {
     id: string,
     { model, provider }: { model: string; provider: string },
   ): Promise<void> => {
+    this.#pendingTopicModelWrites.set(id, { expiresAt: Date.now() + 15_000, model, provider });
     await this.#get().internal_updateTopic(id, { model, provider });
   };
 
@@ -427,6 +428,21 @@ export class ChatTopicActionImpl {
    */
   #pendingTopicStatusWrites = new Map<string, { expiresAt: number; status: ChatTopicStatus }>();
 
+  /**
+   * Same guard as `#pendingTopicStatusWrites`, for `updateTopicModel`. It
+   * matters most for a model switch made while the topic still carried its
+   * first-send optimistic `tmp_topic_*` id: `resolveOptimisticTopic` replays
+   * that switch as a real `updateTopicModel` once the id resolves (see
+   * `conversationLifecycle.ts`), but the SAME server response that resolved
+   * the id also carries the topic LIST fetched before that replay's persist
+   * completes — its stale (pre-switch) model would otherwise win the very next
+   * `internal_updateTopics` reconciliation, in the same tick.
+   */
+  #pendingTopicModelWrites = new Map<
+    string,
+    { expiresAt: number; model: string; provider: string }
+  >();
+
   #reconcileFetchedTopics = (items: ChatTopic[], currentItems?: ChatTopic[]): ChatTopic[] => {
     let next = items;
 
@@ -439,6 +455,21 @@ export class ChatTopicActionImpl {
           return item;
         }
         return { ...item, status: pending.status };
+      });
+    }
+
+    if (this.#pendingTopicModelWrites.size > 0) {
+      next = next.map((item) => {
+        const pending = this.#pendingTopicModelWrites.get(item.id);
+        if (!pending) return item;
+        if (
+          pending.expiresAt <= Date.now() ||
+          (item.model === pending.model && item.provider === pending.provider)
+        ) {
+          this.#pendingTopicModelWrites.delete(item.id);
+          return item;
+        }
+        return { ...item, model: pending.model, provider: pending.provider };
       });
     }
 


### PR DESCRIPTION
Switching models in the brief window between hitting send on a new topic and the server confirming its real topic id got silently reverted — the conversation kept using whatever model it started with, even though the switch appeared to work in the UI for a moment.

**Root cause**

When the first message of a new topic is sent, the client shows an optimistic placeholder topic with a temporary id (`tmp_topic_*`) while the server creates the real one. Switching models during that window calls `updateTopicModel(tmp_topic_xxx, ...)` — this only ever patches client-side state, since the server has no such id to persist against.

Once the server confirms the real topic id, `resolveOptimisticTopic` (`conversationLifecycle.ts`) re-applied the *original* model snapshot captured at send time, clobbering the switch. The same response's topic-list refetch (`internal_updateTopics`) then clobbered it a second time, since the server's row reflects the model it actually created the topic with (the original one — the switch never reached it).

**Fix**

- `resolveOptimisticTopic` now reads the topic's *live* model (reflecting any switch made during the pending window) instead of the stale send-time snapshot, and replays it as a genuine `updateTopicModel` call once the topic id is real — so it actually reaches the server this time.
- Added a `#pendingTopicModelWrites` TTL guard in `topic/action.ts`, mirroring the existing `#pendingTopicStatusWrites` pattern, so the same response's topic-list refetch can't clobber the replayed switch before its persist completes.

**Notes for reviewers**

- This only affects the narrow race window right after sending the first message of a new topic. Switching models on an already-resolved topic (several messages in) was unaffected — that path already persisted correctly.
- No server/schema changes; `updateTopic` already accepted `model`/`provider` (from the prior topic-scoped-model feature).

| Before | After |
| ------ | ----- |
| Switch model right after hitting send on a new topic → silently reverts to the original model once the topic resolves; every later message in that topic keeps using the original model. | The switch survives topic resolution and is durably persisted. |

#### Test

- New regression test in `conversationLifecycle.test.ts`: sends a message, switches the model while the topic is still the optimistic placeholder, resolves the server response, and asserts the switched model survives. It failed before the fix (came back reverted/`undefined`) and passes now.
- Full `conversationLifecycle.test.ts` (58 tests), `topic/action.test.ts`, `gateway.test.ts`, and `heterogeneousAgentExecutor.test.ts` pass — one pre-existing, unrelated failure in `topic/action.test.ts` (`createTopic > should create a new topic and update the store`) was confirmed present on `canary` before this change too.
- `bun run check` on touched files: lint clean, no new type errors.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A — no open issue matches this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
