### PR TITLE
🐛 fix(models): pin the default mini model so it stays enabled

### DIFF
--- a/packages/business/const/src/openrouterDefaultModels.test.ts
+++ b/packages/business/const/src/openrouterDefaultModels.test.ts
@@ -82,6 +82,19 @@ describe('computeDefaultEnabledOpenRouterModelIds', () => {
     expect(enabled.has('openai/gpt-4o')).toBe(true);
   });
 
+  it('pins DEFAULT_MINI_MODEL (gpt-4o-mini) even when newer generations push it out of the newest 4', () => {
+    const enabled = computeDefaultEnabledOpenRouterModelIds([
+      { id: 'openai/gpt-4o-mini', releasedAt: '2024-07-18', type: 'chat' },
+      { id: 'openai/gpt-5', releasedAt: '2025-08-01', type: 'chat' },
+      { id: 'openai/gpt-5.1', releasedAt: '2025-11-01', type: 'chat' },
+      { id: 'openai/gpt-5.2', releasedAt: '2026-01-01', type: 'chat' },
+      { id: 'openai/gpt-5.3', releasedAt: '2026-03-01', type: 'chat' },
+      { id: 'openai/gpt-5.4', releasedAt: '2026-05-01', type: 'chat' },
+    ]);
+
+    expect(enabled.has('openai/gpt-4o-mini')).toBe(true);
+  });
+
   it('enables every catalog embedding model', () => {
     const enabled = computeDefaultEnabledOpenRouterModelIds([
       { id: 'openai/gpt-4o', releasedAt: '2025-01-01', type: 'chat' },

--- a/packages/business/const/src/openrouterDefaultModels.ts
+++ b/packages/business/const/src/openrouterDefaultModels.ts
@@ -1,4 +1,5 @@
 import { BRANDING_NAME } from './branding';
+import { DEFAULT_MINI_MODEL } from './llm';
 
 /** Pinned OpenRouter auto-router id (UI brands as `{BRANDING_NAME}/auto`, e.g. panachat/auto). */
 export const OPENROUTER_AUTO_MODEL_ID = 'openrouter/auto';
@@ -17,9 +18,14 @@ export const DEFAULT_ENABLED_MODELS_PER_FAMILY = 4;
 /**
  * Chat models pinned on top of the newest-per-family curation, so widely used
  * models stay enabled even after newer generations push them out of the top 4
- * (e.g. `openai/gpt-4o`).
+ * (e.g. `openai/gpt-4o`). Includes {@link DEFAULT_MINI_MODEL} — most system-agent
+ * roles (topic naming, translation, prompt rewrite, ...) default to it, so it
+ * must stay enabled or those roles show a disabled model out of the box.
  */
-export const DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS = ['openai/gpt-4o'] as const;
+export const DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS = [
+  'openai/gpt-4o',
+  DEFAULT_MINI_MODEL,
+] as const;
 
 /**
  * Image Create defaults (OpenRouter Nano Banana family).


### PR DESCRIPTION
Most **Service Model Settings** roles (Topic Auto-Naming, Message Translation, Prompt Rewriting, Memory Analysis, Follow-up Suggestions, ...) default to `DEFAULT_MINI_MODEL` (`openai/gpt-4o-mini`) on the `openrouter` provider.

The default-enabled OpenRouter model set is recomputed live from the synced catalog: the newest 4 chat models per family (openai/anthropic/google), plus an explicit pin list for widely-used models that would otherwise be pushed out. `openai/gpt-4o` was already pinned for this reason, but `openai/gpt-4o-mini` wasn't — so as OpenAI keeps shipping newer models (verified against a live catalog with a string of gpt-5.x releases), it fell out of the top-4 window and every system-agent role defaulting to it showed as **disabled** out of the box.

| Before | After |
| ------ | ----- |
| Topic Auto-Naming shows `gpt-4o-mini` disabled/grayed out | Topic Auto-Naming (and every other role sharing the mini-model default) shows an enabled model |

#### Fix

Added `DEFAULT_MINI_MODEL` to `DEFAULT_ENABLED_OPENROUTER_PINNED_CHAT_MODEL_IDS` in [`packages/business/const/src/openrouterDefaultModels.ts`](https://github.com/Panafor-Ai-Team/Aico/blob/canary/packages/business/const/src/openrouterDefaultModels.ts), mirroring the existing `gpt-4o` pin. Since `listAsProviderModels` recomputes `enabled` live from the catalog on every request (not from a stored flag), this takes effect immediately on deploy — no DB migration or manual resync needed.

#### Test

- [x] Tested locally — verified against a live self-hosted catalog snapshot (`openrouter_model_catalog`) that `openai/gpt-4o-mini` resolves enabled after the fix, matching the existing `openai/gpt-4o` pin behavior
- [x] Added/updated tests — new case in `openrouterDefaultModels.test.ts` mirroring the existing "pins gpt-4o even when newer generations push it out of the newest 4" test
- [ ] No tests needed

#### 🔗 Related Issue

<!-- No matching open issue found in the tracker -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)