### PR TITLE
🐛 fix(stats): brand OpenRouter model/provider ids on the Statistics page

### DIFF
--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/ModelTable.tsx
@@ -16,6 +16,7 @@ import { formatPrice } from '@/utils/format';
 
 import { type UsageChartProps } from '../../../../types';
 import { GroupBy } from '../../../../types';
+import { isInnerRowProvider } from './innerRowDimension';
 
 interface WeightGroup {
   id: string;
@@ -98,17 +99,19 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveUse
 
   // Sub-row column shows the "other" dimension. For Model→Provider,
   // Provider→Model, and User→Model.
-  const innerColumnKey =
-    (groupBy ?? GroupBy.Model) === GroupBy.Model
-      ? 'usage.activeModels.table.provider'
-      : 'usage.activeModels.table.model';
+  const innerColumnKey = isInnerRowProvider(groupBy ?? GroupBy.Model)
+    ? 'usage.activeModels.table.provider'
+    : 'usage.activeModels.table.model';
 
-  const renderInnerIcon = (id: string, color: string) => {
+  // Sub-rows carry whatever `innerKey` grouped them by: providers when the
+  // table is grouped by Model, models otherwise (Provider/User) — must match
+  // `innerIsProvider` below, since both describe the same inner-row dimension.
+  const renderInnerIcon = (id: string, color: string, isProvider: boolean) => {
     const baseStyle = {
       boxShadow: `0 0 0 2px ${cssVar.colorBgContainer}, 0 0 0 4px ${color}`,
       boxSizing: 'content-box' as const,
     };
-    return (groupBy ?? GroupBy.Model) === GroupBy.Provider ? (
+    return isProvider ? (
       <BrandedProviderIcon provider={id} style={baseStyle} />
     ) : (
       <BrandedModelIcon model={id} style={baseStyle} />
@@ -175,10 +178,10 @@ const ModelTable = memo<UsageChartProps>(({ data, isLoading, groupBy, resolveUse
                     dataIndex: 'id',
                     key: 'id',
                     render: (value, record, index) => {
-                      const innerIsProvider = (groupBy ?? GroupBy.Model) === GroupBy.Model;
+                      const innerIsProvider = isInnerRowProvider(groupBy ?? GroupBy.Model);
                       return (
                         <Flexbox horizontal align={'center'} gap={12} key={value}>
-                          {renderInnerIcon(record.id, themeColorRange[index])}
+                          {renderInnerIcon(record.id, themeColorRange[index], innerIsProvider)}
                           {innerIsProvider
                             ? formatBrandedProviderId(value)
                             : formatBrandedModelId(value)}

--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/innerRowDimension.test.ts
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/innerRowDimension.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { GroupBy } from '../../../../types';
+import { isInnerRowProvider } from './innerRowDimension';
+
+describe('isInnerRowProvider', () => {
+  // ModelTable's `innerKey` groups sub-rows by `log.provider` when grouped by
+  // Model, and by `log.model` otherwise (Provider/User) — this must agree,
+  // since it drives which icon (BrandedProviderIcon vs. BrandedModelIcon) and
+  // label formatter the sub-rows render with.
+  it('is true when grouped by Model (sub-rows are providers)', () => {
+    expect(isInnerRowProvider(GroupBy.Model)).toBe(true);
+  });
+
+  it('is false when grouped by Provider (sub-rows are models)', () => {
+    expect(isInnerRowProvider(GroupBy.Provider)).toBe(false);
+  });
+
+  it('is false when grouped by User (sub-rows are models)', () => {
+    expect(isInnerRowProvider(GroupBy.User)).toBe(false);
+  });
+});

--- a/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/innerRowDimension.ts
+++ b/src/routes/(main)/settings/stats/features/usage/UsageCards/ActiveModels/innerRowDimension.ts
@@ -1,0 +1,12 @@
+import { GroupBy } from '../../../../types';
+
+/**
+ * ModelTable sub-row dimension: providers when the table is grouped by Model,
+ * models otherwise (Provider/User). Mirrors `innerKey` in `ModelTable.tsx`,
+ * which groups sub-rows by `log.provider` when grouped by Model and by
+ * `log.model` otherwise — both must agree on which dimension the sub-rows are,
+ * since it drives both the sub-row icon (BrandedProviderIcon vs.
+ * BrandedModelIcon) and label text (formatBrandedProviderId vs.
+ * formatBrandedModelId).
+ */
+export const isInnerRowProvider = (groupBy: GroupBy): boolean => groupBy === GroupBy.Model;

--- a/src/routes/(main)/settings/stats/features/usage/UsageTrends.test.ts
+++ b/src/routes/(main)/settings/stats/features/usage/UsageTrends.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { GroupBy } from '../../types';
+import { categoryLabel } from './UsageTrends';
+
+describe('categoryLabel', () => {
+  // The returned string becomes both the chart's grouping key and the visible
+  // legend/tooltip label, so a raw provider-namespaced model id (e.g. the
+  // stored `openrouter/auto`) must be branded before it reaches the chart.
+  it('brands a model id for GroupBy.Model', () => {
+    expect(categoryLabel('openrouter/auto', GroupBy.Model)).toBe('panachat/auto');
+  });
+
+  it('leaves a non-openrouter model id unchanged for GroupBy.Model', () => {
+    expect(categoryLabel('gpt-5-mini', GroupBy.Model)).toBe('gpt-5-mini');
+  });
+
+  it('brands a provider id for GroupBy.Provider', () => {
+    expect(categoryLabel('openrouter', GroupBy.Provider)).toBe('Panachat');
+  });
+
+  it('resolves the display name for GroupBy.User', () => {
+    expect(
+      categoryLabel('user-1', GroupBy.User, () => ({ avatar: null, name: 'Ada Lovelace' })),
+    ).toBe('Ada Lovelace');
+  });
+});

--- a/src/routes/(main)/settings/stats/features/usage/UsageTrends.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageTrends.tsx
@@ -4,6 +4,7 @@ import { Tabs } from '@lobehub/ui/base-ui';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { formatBrandedModelId, formatBrandedProviderId } from '@/components/Branding';
 import { type UsageLog, type UsageRecordItem } from '@/types/usage/usageRecord';
 import { formatNumber } from '@/utils/format';
 
@@ -18,12 +19,14 @@ const recordKey = (item: UsageRecordItem, groupBy: GroupBy): string => {
   return item.userId;
 };
 
-const categoryLabel = (
+export const categoryLabel = (
   key: string,
   groupBy: GroupBy,
   resolveUser?: UserDisplayResolver,
 ): string => {
   if (groupBy === GroupBy.User && resolveUser) return resolveUser(key).name;
+  if (groupBy === GroupBy.Model) return formatBrandedModelId(key);
+  if (groupBy === GroupBy.Provider) return formatBrandedProviderId(key);
   return key;
 };
 


### PR DESCRIPTION
Follow-up to #328/#329/#330 (hiding OpenRouter/LobeHub branding from the UI). Settings → Statistics still leaked raw `openrouter/auto` text and the wrong provider/model icon — the earlier pass missed this page.

| Before | After |
| ------ | ----- |
| Usage chart legend/tooltip shows raw `openrouter/auto`; Active Models table shows wrong icons when grouped by Provider | Chart labels branded to `panachat/auto`; icons match the actual sub-row dimension in both group-by modes |

#### Two separate bugs found

- **`UsageTrends.tsx`** — the usage chart's category labels (grouped by Model by default) rendered the raw stored id with no branding wrapper at all — a plain missing-wrapper bug.
- **`ModelTable.tsx`** (Active Models drill-down) — the sub-row icon logic was inverted: it picked `BrandedProviderIcon` exactly when the sub-rows were actually models, and vice versa. It only looked right on the default "grouped by Model" tab (a lucky regex match on the bare string `"openrouter"` against `isBrandedOpenRouterModelId`); switching to the Provider tab fed real model ids into the provider icon component, producing wrong/generic icons.

#### Fix

Extracted the shared "which dimension are sub-rows" decision into a new `innerRowDimension.ts` pure function, used by both the icon and the label-text logic in `ModelTable.tsx` — so icon and text can no longer diverge. `UsageTrends.tsx`'s category labels now run through `formatBrandedModelId`/`formatBrandedProviderId`.

#### Test

- [x] Tested locally — `bun run check` clean on all changed files
- [x] Added/updated tests — per this repo's "no new component tests" convention, extracted the logic into pure functions and added `innerRowDimension.test.ts` and `UsageTrends.test.ts` covering it (all passing)
- [ ] No tests needed

#### 🔗 Related Issue

<!-- No matching open issue found in the tracker -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)