### PR TITLE
🐛 fix(models): inject the default embedding model into the OpenRouter catalog

### DIFF
--- a/packages/business/const/src/openrouterDefaultModels.test.ts
+++ b/packages/business/const/src/openrouterDefaultModels.test.ts
@@ -4,6 +4,7 @@ import {
   computeDefaultEnabledOpenRouterModelIds,
   DEFAULT_AUTO_IMAGE_MODEL_ID,
   ensureOpenRouterAutoModel,
+  ensureOpenRouterModels,
   isDefaultAutoImageModelId,
   OPENROUTER_AUTO_MODEL_ID,
   pickPreferredDefaultOpenRouterModelId,
@@ -135,6 +136,22 @@ describe('ensureOpenRouterAutoModel', () => {
       id: OPENROUTER_AUTO_MODEL_ID,
     });
     expect(result).toHaveLength(1);
+  });
+});
+
+describe('ensureOpenRouterModels', () => {
+  it('injects every extra card missing from the snapshot', () => {
+    const result = ensureOpenRouterModels(
+      [{ id: 'openai/gpt-4o' }],
+      [{ id: 'openai/text-embedding-3-small' }, { id: 'openai/gpt-4o' }],
+    );
+    expect(result.map((m) => m.id)).toEqual(['openai/text-embedding-3-small', 'openai/gpt-4o']);
+  });
+
+  it('is a no-op when every extra card already exists', () => {
+    const models = [{ id: 'openai/gpt-4o' }, { id: 'openai/text-embedding-3-small' }];
+    const result = ensureOpenRouterModels(models, [{ id: 'openai/text-embedding-3-small' }]);
+    expect(result).toBe(models);
   });
 });
 

--- a/packages/business/const/src/openrouterDefaultModels.ts
+++ b/packages/business/const/src/openrouterDefaultModels.ts
@@ -179,11 +179,23 @@ export const pickPreferredDefaultOpenRouterModelId = (
   return null;
 };
 
+/**
+ * Ensure specific catalog cards exist by id (inject any card whose id is missing
+ * from the snapshot, preserving the rest). Used for cards the live OpenRouter
+ * `/models` listing omits — the product Auto router, and embedding models (the
+ * OpenRouter embeddings API isn't covered by that listing endpoint).
+ */
+export const ensureOpenRouterModels = <T extends { id: string }>(
+  models: T[],
+  extraCards: T[],
+): T[] => {
+  const existingIds = new Set(models.map((m) => m.id));
+  const missing = extraCards.filter((card) => !existingIds.has(card.id));
+  return missing.length > 0 ? [...missing, ...models] : models;
+};
+
 /** Ensure the Auto router card exists in a catalog snapshot (inject if missing). */
 export const ensureOpenRouterAutoModel = <T extends { id: string }>(
   models: T[],
   autoCard: T,
-): T[] => {
-  if (models.some((m) => m.id === OPENROUTER_AUTO_MODEL_ID)) return models;
-  return [autoCard, ...models];
-};
+): T[] => ensureOpenRouterModels(models, [autoCard]);

--- a/packages/const/src/settings/llm.ts
+++ b/packages/const/src/settings/llm.ts
@@ -3,7 +3,8 @@ import type { LobeAgentAgencyConfig } from '@lobechat/types';
 
 export { DEFAULT_MINI_MODEL, DEFAULT_MODEL } from '@lobechat/business-const';
 
