### PR TITLE
fix(desktop): brand OpenRouter model id/icon in overlay chat panel

### DIFF
--- a/apps/desktop/src/overlay/ChatPanel.test.tsx
+++ b/apps/desktop/src/overlay/ChatPanel.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { resolveOverlayModelSelectionPayload, shouldShowOverlayModelSelector } from './ChatPanel';
+import {
+  getOverlayModelLabel,
+  isOverlayModelBrandedIcon,
+  resolveOverlayModelSelectionPayload,
+  shouldShowOverlayModelSelector,
+} from './ChatPanel';
 import { resolvePanelPlacement } from './panelPlacement';
 
 vi.mock('./chatPanel.css.ts', () => new Proxy({}, { get: (_, key) => String(key) }));
@@ -83,5 +88,13 @@ describe('ChatPanel', () => {
       modelId: 'gpt-4.1',
       provider: 'openai',
     });
+  });
+
+  it('brands openrouter model ids and icons to the product, leaving other models untouched', () => {
+    expect(getOverlayModelLabel('openrouter/auto')).toBe('panachat/auto');
+    expect(isOverlayModelBrandedIcon('openrouter/auto')).toBe(true);
+
+    expect(getOverlayModelLabel('gpt-4.1')).toBe('gpt-4.1');
+    expect(isOverlayModelBrandedIcon('gpt-4.1')).toBe(false);
   });
 });

--- a/apps/desktop/src/overlay/ChatPanel.tsx
+++ b/apps/desktop/src/overlay/ChatPanel.tsx
@@ -1,4 +1,6 @@
 import { Select } from '@base-ui/react/select';
+import { BRANDING_LOGO_URL, BRANDING_NAME } from '@lobechat/business-const';
+import { isCustomBranding } from '@lobechat/const';
 import type {
   OverlayCaptureUploadStatus,
   ScreenCaptureAgentOption,
@@ -74,6 +76,28 @@ export const resolveOverlayModelSelectionPayload = ({
   }
 
   return { modelId, provider: model?.provider };
+};
+
+// Mirrors `src/components/Branding/brandedModelId.ts` — duplicated here because this
+// overlay renderer resolves `@/*` against its own `apps/desktop` tsconfig, not the
+// main app's `src/`, so the shared helper isn't reachable from this bundle.
+const OPENROUTER_MODEL_ID_PATTERN = /^openrouter\b/i;
+
+/**
+ * Whether a model's icon should be swapped for the product logo instead of
+ * `ModelIcon`'s own OpenRouter fallback (which matches any `openrouter/*` id).
+ */
+export const isOverlayModelBrandedIcon = (modelId?: string | null): boolean =>
+  Boolean(isCustomBranding && modelId && OPENROUTER_MODEL_ID_PATTERN.test(modelId));
+
+/** Display label for a model id, branding OpenRouter-namespace ids to the product name. */
+export const getOverlayModelLabel = (modelId?: string | null): string | undefined => {
+  if (!modelId) return undefined;
+  if (!isOverlayModelBrandedIcon(modelId)) return modelId;
+
+  const slug = BRANDING_NAME.trim().toLowerCase();
+  const rest = modelId.replace(/^openrouter\/?/i, '');
+  return rest ? `${slug}/${rest}` : slug;
 };
 
 const formatBytes = (rect: Rect): string =>
@@ -540,14 +564,18 @@ const ChatPanel = memo<ChatPanelProps>(
                   >
                     {currentModel ? (
                       <span className={styles.modelIconBox}>
-                        <ModelIcon model={currentModel.id} size={16} />
+                        {isOverlayModelBrandedIcon(currentModel.id) ? (
+                          <img alt={BRANDING_NAME} height={16} src={BRANDING_LOGO_URL} width={16} />
+                        ) : (
+                          <ModelIcon model={currentModel.id} size={16} />
+                        )}
                       </span>
                     ) : (
                       <span className={styles.modelIconBoxFallback} />
                     )}
                     <Select.Value className={styles.chipLabel}>
                       {currentModel?.displayName ??
-                        currentModel?.id ??
+                        getOverlayModelLabel(currentModel?.id) ??
                         OVERLAY_COPY.modelSelectPlaceholder}
                     </Select.Value>
                     <ChevronDownIcon className={styles.chevron} size={12} strokeWidth={2} />
@@ -564,7 +592,9 @@ const ChatPanel = memo<ChatPanelProps>(
                             <Select.ItemIndicator className={styles.popupItemIndicator}>
                               <CheckIcon size={12} strokeWidth={2.4} />
                             </Select.ItemIndicator>
-                            <Select.ItemText>{item.displayName ?? item.id}</Select.ItemText>
+                            <Select.ItemText>
+                              {item.displayName ?? getOverlayModelLabel(item.id)}
+                            </Select.ItemText>
                           </Select.Item>
                         ))}
                       </Select.Popup>


### PR DESCRIPTION
## Summary
- The screen-capture overlay's model picker (`apps/desktop/src/overlay/ChatPanel.tsx`) builds as a separate renderer bundle from the main SPA, so it missed the earlier OpenRouter/LobeHub branding fixes (#327-adjacent commits `9c50784c16` / `61daee5035`).
- It still rendered the raw `ModelIcon` from `@lobehub/icons` (which shows the OpenRouter logo for any `openrouter/*` model id) and fell back to the literal `openrouter/auto` id text when `displayName` was empty.
- Added `isOverlayModelBrandedIcon`/`getOverlayModelLabel` helpers (mirroring `src/components/Branding/brandedModelId.ts`, duplicated locally since this app's own `@/` alias doesn't reach into the main app's `src/`) and used them to swap in the product logo and the branded `panachat/auto`-style label in both the selected-model chip and the dropdown list.

## Test plan
- [x] `bun run check` on the changed files: lint clean.
- [x] Added a regression test in `ChatPanel.test.tsx` covering both a branded `openrouter/auto` id and a regular model id.
- [ ] `bun run check --test` reports a pre-existing, unrelated failure (`Cannot find package '@base-ui/react/select'`) reproduced identically on the unmodified file — a missing dependency install in this environment, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)