### PR TITLE
🐛 fix(agent-runtime): correct the reused message's model/provider on generation

### DIFF
--- a/packages/agent-runtime/src/executors/callLlm.test.ts
+++ b/packages/agent-runtime/src/executors/callLlm.test.ts
@@ -268,9 +268,13 @@ describe('callLlm executor', () => {
     });
     expect(messages.createAssistantMessage).not.toHaveBeenCalled();
     // Pre-created placeholders exist before the operation does — the executor
-    // must merge the provenance stamp onto them.
+    // must merge the provenance stamp onto them, and correct their model/provider
+    // to what this call actually resolved to (the placeholder may have been
+    // stamped with the agent's default, e.g. before a mid-topic model switch).
     expect(messages.update).toHaveBeenCalledWith('assistant-existing', {
       metadata: { operationId: 'op-1' },
+      model: 'gpt-4',
+      provider: 'openai',
     });
     expect(transport.createTrace).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/agent-runtime/src/executors/callLlm.ts
+++ b/packages/agent-runtime/src/executors/callLlm.ts
@@ -307,13 +307,22 @@ export const callLlm =
     const existingAssistantMessageId = llmPayload.assistantMessageId;
     // Pre-created placeholders (e.g. sendMessage creates the assistant row
     // before the operation exists) miss the creation-time provenance stamp —
-    // merge it here so reused messages carry metadata.operationId too.
-    // Best-effort: the stamp is only a tracing aid and must never turn a
-    // normal send/resume into an LLM error before streaming starts.
+    // merge it here so reused messages carry metadata.operationId too. They
+    // also carry whatever model/provider the placeholder was stamped with at
+    // creation time, which for the top-level turn is the AGENT's default
+    // (sendMessage doesn't know about a topic-scoped model override) — not
+    // necessarily `model`/`provider` resolved above, the ones this call
+    // actually runs against (e.g. after a mid-topic model switch). Correct it
+    // here so the persisted row, and everything reading it (cost/usage
+    // display, history replay), reflects the model that really answered.
+    // Best-effort: this stamp is only a tracing/display aid and must never
+    // turn a normal send/resume into an LLM error before streaming starts.
     if (existingAssistantMessageId) {
       try {
         await transports.messages.update(existingAssistantMessageId, {
           metadata: { operationId: operation.operationId },
+          model,
+          provider,
         });
       } catch (error) {
         console.warn('[call_llm] Failed to stamp operation id provenance:', error);


### PR DESCRIPTION
Switching the model in the middle of a chat, then checking the cost hover card on the next reply, still showed the model the topic was switched *away from* — even though the reply itself was correctly generated by the new model. (This is a distinct bug from #326, which fixed the switch itself getting reverted — this one is about the *display* never catching up even when the switch sticks.)

**Root cause**

`sendMessage` pre-creates the assistant's message row before generation starts, stamping it with the agent's *default* model (it has no notion of a topic-scoped model override). Generation later correctly resolves and calls the actual (possibly just-switched) model — that part already worked. But in `callLlm.ts`, when generation reuses that pre-created row (`existingAssistantMessageId`), it only patched the row's `metadata.operationId` (a tracing stamp) — never its `model`/`provider` columns. So the persisted row, and everything reading it (the cost/usage hover card, message history), kept showing the original model indefinitely.

**Fix**

`callLlm.ts` — the same best-effort update that already stamps `operationId` onto the reused placeholder now also corrects `model`/`provider` to whatever this call actually resolved to.

This lives in `packages/agent-runtime`, the shared execution package, so it fixes the display for both the client and gateway-routed runtimes in one place. No server/schema changes — `model`/`provider` were already valid `UpdateMessageParams` fields.

**Notes for reviewers**

- Only affects the top-level turn reusing a pre-created placeholder; a message created inline (no `existingAssistantMessageId`, e.g. sub-agent turns) already got stamped with the correct model at creation.
- No behavior change to which model actually runs — only to what gets persisted/displayed for the message that already ran.

| Before | After |
| ------ | ----- |
| Switch model mid-chat → send → the reply's cost card still shows the *previous* model. | The reply's cost card shows the model that actually generated it. |

#### Test

- Updated the existing "reuses an existing assistant message" test in `callLlm.test.ts` to assert the reused-placeholder update call includes the resolved `model`/`provider`. Confirmed it fails on the pre-fix code (previously asserted only `{ metadata: {...} }`) and passes with the fix.
- Full `packages/agent-runtime` suite: 404/404 pass.
- `bun run check` on touched files: lint clean, no new type errors.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

N/A — no open issue matches this scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
