### PR TITLE
🐛 fix(branding): hide OpenRouter and LobeHub references from UI

### DIFF
--- a/packages/business/const/src/openrouterDefaultModels.test.ts
+++ b/packages/business/const/src/openrouterDefaultModels.test.ts
@@ -68,6 +68,32 @@ describe('computeDefaultEnabledOpenRouterModelIds', () => {
     expect(enabled.has('google/veo-3')).toBe(true);
     expect(enabled.has('deepseek/deepseek-chat')).toBe(false);
   });
+
+  it('pins gpt-4o even when newer generations push it out of the newest 4', () => {
+    const enabled = computeDefaultEnabledOpenRouterModelIds([
+      { id: 'openai/gpt-4o', releasedAt: '2024-05-01', type: 'chat' },
+      { id: 'openai/gpt-5', releasedAt: '2025-08-01', type: 'chat' },
+      { id: 'openai/gpt-5.1', releasedAt: '2025-11-01', type: 'chat' },
+      { id: 'openai/gpt-5.2', releasedAt: '2026-01-01', type: 'chat' },
+      { id: 'openai/gpt-5.3', releasedAt: '2026-03-01', type: 'chat' },
+      { id: 'openai/gpt-5.4', releasedAt: '2026-05-01', type: 'chat' },
+    ]);
+
+    expect(enabled.has('openai/gpt-4o')).toBe(true);
+  });
+
+  it('enables every catalog embedding model', () => {
+    const enabled = computeDefaultEnabledOpenRouterModelIds([
+      { id: 'openai/gpt-4o', releasedAt: '2025-01-01', type: 'chat' },
+      { id: 'openai/text-embedding-3-small', type: 'embedding' },
+      { id: 'openai/text-embedding-3-large', type: 'embedding' },
+      { id: 'google/text-embedding-005', type: 'embedding' },
+    ]);
+
+    expect(enabled.has('openai/text-embedding-3-small')).toBe(true);
+    expect(enabled.has('openai/text-embedding-3-large')).toBe(true);
+    expect(enabled.has('google/text-embedding-005')).toBe(true);
+  });
 });
 
 describe('pickPreferredDefaultOpenRouterModelId', () => {

--- a/packages/business/const/src/openrouterDefaultModels.ts
+++ b/packages/business/const/src/openrouterDefaultModels.ts
@@ -15,6 +15,13 @@ export type OpenRouterDefaultEnabledFamily = (typeof OPENROUTER_DEFAULT_ENABLED_
 export const DEFAULT_ENABLED_MODELS_PER_FAMILY = 4;
 
 /**
+ * Chat models pinned on top of the newest-per-family curation, so widely used
+ * models stay enabled even after newer generations push them out of the top 4
+ * (e.g. `openai/gpt-4o`).
+ */
+export const DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS = ['openai/gpt-4o'] as const;
+
+/**
  * Image Create defaults (OpenRouter Nano Banana family).
  * Catalog sync stores these as `type: 'image'` with `:image` suffix; chat-only
  * default selection never enables them unless we pin them here.
@@ -72,14 +79,19 @@ const isImageOrVideoType = (type?: string | null): boolean => {
   return normalized === 'image' || normalized === 'video';
 };
 
+const isEmbeddingType = (type?: string | null): boolean =>
+  (type || '').toLowerCase() === 'embedding';
+
 /**
  * Returns the set of OpenRouter model ids that should be enabled by default:
  * always includes {@link OPENROUTER_AUTO_MODEL_ID}, plus the
  * {@link DEFAULT_ENABLED_MODELS_PER_FAMILY} newest chat models from each of
  * openai / anthropic / google (by `releasedAt` desc; missing dates sort last),
+ * pinned chat models ({@link DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS}),
  * every catalog `image` / `video` generator (Create pickers only list enabled
- * models), plus Nano Banana Image-tab pins and `:image` clones of default chat
- * ids when those rows exist.
+ * models) and every catalog `embedding` model (knowledge / memory pickers only
+ * list enabled models), plus Nano Banana Image-tab pins and `:image` clones of
+ * default chat ids when those rows exist.
  */
 export const computeDefaultEnabledOpenRouterModelIds = (
   models: OpenRouterDefaultModelCandidate[],
@@ -117,6 +129,11 @@ export const computeDefaultEnabledOpenRouterModelIds = (
     }
   }
 
+  // Pin widely used chat models that the newest-per-family curation would drop.
+  for (const pinnedId of DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS) {
+    if (catalogIds.has(pinnedId)) enabled.add(pinnedId);
+  }
+
   // Pin Image Create Nano Banana defaults when the catalog has them.
   for (const imageId of DEFAULT_ENABLED_OPENROUTER_IMAGE_MODEL_IDS) {
     if (catalogIds.has(imageId)) enabled.add(imageId);
@@ -131,8 +148,10 @@ export const computeDefaultEnabledOpenRouterModelIds = (
 
   // Image / Video Create list enabled models only. Chat stays curated (hundreds
   // of cards); enable every catalog generator so Flux, Veo, etc. appear.
+  // Same for embeddings: knowledge / memory pickers only list enabled models,
+  // so enable every catalog embedding (e.g. text-embedding-3-small/large).
   for (const model of models) {
-    if (isImageOrVideoType(model.type)) enabled.add(model.id);
+    if (isImageOrVideoType(model.type) || isEmbeddingType(model.type)) enabled.add(model.id);
   }
 
   return enabled;

--- a/packages/database/src/models/openrouterModelCatalog.ts
+++ b/packages/database/src/models/openrouterModelCatalog.ts
@@ -128,7 +128,7 @@ export class OpenRouterModelCatalogModel {
         description: row.description ?? undefined,
         displayName: isAuto ? OPENROUTER_AUTO_DISPLAY_NAME : (row.displayName ?? undefined),
         // Platform default: Auto + latest 4 chat / openai|anthropic|google
-        // + every image/video generator. Per-user overrides live in `ai_models`.
+        // + pinned chat ids + every image/video/embedding generator. Per-user overrides live in `ai_models`.
         enabled: defaultEnabled.has(row.id),
         id: row.id,
         pricing: (row.pricing ?? undefined) as Pricing | undefined,
@@ -158,7 +158,8 @@ export class OpenRouterModelCatalogModel {
 
   /**
    * Recompute and persist `enabled` flags from the current catalog rows
-   * (latest 4 chat models per openai / anthropic / google, plus all image/video).
+   * (latest 4 chat models per openai / anthropic / google, pinned chat ids,
+   * plus all image/video/embedding models).
    */
   reseedDefaultEnabledFlags = async (): Promise<number> => {
     const rows = await this.db

--- a/src/components/Branding/BrandedProviderCombine.tsx
+++ b/src/components/Branding/BrandedProviderCombine.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { ProviderCombine } from '@lobehub/icons';
+import { type ComponentProps, memo } from 'react';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { isCustomBranding } from '@/const/version';
+
+import { isBrandedOpenRouterProvider } from './brandedModelId';
+
+type BrandedProviderCombineProps = ComponentProps<typeof ProviderCombine> & {
+  provider?: string;
+  size?: number;
+};
+
+/**
+ * Provider wordmark that swaps managed (`openrouter`/`aico`) and legacy
+ * `lobehub` ids to the product logo when custom branding is on.
+ * Every other provider keeps its own vendor wordmark.
+ */
+export const BrandedProviderCombine = memo<BrandedProviderCombineProps>(
+  ({ provider, size = 24, ...rest }) => {
+    const branded =
+      isBrandedOpenRouterProvider(provider) ||
+      Boolean(isCustomBranding && provider && provider.trim().toLowerCase() === 'lobehub');
+
+    if (branded) {
+      return <ProductLogo size={size} type={'flat'} {...rest} />;
+    }
+
+    return <ProviderCombine provider={provider} size={size} {...rest} />;
+  },
+);
+
+BrandedProviderCombine.displayName = 'BrandedProviderCombine';

--- a/src/components/Branding/BrandedProviderIcon.tsx
+++ b/src/components/Branding/BrandedProviderIcon.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { ProviderIcon } from '@lobehub/icons';
+import { type ComponentProps, memo } from 'react';
+
+import { ProductLogo } from '@/components/Branding/ProductLogo';
+import { isCustomBranding } from '@/const/version';
+
+import { isBrandedOpenRouterProvider } from './brandedModelId';
+
+type BrandedProviderIconProps = ComponentProps<typeof ProviderIcon> & {
+  provider?: string;
+  size?: number;
+};
+
+/**
+ * Provider avatar that swaps managed (`openrouter`/`aico`) and legacy
+ * `lobehub` ids to the product logo when custom branding is on.
+ * Every other provider keeps its own vendor logo — the OpenRouter mark is
+ * never rendered.
+ */
+export const BrandedProviderIcon = memo<BrandedProviderIconProps>(
+  ({ provider, size = 24, type, shape, ...rest }) => {
+    const branded =
+      isBrandedOpenRouterProvider(provider) ||
+      Boolean(isCustomBranding && provider && provider.trim().toLowerCase() === 'lobehub');
+
+    if (branded) {
+      return <ProductLogo size={size} type={type === 'mono' ? 'mono' : 'flat'} {...rest} />;
+    }
+
+    return <ProviderIcon provider={provider} shape={shape} size={size} type={type} {...rest} />;
+  },
+);
+
+BrandedProviderIcon.displayName = 'BrandedProviderIcon';

--- a/src/components/Branding/index.ts
+++ b/src/components/Branding/index.ts
@@ -7,5 +7,7 @@ export {
   isBrandedOpenRouterProvider,
 } from './brandedModelId';
 export { BrandedModelTag } from './BrandedModelTag';
+export { BrandedProviderCombine } from './BrandedProviderCombine';
+export { BrandedProviderIcon } from './BrandedProviderIcon';
 export { OrgBrand } from './OrgBrand';
 export { ProductLogo } from './ProductLogo';

--- a/src/components/ModelSelect/index.tsx
+++ b/src/components/ModelSelect/index.tsx
@@ -1,7 +1,7 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
 import { type ChatModelCard } from '@lobechat/types';
 import { type IconAvatarProps } from '@lobehub/icons';
-import { LobeHub, ProviderIcon } from '@lobehub/icons';
+import { ProviderIcon } from '@lobehub/icons';
 import { type FlexboxProps } from '@lobehub/ui';
 import { Avatar, Flexbox, Icon, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, useResponsive } from 'antd-style';
@@ -352,7 +352,9 @@ interface ProviderItemRenderProps {
 export const ProviderItemRender = memo<ProviderItemRenderProps>(
   ({ provider, name, source, logo, type = 'mono', size = 16 }) => {
     const isMono = type === 'mono';
-    const useBrandLogo = isCustomBranding && (provider === 'openrouter' || provider === 'aico');
+    const useBrandLogo =
+      isCustomBranding &&
+      (provider === 'openrouter' || provider === 'aico' || provider === 'lobehub');
     const displayName = useBrandLogo ? BRANDING_NAME : name;
     return (
       <Flexbox
@@ -374,8 +376,6 @@ export const ProviderItemRender = memo<ProviderItemRenderProps>(
           />
         ) : useBrandLogo ? (
           <ProductLogo size={size} type={isMono ? 'mono' : 'flat'} />
-        ) : provider === 'lobehub' ? (
-          <LobeHub.Morden size={size} />
         ) : (
           <ProviderIcon provider={provider} size={size} type={type} />
         )}

--- a/src/features/Conversation/Error/ChatInvalidApiKey.tsx
+++ b/src/features/Conversation/Error/ChatInvalidApiKey.tsx
@@ -1,4 +1,3 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Button } from '@lobehub/ui/base-ui';
 import { ModelProvider } from 'model-bank';
 import { memo } from 'react';
@@ -6,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
 import { extractErrorCodeCandidate } from '@/business/client/resolveAicoErrorMessage';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useProviderName } from '@/hooks/useProviderName';
@@ -48,7 +48,7 @@ const ChatInvalidAPIKey = memo<ChatInvalidAPIKeyProps>(({ id, provider }) => {
 
   return (
     <BaseErrorForm
-      avatar={<ProviderIcon provider={provider} shape={'square'} size={40} />}
+      avatar={<BrandedProviderIcon provider={provider} shape={'square'} size={40} />}
       title={t(`unlock.apiKey.title`, { name: providerName, ns: 'error' })}
       action={
         <Button

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/ModelCard.tsx
@@ -8,7 +8,10 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
-import { formatBrandedProviderId } from '@/components/Branding/brandedModelId';
+import {
+  formatBrandedModelId,
+  formatBrandedProviderId,
+} from '@/components/Branding/brandedModelId';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -56,7 +59,7 @@ const ModelCard = memo<ModelCardProps>(({ pricing, id, provider, displayName }) 
           <BrandedModelIcon model={id} size={22} />
           <Flexbox flex={1} gap={2} style={{ minWidth: 0 }}>
             <Flexbox horizontal align={'center'} gap={8} style={{ lineHeight: '12px' }}>
-              {displayName || id}
+              {displayName || formatBrandedModelId(id)}
             </Flexbox>
             <span className={styles.desc}>{formatBrandedProviderId(provider)}</span>
           </Flexbox>

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -11,6 +11,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
@@ -80,7 +81,7 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
           {heteroName || (
             <>
               <BrandedModelIcon model={model as string} type={'mono'} />
-              {modelCard?.displayName || model}
+              {modelCard?.displayName || formatBrandedModelId(model as string)}
             </>
           )}
         </Center>

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.ts
@@ -3,6 +3,8 @@ import {
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
 
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
+
 interface MessageModelNameInput {
   /** `displayName` of the resolved model card, when the model is known locally. */
   displayName?: string;
@@ -18,7 +20,8 @@ interface MessageModelName {
 
 /**
  * Model identity for the cost hover card: the friendly display name when the
- * model card is known, the raw id otherwise. Remote platform agents (openclaw,
+ * model card is known, the branded id otherwise (`openrouter/auto` shows as
+ * `panachat/auto`). Remote platform agents (openclaw,
  * hermes) never expose a real model id and fall back to their brand label —
  * the same rule the inline Usage row applies.
  */
@@ -32,5 +35,8 @@ export const resolveMessageModelName = ({
     if (brand) return { name: brand, showIcon: false };
   }
 
-  return { name: displayName || model || undefined, showIcon: !!model };
+  return {
+    name: displayName || (model ? formatBrandedModelId(model) : undefined),
+    showIcon: !!model,
+  };
 };

--- a/src/hooks/useProviderName.ts
+++ b/src/hooks/useProviderName.ts
@@ -1,10 +1,12 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 
+import { isCustomBranding } from '@/const/version';
 import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
 
 export const useProviderName = (provider: string) => {
   if (isAicoManagedRuntimeProvider(provider)) return BRANDING_NAME;
+  if (isCustomBranding && provider?.trim().toLowerCase() === 'lobehub') return BRANDING_NAME;
   const providerCard = DEFAULT_MODEL_PROVIDER_LIST.find((p) => p.id === provider);
 
   return providerCard?.name || provider;

--- a/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/GenerationInvalidAPIKey.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { ProviderIcon } from '@lobehub/icons';
 import { Button } from '@lobehub/ui/base-ui';
 import { ModelProvider } from 'model-bank';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { isAicoManagedRuntimeProvider } from '@/features/AicoBilling/isManagedRuntimeProvider';
 import BaseErrorForm from '@/features/Conversation/Error/BaseErrorForm';
 import { isAicoManagedProviderMode } from '@/features/Conversation/Error/isAicoManagedProviderMode';
@@ -37,7 +37,7 @@ const GenerationInvalidAPIKey = memo<GenerationInvalidAPIKeyProps>(({ provider, 
 
   return (
     <BaseErrorForm
-      avatar={<ProviderIcon provider={provider} shape={'square'} size={40} />}
+      avatar={<BrandedProviderIcon provider={provider} shape={'square'} size={40} />}
       title={t(`unlock.apiKey.title`, { name: providerName, ns: 'error' })}
       action={
         <Button

--- a/src/routes/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Details/Overview/ProviderList/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ProviderIcon } from '@lobehub/icons';
 import { ActionIcon, Block, Flexbox, Icon, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { BadgeCheck, BookIcon, ChevronRightIcon, KeyIcon } from 'lucide-react';
@@ -8,6 +7,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import InlineTable from '@/components/InlineTable';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import { BASE_PROVIDER_DOC_URL } from '@/const/url';
@@ -39,7 +39,7 @@ const ProviderList = memo(() => {
                     to={urlJoin('/community/provider', record.id)}
                   >
                     <Flexbox horizontal align="center" gap={8}>
-                      <ProviderIcon provider={record.id} size={24} type={'avatar'} />
+                      <BrandedProviderIcon provider={record.id} size={24} type={'avatar'} />
                       <div style={{ fontWeight: 500 }}>{record.name}</div>
                     </Flexbox>
                   </WorkspaceLink>

--- a/src/routes/(main)/community/(detail)/model/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Header.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox, Icon, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
 import { DotIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import PublishedTime from '@/components/PublishedTime';
 import ModelTypeIcon from '@/routes/(main)/community/(list)/model/features/List/ModelTypeIcon';
@@ -38,7 +39,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
   return (
     <Flexbox gap={12}>
       <Flexbox horizontal align={'flex-start'} gap={16} width={'100%'}>
-        <ModelIcon model={identifier} size={mobile ? 48 : 64} />
+        <BrandedModelIcon model={identifier} size={mobile ? 48 : 64} />
         <Flexbox
           flex={1}
           gap={4}
@@ -72,7 +73,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
                 style={{ fontSize: mobile ? 18 : 24, margin: 0 }}
                 title={identifier}
               >
-                {displayName || identifier}
+                {displayName || formatBrandedModelId(identifier)}
               </Text>
             </Flexbox>
             <Flexbox horizontal align={'center'} gap={6}>
@@ -80,7 +81,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
             </Flexbox>
           </Flexbox>
           <Flexbox horizontal align={'center'} gap={4}>
-            <span>{identifier}</span>
+            <span>{formatBrandedModelId(identifier)}</span>
             <Icon icon={DotIcon} />
             <ModelInfoTags
               directionReverse

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ProviderIcon } from '@lobehub/icons';
 import { DropdownMenu } from '@lobehub/ui';
 import { Button, SplitButton } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -8,6 +7,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 
@@ -29,7 +29,7 @@ const ChatWithModel = memo(() => {
   const list = providers.filter((provider) => provider.id !== 'lobehub');
 
   const items = list.map((item) => ({
-    icon: <ProviderIcon provider={item.id} size={20} type={'avatar'} />,
+    icon: <BrandedProviderIcon provider={item.id} size={20} type={'avatar'} />,
     key: item.id,
     label: (
       <WorkspaceLink to={urlJoin('/community/provider', item.id)}>

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import urlJoin from 'url-join';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import { OFFICIAL_URL } from '@/const/url';
 
 import ShareButton from '../../../../features/ShareButton';
@@ -18,7 +18,7 @@ const ActionButton = memo(() => {
       <ChatWithModel />
       <ShareButton
         meta={{
-          avatar: <ModelIcon model={identifier} size={64} type={'avatar'} />,
+          avatar: <BrandedModelIcon model={identifier} size={64} type={'avatar'} />,
           desc: description,
           hashtags: providers?.map((item) => item.name) || [],
           title: displayName || identifier,

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
@@ -1,9 +1,10 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import { type DiscoverModelItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {
@@ -30,7 +31,7 @@ const RelatedItem = memo<DiscoverModelItem>(({ description, identifier, displayN
   const { t } = useTranslation('models');
   return (
     <Block horizontal gap={12} key={identifier} padding={12} variant={'outlined'}>
-      <ModelIcon model={identifier} size={40} style={{ flex: 'none' }} type={'avatar'} />
+      <BrandedModelIcon model={identifier} size={40} style={{ flex: 'none' }} type={'avatar'} />
       <Flexbox
         flex={1}
         gap={6}
@@ -39,7 +40,7 @@ const RelatedItem = memo<DiscoverModelItem>(({ description, identifier, displayN
         }}
       >
         <Text ellipsis as={'h2'} className={styles.title}>
-          {displayName || identifier}
+          {displayName || formatBrandedModelId(identifier)}
         </Text>
         <Text
           as={'p'}

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
@@ -1,9 +1,9 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { type DiscoverModelDetailProviderItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {
@@ -30,7 +30,7 @@ const RelatedItem = memo<DiscoverModelDetailProviderItem>(({ description, id, na
   const { t } = useTranslation('providers');
   return (
     <Block horizontal gap={12} key={id} padding={12} variant={'outlined'}>
-      <ProviderIcon provider={id} size={40} style={{ flex: 'none' }} type={'avatar'} />
+      <BrandedProviderIcon provider={id} size={40} style={{ flex: 'none' }} type={'avatar'} />
       <Flexbox
         flex={1}
         gap={6}

--- a/src/routes/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Details/Overview/ModelList/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon, Block, Flexbox, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { ChevronRightIcon } from 'lucide-react';
@@ -8,6 +7,8 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import InlineTable from '@/components/InlineTable';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
@@ -38,11 +39,11 @@ const ModelList = memo(() => {
                     to={urlJoin('/community/model', record.id)}
                   >
                     <Flexbox horizontal align="center" gap={8}>
-                      <ModelIcon model={record.id} size={24} type={'avatar'} />
+                      <BrandedModelIcon model={record.id} size={24} type={'avatar'} />
                       <Flexbox style={{ overflow: 'hidden' }}>
                         <div style={{ fontWeight: 500 }}>{record.displayName}</div>
                         <div style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>
-                          {record.id}
+                          {formatBrandedModelId(record.id)}
                         </div>
                       </Flexbox>
                     </Flexbox>

--- a/src/routes/(main)/community/(detail)/provider/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Header.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { Github, ProviderCombine } from '@lobehub/icons';
+import { Github } from '@lobehub/icons';
 import { ActionIcon, Flexbox, stopPropagation } from '@lobehub/ui';
 import { cssVar, useResponsive } from 'antd-style';
 import { GlobeIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
+
+import { BrandedProviderCombine } from '@/components/Branding/BrandedProviderCombine';
 
 import { useDetailContext } from './DetailProvider';
 
@@ -28,7 +30,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
         }}
       >
         <Flexbox align={'flex-start'} width={'100%'}>
-          <ProviderCombine provider={identifier} size={mobile ? 32 : 48} />
+          <BrandedProviderCombine provider={identifier} size={mobile ? 32 : 48} />
           <Flexbox horizontal align={'center'} gap={4}>
             {Boolean(url || modelsUrl) ? (
               <a href={url || (modelsUrl as string)} rel="noreferrer" target="_blank">

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { ModelTag, ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Tag } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedModelTag } from '@/components/Branding/BrandedModelTag';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { OFFICIAL_URL } from '@/const/url';
 
 import ShareButton from '../../../../features/ShareButton';
@@ -20,7 +21,7 @@ const ActionButton = memo(() => {
       <ProviderConfig />
       <ShareButton
         meta={{
-          avatar: <ProviderIcon provider={identifier} size={64} type={'avatar'} />,
+          avatar: <BrandedProviderIcon provider={identifier} size={64} type={'avatar'} />,
           desc: t(`${identifier}.description`, { defaultValue: description }),
           tags: (
             <Flexbox horizontal align={'center'} gap={4} justify={'center'} wrap={'wrap'}>
@@ -28,7 +29,7 @@ const ActionButton = memo(() => {
                 .slice(0, 4)
                 .filter(Boolean)
                 .map((item) => (
-                  <ModelTag key={item.id} model={item.id} style={{ margin: 0 }} />
+                  <BrandedModelTag key={item.id} model={item.id} style={{ margin: 0 }} />
                 ))}
               {models.length > 3 && <Tag>+{models.length - 3}</Tag>}
             </Flexbox>

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
@@ -1,9 +1,9 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { type DiscoverProviderItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {
@@ -30,7 +30,12 @@ const RelatedItem = memo<DiscoverProviderItem>(({ description, identifier, name 
   const { t } = useTranslation('providers');
   return (
     <Block horizontal gap={12} key={identifier} padding={12} variant={'outlined'}>
-      <ProviderIcon provider={identifier} size={40} style={{ flex: 'none' }} type={'avatar'} />
+      <BrandedProviderIcon
+        provider={identifier}
+        size={40}
+        style={{ flex: 'none' }}
+        type={'avatar'}
+      />
       <Flexbox
         flex={1}
         gap={6}

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
@@ -1,9 +1,10 @@
-import { ModelIcon } from '@lobehub/icons';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import { type DiscoverProviderDetailModelItem } from '@/types/discover';
 
 const styles = createStaticStyles(({ css, cssVar }) => {
@@ -30,7 +31,7 @@ const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ description, id, di
   const { t } = useTranslation('models');
   return (
     <Block horizontal gap={12} key={id} padding={12} variant={'outlined'}>
-      <ModelIcon model={id} size={40} style={{ flex: 'none' }} type={'avatar'} />
+      <BrandedModelIcon model={id} size={40} style={{ flex: 'none' }} type={'avatar'} />
       <Flexbox
         flex={1}
         gap={6}
@@ -39,7 +40,7 @@ const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ description, id, di
         }}
       >
         <Text ellipsis as={'h2'} className={styles.title}>
-          {displayName || id}
+          {displayName || formatBrandedModelId(id)}
         </Text>
         <Text
           as={'p'}

--- a/src/routes/(main)/community/(list)/model/features/Category/useCategory.tsx
+++ b/src/routes/(main)/community/(list)/model/features/Category/useCategory.tsx
@@ -1,9 +1,16 @@
-import { ProviderIcon } from '@lobehub/icons';
+import { BRANDING_NAME } from '@lobechat/business-const';
 import { uniqBy } from 'es-toolkit/compat';
 import { LayoutPanelTopIcon } from 'lucide-react';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
+import { isCustomBranding } from '@/const/version';
+
+const isBrandedCategoryProvider = (id: string) =>
+  isCustomBranding &&
+  (id === 'openrouter' || id === 'aico' || id.trim().toLowerCase() === 'lobehub');
 
 export const useCategory = () => {
   const { t } = useTranslation('discover');
@@ -12,9 +19,9 @@ export const useCategory = () => {
     () =>
       uniqBy(DEFAULT_MODEL_PROVIDER_LIST, (item) => item.id).map((item) => {
         return {
-          icon: <ProviderIcon provider={item.id} size={18} type={'mono'} />,
+          icon: <BrandedProviderIcon provider={item.id} size={18} type={'mono'} />,
           key: item.id,
-          label: item.name,
+          label: isBrandedCategoryProvider(item.id) ? BRANDING_NAME : item.name,
         };
       }),
     [],

--- a/src/routes/(main)/community/(list)/model/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/model/features/List/Item.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ModelIcon, ProviderIcon } from '@lobehub/icons';
 import { Block, Flexbox, Icon, Popover, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
@@ -9,6 +8,9 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { ModelInfoTags } from '@/components/ModelSelect';
 import PublishedTime from '@/components/PublishedTime';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -96,7 +98,12 @@ const ModelItem = memo<DiscoverModelItem>(
               overflow: 'hidden',
             }}
           >
-            <ModelIcon model={identifier} size={40} style={{ flex: 'none' }} type={'avatar'} />
+            <BrandedModelIcon
+              model={identifier}
+              size={40}
+              style={{ flex: 'none' }}
+              type={'avatar'}
+            />
             <Flexbox
               flex={1}
               gap={2}
@@ -119,7 +126,7 @@ const ModelItem = memo<DiscoverModelItem>(
                   </Text>
                 </WorkspaceLink>
               </Flexbox>
-              <div className={styles.author}>{identifier}</div>
+              <div className={styles.author}>{formatBrandedModelId(identifier)}</div>
             </Flexbox>
           </Flexbox>
           <Flexbox horizontal align={'center'} gap={4}>
@@ -173,14 +180,14 @@ const ModelItem = memo<DiscoverModelItem>(
                   }}
                 >
                   {providers.map((item) => (
-                    <ProviderIcon key={item} provider={item} size={24} />
+                    <BrandedProviderIcon key={item} provider={item} size={24} />
                   ))}
                 </Flexbox>
               }
             >
               <Flexbox horizontal align={'center'} gap={6}>
                 {providers.slice(0, 6).map((item) => (
-                  <ProviderIcon key={item} provider={item} size={14} type={'mono'} />
+                  <BrandedProviderIcon key={item} provider={item} size={14} type={'mono'} />
                 ))}
                 {providers.length > 6 && <Tag size={'small'}>{providers.length}</Tag>}
               </Flexbox>

--- a/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
@@ -1,4 +1,4 @@
-import { Github, ModelTag, ProviderCombine } from '@lobehub/icons';
+import { Github } from '@lobehub/icons';
 import { ActionIcon, Block, Flexbox, MaskShadow, stopPropagation, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { GlobeIcon } from 'lucide-react';
@@ -6,6 +6,8 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
 
+import { BrandedModelTag } from '@/components/Branding/BrandedModelTag';
+import { BrandedProviderCombine } from '@/components/Branding/BrandedProviderCombine';
 import { GITHUB } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
@@ -81,7 +83,7 @@ const ProviderItem = memo<DiscoverProviderItem>(
             }}
           >
             <WorkspaceLink style={{ color: 'inherit', overflow: 'hidden' }} to={link}>
-              <ProviderCombine provider={identifier} size={28} style={{ flex: 'none' }} />
+              <BrandedProviderCombine provider={identifier} size={28} style={{ flex: 'none' }} />
             </WorkspaceLink>
             <div className={styles.author}>@{name}</div>
           </Flexbox>
@@ -124,7 +126,7 @@ const ProviderItem = memo<DiscoverProviderItem>(
               .filter(Boolean)
               .map((tag: string) => (
                 <WorkspaceLink key={tag} to={urlJoin('/community/model', tag)}>
-                  <ModelTag model={tag} style={{ margin: 0 }} />
+                  <BrandedModelTag model={tag} style={{ margin: 0 }} />
                 </WorkspaceLink>
               ))}
           </MaskShadow>

--- a/src/routes/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
+++ b/src/routes/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
@@ -60,7 +60,7 @@ const ProviderCard = memo<ProviderCardProps>(
           >
             <Flexbox gap={12} width={'100%'}>
               <Flexbox horizontal align={'center'} justify={'space-between'}>
-                {isCustomBranding && (id === 'openrouter' || id === 'aico') ? (
+                {isCustomBranding && (id === 'openrouter' || id === 'aico' || id === 'lobehub') ? (
                   <Flexbox horizontal align={'center'} gap={8}>
                     <ProductLogo size={24} type={'flat'} />
                     <Text style={{ fontSize: 16, fontWeight: 'bold' }}>{BRANDING_NAME}</Text>

--- a/src/routes/(main)/settings/provider/ProviderMenu/Item.tsx
+++ b/src/routes/(main)/settings/provider/ProviderMenu/Item.tsx
@@ -1,10 +1,10 @@
 import { BRANDING_NAME, BRANDING_PROVIDER } from '@lobechat/business-const';
-import { ProviderIcon } from '@lobehub/icons';
 import { Avatar, Center } from '@lobehub/ui';
 import { Badge } from 'antd';
 import { memo, useMemo } from 'react';
 import { useLocation } from 'react-router';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { ProductLogo } from '@/components/Branding/ProductLogo';
 import { isCustomBranding } from '@/const/version';
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -16,7 +16,7 @@ interface ProviderItemProps extends AiProviderListItem {
 }
 
 const isBrandedRuntimeProvider = (id: string) =>
-  id === BRANDING_PROVIDER || id === 'openrouter' || id === 'aico';
+  id === BRANDING_PROVIDER || id === 'openrouter' || id === 'aico' || id === 'lobehub';
 
 const ProviderItem = memo<ProviderItemProps>(
   ({ id, name, source, enabled, logo, onClick = () => {} }) => {
@@ -46,7 +46,7 @@ const ProviderItem = memo<ProviderItemProps>(
       ) : useBrandLogo ? (
         <ProductLogo size={22} type={'flat'} />
       ) : (
-        <ProviderIcon
+        <BrandedProviderIcon
           provider={id}
           shape={'square'}
           size={22}

--- a/src/routes/(main)/settings/provider/ProviderMenu/SortProviderModal/GroupItem.tsx
+++ b/src/routes/(main)/settings/provider/ProviderMenu/SortProviderModal/GroupItem.tsx
@@ -1,7 +1,7 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Avatar, Flexbox, SortableList } from '@lobehub/ui';
 import { memo } from 'react';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { type AiProviderListItem } from '@/types/aiProvider';
 
 interface GroupItemProps extends AiProviderListItem {
@@ -21,7 +21,12 @@ const GroupItem = memo<GroupItemProps>(({ id, name, source, logo, disabled }) =>
             style={{ borderRadius: 6 }}
           />
         ) : (
-          <ProviderIcon provider={id} size={24} style={{ borderRadius: 6 }} type={'avatar'} />
+          <BrandedProviderIcon
+            provider={id}
+            size={24}
+            style={{ borderRadius: 6 }}
+            type={'avatar'}
+          />
         )}
         {name}
       </Flexbox>

--- a/src/routes/(main)/settings/provider/features/CreateNewProvider/Content.tsx
+++ b/src/routes/(main)/settings/provider/features/CreateNewProvider/Content.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Input, InputPassword, Text, TextArea } from '@lobehub/ui';
 import { Button, Select, toast, useModalContext } from '@lobehub/ui/base-ui';
 import { Form } from 'antd';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useAiInfraStore } from '@/store/aiInfra/store';
 import { type CreateAiProviderParams } from '@/types/aiProvider';
@@ -138,7 +138,7 @@ const CreateNewProviderContent = memo(() => {
               const iconProvider = value === 'router' ? 'newapi' : (value as string);
               return (
                 <Flexbox horizontal align={'center'} gap={8}>
-                  <ProviderIcon provider={iconProvider} size={18} />
+                  <BrandedProviderIcon provider={iconProvider} size={18} />
                   {label}
                 </Flexbox>
               );

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/Checker.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/Checker.tsx
@@ -4,7 +4,6 @@ import { CheckCircleFilled } from '@ant-design/icons';
 import { type ChatMessageError } from '@lobechat/types';
 import { TraceNameMap } from '@lobechat/types';
 import { isRecord, pickTrimmedString } from '@lobechat/utils/object';
-import { ModelIcon } from '@lobehub/icons';
 import { Alert, Flexbox, Highlighter, Icon } from '@lobehub/ui';
 import { Button, Select } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -13,6 +12,8 @@ import { type ReactNode } from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import { usePermission } from '@/hooks/usePermission';
 import { useProviderName } from '@/hooks/useProviderName';
 import { chatService } from '@/services/chat';
@@ -184,18 +185,21 @@ const Checker = memo<ConnectionCheckerProps>(
             virtual
             disabled={!canManageProvider}
             listItemHeight={36}
-            options={sortedModels.map((id) => ({ label: id, value: id }))}
             popupClassName={cx(styles.popup)}
             suffixIcon={isProviderConfigUpdating && <Icon spin icon={Loader2Icon} />}
             value={checkModel}
             optionRender={({ value }) => {
               return (
                 <Flexbox horizontal align={'center'} gap={6}>
-                  <ModelIcon model={value as string} size={20} />
-                  {value}
+                  <BrandedModelIcon model={value as string} size={20} />
+                  {formatBrandedModelId(value as string)}
                 </Flexbox>
               );
             }}
+            options={sortedModels.map((id) => ({
+              label: formatBrandedModelId(id),
+              value: id,
+            }))}
             style={{
               flex: 1,
               overflow: 'hidden',

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Icon, Input, Text, TextArea } from '@lobehub/ui';
 import {
   Button,
@@ -19,6 +18,7 @@ import { BrainIcon } from 'lucide-react';
 import { memo, type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useAiInfraStore } from '@/store/aiInfra/store';
 import { type AiProviderDetailItem, type UpdateAiProviderParams } from '@/types/aiProvider';
@@ -162,7 +162,7 @@ const SettingContent = memo<SettingContentProps>(({ initialValues, id }) => {
                 const iconProvider = value === 'router' ? 'newapi' : (value as string);
                 return (
                   <Flexbox horizontal align={'center'} gap={8}>
-                    <ProviderIcon provider={iconProvider} size={18} />
+                    <BrandedProviderIcon provider={iconProvider} size={18} />
                     {label}
                   </Flexbox>
                 );

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -480,7 +480,7 @@ const ProviderConfig = memo<ProviderConfigProps>(
             )}
             {name}
           </Flexbox>
-        ) : isCustomBranding && (id === 'openrouter' || id === 'aico') ? (
+        ) : isCustomBranding && (id === 'openrouter' || id === 'aico' || id === 'lobehub') ? (
           <Flexbox horizontal align={'center'} gap={8}>
             <ProductLogo size={24} type={'flat'} />
             <Text style={{ fontSize: 16, fontWeight: 'bold' }}>{BRANDING_NAME}</Text>

--- a/src/routes/(main)/settings/stats/features/rankings/ModelsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/ModelsRank.tsx
@@ -1,12 +1,13 @@
 import { type ModelRankItem } from '@lobechat/types';
 import { BarList } from '@lobehub/charts';
-import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon } from '@lobehub/ui';
 import { MaximizeIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AsyncBoundary from '@/components/AsyncBoundary';
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 import ImperativeModal from '@/components/ImperativeModal';
 import { useClientDataSWR } from '@/libs/swr';
 import { statsKeys } from '@/libs/swr/keys';
@@ -25,10 +26,10 @@ export const TopicsRank = memo(() => {
 
   const mapData = (item: ModelRankItem) => {
     return {
-      icon: <ModelIcon model={item.id as string} size={20} />,
+      icon: <BrandedModelIcon model={item.id as string} size={20} />,
       id: item.id,
 
-      name: item.id,
+      name: formatBrandedModelId(item.id as string),
       value: item.count,
     };
   };

--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
@@ -1,10 +1,15 @@
 import { CategoryBar, useThemeColorRange } from '@lobehub/charts';
-import { ModelIcon, ProviderIcon } from '@lobehub/icons';
 import { Avatar, Collapse, Flexbox, Skeleton, Tag } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import {
+  formatBrandedModelId,
+  formatBrandedProviderId,
+} from '@/components/Branding/brandedModelId';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import InlineTable from '@/components/InlineTable';
 import { type UsageLog, type UsageRecordItem } from '@/types/usage/usageRecord';
 import { formatPrice } from '@/utils/format';
@@ -104,9 +109,9 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveUse
       boxSizing: 'content-box' as const,
     };
     return (groupBy ?? GroupBy.Model) === GroupBy.Provider ? (
-      <ProviderIcon provider={id} style={baseStyle} />
+      <BrandedProviderIcon provider={id} style={baseStyle} />
     ) : (
-      <ModelIcon model={id} style={baseStyle} />
+      <BrandedModelIcon model={id} style={baseStyle} />
     );
   };
 
@@ -129,11 +134,15 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveUse
     return (
       <Flexbox horizontal align={'center'} gap={8}>
         {groupBy === GroupBy.Provider ? (
-          <ProviderIcon provider={key} size={24} />
-        ) : (
-          <ModelIcon model={key} size={24} />
-        )}
-        {key}
+          <BrandedProviderIcon provider={key} size={24} />
+        ) : groupBy === GroupBy.Model ? (
+          <BrandedModelIcon model={key} size={24} />
+        ) : null}
+        {groupBy === GroupBy.Provider
+          ? formatBrandedProviderId(key)
+          : groupBy === GroupBy.Model
+            ? formatBrandedModelId(key)
+            : key}
       </Flexbox>
     );
   };
@@ -166,10 +175,13 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveUse
                     dataIndex: 'id',
                     key: 'id',
                     render: (value, record, index) => {
+                      const innerIsProvider = (groupBy ?? GroupBy.Model) === GroupBy.Model;
                       return (
                         <Flexbox horizontal align={'center'} gap={12} key={value}>
                           {renderInnerIcon(record.id, themeColorRange[index])}
-                          {value}
+                          {innerIsProvider
+                            ? formatBrandedProviderId(value)
+                            : formatBrandedModelId(value)}
                         </Flexbox>
                       );
                     },

--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/index.test.tsx
@@ -16,10 +16,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('@lobehub/icons', () => ({
-  ModelIcon: ({ model }: { model: string }) => <span>{model}</span>,
-  ProviderIcon: ({ provider }: { provider: string }) => <span>{provider}</span>,
-}));
+vi.mock('@lobehub/icons', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    ModelIcon: ({ model }: { model: string }) => <span>{model}</span>,
+    ProviderIcon: ({ provider }: { provider: string }) => <span>{provider}</span>,
+  };
+});
 
 vi.mock('@lobehub/ui', () => ({
   ActionIcon: () => <button type="button" />,

--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/index.tsx
@@ -1,10 +1,11 @@
-import { ModelIcon, ProviderIcon } from '@lobehub/icons';
 import { ActionIcon, Avatar, Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { MaximizeIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import ImperativeModal from '@/components/ImperativeModal';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
@@ -89,9 +90,9 @@ const ActiveModels = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveU
       );
     }
     return groupBy === GroupBy.Provider ? (
-      <ProviderIcon key={item} provider={item} size={18} style={baseStyle} />
+      <BrandedProviderIcon key={item} provider={item} size={18} style={baseStyle} />
     ) : (
-      <ModelIcon key={item} model={item} size={18} style={baseStyle} />
+      <BrandedModelIcon key={item} model={item} size={18} style={baseStyle} />
     );
   };
 

--- a/src/routes/(main)/settings/stats/features/usage/UsageTable.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageTable.tsx
@@ -1,10 +1,11 @@
-import { ProviderIcon } from '@lobehub/icons';
 import { Flexbox, Text, Tooltip } from '@lobehub/ui';
 import { type TableColumnType } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
+import { BrandedProviderIcon } from '@/components/Branding/BrandedProviderIcon';
 import InlineTable from '@/components/InlineTable';
 import SpendType, { type SpendTypeValue } from '@/components/SpendType';
 import TablePagination from '@/components/TablePagination';
@@ -110,7 +111,7 @@ const UsageTable = memo<UsageChartProps>(({ dateStrings }) => {
       key: 'model',
       render: (value, record) => (
         <Flexbox horizontal align={'center'} gap={16}>
-          <ProviderIcon
+          <BrandedProviderIcon
             provider={record.provider}
             size={18}
             style={{
@@ -119,8 +120,13 @@ const UsageTable = memo<UsageChartProps>(({ dateStrings }) => {
               marginRight: -8,
             }}
           />
-          <Tooltip title={value}>
-            <Text>{value?.length > 12 ? `${value.slice(0, 12)}...` : value}</Text>
+          <Tooltip title={formatBrandedModelId(value)}>
+            <Text>
+              {(() => {
+                const display = formatBrandedModelId(value);
+                return display?.length > 12 ? `${display.slice(0, 12)}...` : display;
+              })()}
+            </Text>
           </Tooltip>
         </Flexbox>
       ),

--- a/src/routes/(mobile)/(home)/features/SessionListContent/List/Item/index.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/List/Item/index.tsx
@@ -1,8 +1,8 @@
-import { ModelTag } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import React, { memo, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 
+import { BrandedModelTag } from '@/components/Branding/BrandedModelTag';
 import { DEFAULT_AVATAR } from '@/const/meta';
 import { INBOX_SESSION_ID } from '@/const/session';
 import { isDesktop } from '@/const/version';
@@ -91,7 +91,7 @@ const SessionItem = memo<SessionItemProps>(({ id }) => {
     () =>
       !showModel ? undefined : (
         <Flexbox horizontal gap={4} style={{ flexWrap: 'wrap' }}>
-          <ModelTag model={model} />
+          <BrandedModelTag model={model} />
         </Flexbox>
       ),
     [showModel, model],


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| OpenRouter / LobeHub provider icons, names, and model ids visible across community pages, settings, usage stats, and error states | Managed (`openrouter`/`aico`) and legacy `lobehub` ids render with the product logo/brand name via `BrandedProviderIcon` / `BrandedProviderCombine` / `BrandedModelIcon` when custom branding is on |

Hides OpenRouter and LobeHub traces from the UI and tightens OpenRouter defaults:

- Adds `BrandedProviderIcon` and `BrandedProviderCombine` wrappers that swap managed (`openrouter`/`aico`) and legacy `lobehub` ids to `ProductLogo` under custom branding; migrates community, settings, stats, error states, `ModelSelect`, and message usage cards to them.
- Routes provider display names (`useProviderName`) and message model ids (`resolveMessageModelName` + `formatBrandedModelId`) through branding so `openrouter/auto` shows as branded.
- Pins `openai/gpt-4o` in `computeDefaultEnabledOpenRouterModelIds` so it stays enabled when newer generations push it out of the newest-4 curation, and enables every catalog `embedding` model so knowledge/memory pickers list them.

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`openrouterDefaultModels.test.ts` covers the gpt-4o pin and embedding defaults; `ActiveModels/index.test.tsx` updated for branded names.

#### 🔗 Related Issue

No matching issue found.