-export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
+/** OpenRouter SKU (matches the catalog's `openai/`-namespaced chat model ids). */
+export const DEFAULT_EMBEDDING_MODEL = 'openai/text-embedding-3-small';
 
 /**
  * Default model for sub-agents spawned via `lobe-agent.callSubAgent`.

--- a/packages/database/src/models/__tests__/openrouterModelCatalog.test.ts
+++ b/packages/database/src/models/__tests__/openrouterModelCatalog.test.ts
@@ -89,8 +89,8 @@ describe('OpenRouterModelCatalogModel', () => {
     expect(status).toMatchObject({
       lastStatus: 'success',
       lastTriggeredBy: 'manual:admin',
-      // Input models + product Auto
-      modelCount: 11,
+      // Input models + product Auto + injected embedding cards
+      modelCount: 12,
     });
   });
 
@@ -130,8 +130,8 @@ describe('OpenRouterModelCatalogModel', () => {
     expect(status).toMatchObject({
       lastStatus: 'success',
       lastTriggeredBy: 'cron',
-      // Remaining models + product Auto
-      modelCount: 4,
+      // Remaining models + product Auto + injected embedding cards
+      modelCount: 5,
     });
     expect(status.lastSyncedAt).toBeTruthy();
   });
@@ -151,8 +151,8 @@ describe('OpenRouterModelCatalogModel', () => {
       lastError: 'OpenRouter down',
       lastStatus: 'error',
       lastTriggeredBy: 'manual:ops',
-      // openai/x + product Auto
-      modelCount: 2,
+      // openai/x + product Auto + injected embedding cards
+      modelCount: 3,
     });
     expect(afterError.lastSyncedAt).toBeTruthy();
 
@@ -193,6 +193,27 @@ describe('OpenRouterModelCatalogModel', () => {
       removedModelIds: ['openai/a'],
       status: 'success',
       triggeredBy: 'manual:2',
+    });
+  });
+
+  it('injects the default embedding model even when the live sync omits it, and keeps it enabled', async () => {
+    await catalog.replaceCatalog({
+      models: [{ displayName: 'GPT-A', id: 'openai/gpt-a', type: 'chat' }],
+      triggeredBy: 'manual:admin',
+    });
+
+    const rows = await catalog.listAsProviderModels();
+    const embedding = rows.find((r) => r.id === 'openai/text-embedding-3-small');
+    expect(embedding).toMatchObject({ enabled: true, type: 'embedding' });
+
+    // Stays present and enabled across a re-sync too, same as product Auto.
+    await catalog.replaceCatalog({
+      models: [{ displayName: 'GPT-B', id: 'openai/gpt-b', type: 'chat' }],
+      triggeredBy: 'cron',
+    });
+    const rowsAfterResync = await catalog.listAsProviderModels();
+    expect(rowsAfterResync.find((r) => r.id === 'openai/text-embedding-3-small')).toMatchObject({
+      enabled: true,
     });
   });
 

--- a/packages/database/src/models/openrouterModelCatalog.ts
+++ b/packages/database/src/models/openrouterModelCatalog.ts
@@ -1,6 +1,7 @@
 import {
   computeDefaultEnabledOpenRouterModelIds,
   ensureOpenRouterAutoModel,
+  ensureOpenRouterModels,
   OPENROUTER_AUTO_DISPLAY_NAME,
   OPENROUTER_AUTO_MODEL_ID,
 } from '@lobechat/business-const';
@@ -60,6 +61,29 @@ const AUTO_CATALOG_CARD: OpenRouterCatalogModelInput = {
   id: OPENROUTER_AUTO_MODEL_ID,
   type: 'chat',
 };
+
+/**
+ * OpenRouter serves embeddings through a dedicated `/embeddings` endpoint, not
+ * through the general `/models` chat-completions listing this catalog syncs from
+ * — so embedding models never appear in a live sync snapshot on their own. Inject
+ * the ones the product relies on (system-agent memory embedding default) so they
+ * exist in the catalog and pick up `computeDefaultEnabledOpenRouterModelIds`'s
+ * "every catalog embedding model is enabled" rule instead of showing disabled.
+ */
+const EMBEDDING_CATALOG_CARDS: OpenRouterCatalogModelInput[] = [
+  {
+    contextWindowTokens: 8192,
+    description:
+      'An efficient, cost-effective next-generation embedding model for retrieval and RAG scenarios.',
+    displayName: 'Text Embedding 3 Small',
+    id: 'openai/text-embedding-3-small',
+    pricing: {
+      units: [{ name: 'textInput', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2024-01-25',
+    type: 'embedding',
+  },
+];
 
 export class OpenRouterModelCatalogModel {
   private db: LobeChatDatabase;
@@ -212,7 +236,10 @@ export class OpenRouterModelCatalogModel {
     triggeredBy: string;
   }): Promise<OpenRouterCatalogSyncStatus> => {
     const now = new Date();
-    const models = ensureOpenRouterAutoModel(params.models, AUTO_CATALOG_CARD);
+    const models = ensureOpenRouterModels(
+      ensureOpenRouterAutoModel(params.models, AUTO_CATALOG_CARD),
+      EMBEDDING_CATALOG_CARDS,
+    );
     const incomingIds = models.map((m) => m.id);
 
     const existing = await this.db


### PR DESCRIPTION
Follow-up to #331 (pinning `openai/gpt-4o-mini` so it stays enabled). The **Memory Embedding** system-agent default (`text-embedding-3-small`) was disabled too — a different root cause.

OpenRouter serves embeddings through a dedicated `/embeddings` endpoint, not through the general `/models` chat-completions listing this catalog syncs from (verified live: 430 synced models, zero embeddings). So `text-embedding-3-small` never had a chance to appear in the catalog and be marked enabled, regardless of pinning — there was nothing to pin.

| Before | After |
| ------ | ----- |
| Memory Embedding shows `text-embedding-3-small` disabled/grayed out, no alternative in the picker | The model exists in the catalog and picks up the existing "every catalog embedding model is enabled" rule |

#### Fix

- Injects `openai/text-embedding-3-small` into the catalog on every sync the same way the product Auto router card is already injected — generalized `ensureOpenRouterAutoModel` into `ensureOpenRouterModels` (`packages/business/const/src/openrouterDefaultModels.ts`) so it can inject any missing card, then added a static embedding card in `packages/database/src/models/openrouterModelCatalog.ts` (pricing/context metadata pulled from the existing `openai.ts` model-bank entry).
- Corrected `DEFAULT_EMBEDDING_MODEL` (`packages/const/src/settings/llm.ts`) from the bare `text-embedding-3-small` to the `openai/`-namespaced id matching the catalog's convention.

#### Test

- [x] Tested locally — ran the real `packages/database` vitest suite (`openrouterModelCatalog.test.ts`), all 7 tests pass including a new one verifying the embedding card is injected and stays enabled across re-syncs
- [x] Added/updated tests — `openrouterDefaultModels.test.ts` (new `ensureOpenRouterModels` coverage) and `openrouterModelCatalog.test.ts`
- [ ] No tests needed

#### 🔗 Related Issue

<!-- No matching open issue found in the tracker -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)