### PR TITLE
🐛 fix(billing): lock the usage multiplier at top-up time

### DIFF
--- a/apps/server/src/services/openrouter/getUserRemaining.test.ts
+++ b/apps/server/src/services/openrouter/getUserRemaining.test.ts
@@ -31,6 +31,10 @@ class ControllableOpenRouterClient implements OpenRouterManagementClient {
     return { ...row };
   };
 
+  deleteKey: OpenRouterManagementClient['deleteKey'] = async (hash) => {
+    this.keys.delete(hash);
+  };
+
   getKey: OpenRouterManagementClient['getKey'] = async (hash) => {
     const row = this.keys.get(hash);
     if (!row) throw new Error(`OpenRouter mock key not found: ${hash}`);
@@ -99,49 +103,76 @@ describe('getUserRemaining', () => {
     expect(remaining.usageMicroUsd).toBe(3_000_000);
   });
 
-  it('bills usage from before a multiplier change at the old rate', async () => {
+  it('credits capacity at the multiplier in force when the top-up was paid', async () => {
     const billing = new AicoBillingModel(db);
     const client = new ControllableOpenRouterClient();
     const keys = new AicoOpenRouterKeyService(db, client);
 
-    await billing.manualCreditUser({
+    const { transaction } = await billing.manualCreditUser({
       amountMicroUsd: 12_000_000,
       amountToman: 60_000,
       createdByUserId: userId,
       fxRateTomanPerUsd: 50_000,
       userId,
     });
-    await keys.ensureUserKey(userId);
 
-    // Stand the wallet up as if it had been metered at 1.0x until now: $5 of raw
-    // spend billed as $5. The platform multiplier row itself is global and other
-    // suites read it concurrently, so drive the change from the wallet side.
+    // AICO-184: $12 at 1.2x buys $10 of raw spend, once and for good.
+    const wallet = await billing.getUserWallet(userId);
+    expect(Number(wallet!.rawCapacityMicroUsd)).toBe(10_000_000);
+    // The rate is stamped on the transaction so it can never be re-derived.
+    expect(transaction.metadata).toMatchObject({
+      multiplierBp: 12_000,
+      rawCapacityAddedMicroUsd: 10_000_000,
+    });
+
+    await keys.ensureUserKey(userId);
+    const keyed = await billing.getUserWallet(userId);
+    expect(client.keys.get(keyed!.openrouterKeyId!).limit).toBeCloseTo(10, 6);
+  });
+
+  it('does not revalue a paid-for balance when the multiplier changes (AICO-184)', async () => {
+    const billing = new AicoBillingModel(db);
+    const client = new ControllableOpenRouterClient();
+    const keys = new AicoOpenRouterKeyService(db, client);
+
+    await billing.manualCreditUser({
+      amountMicroUsd: 1_200_000,
+      amountToman: 6000,
+      createdByUserId: userId,
+      fxRateTomanPerUsd: 50_000,
+      userId,
+    });
+
+    // Stand in for a second top-up of $1.50 made after the platform rate moved
+    // to 1.5x: $1.50 / 1.5 = $1.00 more of raw spend. Written directly because
+    // the multiplier config row is global and other suites read it concurrently.
     await db
       .update(userWallets)
-      .set({ billedUsageBeforeBaselineMicroUsd: 0, checkpointMultiplierBp: 10_000 })
+      .set({ balanceMicroUsd: 2_700_000, rawCapacityMicroUsd: 2_000_000 })
       .where(eq(userWallets.userId, userId));
 
-    const keyHash = (await billing.getUserWallet(userId))!.openrouterKeyId!;
-    const key = client.keys.get(keyHash);
-    key.usage = 5;
-    key.limitRemaining = key.limit - key.usage;
-
-    // Reading rebases the checkpoint to the platform's 1.2x: the first $5 keeps
-    // its $5, and the meter restarts from there.
-    await expect(keys.getUserRemaining(userId)).resolves.toMatchObject({
-      usageMicroUsd: 5_000_000,
-    });
-    const rebased = await billing.getUserWallet(userId);
-    expect(Number(rebased!.usageBaselineMicroUsd)).toBe(5_000_000);
-    expect(Number(rebased!.billedUsageBeforeBaselineMicroUsd)).toBe(5_000_000);
-    expect(Number(rebased!.checkpointMultiplierBp)).toBe(12_000);
-
-    // $2 more of raw spend now bills at 1.2x -> $2.40, for $7.40 in total.
     await keys.ensureUserKey(userId);
-    key.usage = 7;
+    const wallet = await billing.getUserWallet(userId);
+    const key = client.keys.get(wallet!.openrouterKeyId!);
+
+    // $2.00 of capacity — what the two purchases were worth at their own rates.
+    // Dividing the $2.70 balance by the current 1.5x would have given $1.80.
+    expect(key.limit).toBeCloseTo(2, 6);
+
+    // $1 of raw spend bills at the 1.35 blend the wallet actually bought at.
+    key.usage = 1;
     key.limitRemaining = key.limit - key.usage;
-    await expect(keys.getUserRemaining(userId)).resolves.toMatchObject({
-      usageMicroUsd: 7_400_000,
+    await expect(keys.getUserRemaining(userId)).resolves.toEqual({
+      remainingMicroUsd: 1_350_000,
+      usageMicroUsd: 1_350_000,
+    });
+
+    // Spending the whole capacity bills the whole balance, to the micro-USD.
+    key.usage = 2;
+    key.limitRemaining = 0;
+    await expect(keys.getUserRemaining(userId)).resolves.toEqual({
+      remainingMicroUsd: 0,
+      usageMicroUsd: 2_700_000,
     });
   });
 

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -3,6 +3,7 @@ import { OrganizationModel } from '@/database/models/organization';
 import type { LobeChatDatabase } from '@/database/type';
 import {
   applyMultiplierMicroUsd,
+  billedUsageFromCapacity,
   billedUsageFromRaw,
   type BudgetPeriod,
   currentCycleLimitMicroUsd,
@@ -96,56 +97,6 @@ export class AicoOpenRouterKeyService {
   }
 
   /**
-   * Raw (unmultiplied) lifetime usage OpenRouter has recorded for a key.
-   * Returns null when the key is unusable or OpenRouter is unreachable — callers
-   * must treat null as "cannot rebase now" and leave the checkpoint alone.
-   */
-  private readRawKeyUsageMicro = async (keyId: string | null | undefined) => {
-    if (!keyId || isStaleManagedKeyId(keyId)) return null;
-    try {
-      const info = await this.client.getKey(keyId);
-      return Number(openRouterUsdToMicroFloor(info.usage));
-    } catch {
-      return null;
-    }
-  };
-
-  /**
-   * AICO-180 lazy rebase. The platform multiplier is global, but each wallet
-   * carries the multiplier its checkpoint was taken under. When they differ,
-   * freeze usage-to-date at the old rate and restart the meter at the new one,
-   * so a multiplier change only ever affects subsequent requests.
-   *
-   * `rawUsage` may be supplied by a caller that already fetched the key.
-   */
-  private syncUserCheckpoint = async (params: {
-    checkpoint: UsageMultiplierCheckpoint;
-    keyId: string | null | undefined;
-    rawUsage?: number | null;
-    userId: string;
-  }): Promise<{ bp: number; checkpoint: UsageMultiplierCheckpoint }> => {
-    const bp = await this.billingModel.getUsageMultiplierBp();
-    const currentBp = Number(params.checkpoint.checkpointMultiplierBp ?? bp);
-    if (currentBp === bp) return { bp, checkpoint: params.checkpoint };
-
-    const rawUsage = params.rawUsage ?? (await this.readRawKeyUsageMicro(params.keyId));
-
-    // Never rebase blind: without a usage reading we would zero the baseline and
-    // silently reprice everything spent so far.
-    if (rawUsage == null) return { bp: currentBp, checkpoint: params.checkpoint };
-
-    const rebased = rebaseCheckpoint({ checkpoint: params.checkpoint, nextBp: bp, rawUsage });
-    await this.billingModel.updateUserWalletCheckpoint({
-      billedUsageBeforeBaselineMicroUsd: rebased.billedUsageBeforeBaselineMicroUsd,
-      checkpointMultiplierBp: bp,
-      usageBaselineMicroUsd: rebased.usageBaselineMicroUsd,
-      userId: params.userId,
-    });
-
-    return { bp, checkpoint: { ...rebased, checkpointMultiplierBp: bp } };
-  };
-
-  /**
    * The raw OpenRouter counter that the member key's limit is enforced against.
    * Keys with a `limit_reset` are metered on the period counter, so the
    * multiplier checkpoint baseline must be period-scoped too — using lifetime
@@ -173,7 +124,11 @@ export class AicoOpenRouterKeyService {
     return Number(openRouterUsdToMicroFloor(source));
   };
 
-  /** Member-budget counterpart of `syncUserCheckpoint`. Cycle-scoped. */
+  /**
+   * AICO-180 lazy rebase for member budgets. A budget is an allowance rather
+   * than a payment, so it has no purchased capacity to fall back on: freeze
+   * usage-to-date at the old rate and restart the meter at the new one.
+   */
   private syncMemberCheckpoint = async (params: {
     checkpoint: UsageMultiplierCheckpoint;
     orgMemberId: string;
@@ -203,19 +158,11 @@ export class AicoOpenRouterKeyService {
       const wallet = await this.billingModel.getOrCreateUserWallet(userId);
       const balanceMicro = Number(wallet.balanceMicroUsd ?? 0);
 
-      // AICO-180: the wallet balance is what the user paid for (billed); the
-      // OpenRouter key limit is the raw spend that buys.
-      const { bp, checkpoint } = await this.syncUserCheckpoint({
-        checkpoint: wallet,
-        keyId: wallet.openrouterKeyId,
-        userId,
-      });
-      const limitMicro = keyLimitFromBilled({
-        balance: balanceMicro,
-        baselineRaw: Number(checkpoint.usageBaselineMicroUsd ?? 0),
-        billedBefore: Number(checkpoint.billedUsageBeforeBaselineMicroUsd ?? 0),
-        bp,
-      });
+      // AICO-184: every top-up already converted itself to raw spend at the
+      // rate in force when it was paid, so the key limit is simply the
+      // capacity bought. The current multiplier does not enter here — that is
+      // what stops a rate change from revaluing money already paid.
+      const limitMicro = Number(wallet.rawCapacityMicroUsd ?? 0);
       const limitUsd = microToOpenRouterLimitUsd(limitMicro);
 
       if (
@@ -602,29 +549,21 @@ export class AicoOpenRouterKeyService {
       const info = await this.client.getKey(wallet.openrouterKeyId);
       const rawUsageMicro = Number(openRouterUsdToMicroFloor(info.usage));
 
-      // AICO-180: this is the hot path after every chat, so it doubles as the
-      // lazy rebase point — the raw reading needed to roll the checkpoint
-      // forward is already in hand.
-      const { bp, checkpoint } = await this.syncUserCheckpoint({
-        checkpoint: wallet,
-        keyId: wallet.openrouterKeyId,
-        rawUsage: rawUsageMicro,
-        userId,
+      // AICO-184: bill raw usage at the blend of the rates this wallet's
+      // top-ups actually bought at, not at whatever the platform rate is now.
+      const rawCapacityMicro = Number(wallet.rawCapacityMicroUsd ?? 0);
+      const usageMicro = billedUsageFromCapacity({
+        balanceMicroUsd,
+        fallbackBp: await this.billingModel.getUsageMultiplierBp(),
+        rawCapacityMicroUsd: rawCapacityMicro,
+        rawUsageMicroUsd: rawUsageMicro,
       });
-
-      const usageMicro = billedUsageFromRaw({
-        baselineRaw: Number(checkpoint.usageBaselineMicroUsd ?? 0),
-        billedBefore: Number(checkpoint.billedUsageBeforeBaselineMicroUsd ?? 0),
-        bp,
-        rawUsage: rawUsageMicro,
-      });
-      // Prefer OpenRouter's enforced remaining (a pure delta, so it scales by M)
-      // over balance − usage, which drifts if the key limit is out of date.
-      const remaining =
-        info.limitRemaining == null
-          ? Math.max(0, balanceMicroUsd - usageMicro)
-          : applyMultiplierMicroUsd(Number(openRouterUsdToMicroFloor(info.limitRemaining)), bp);
-      return { remainingMicroUsd: Math.max(0, remaining), usageMicroUsd: usageMicro };
+      // `balance − usage` is exact here: both sides are cumulative and usage
+      // reaches the balance precisely when raw usage reaches capacity.
+      return {
+        remainingMicroUsd: Math.max(0, balanceMicroUsd - usageMicro),
+        usageMicroUsd: usageMicro,
+      };
     } catch {
       return { remainingMicroUsd: Math.max(0, balanceMicroUsd), usageMicroUsd: null };
     }

--- a/packages/database/migrations/0148_aico_wallet_raw_capacity.sql
+++ b/packages/database/migrations/0148_aico_wallet_raw_capacity.sql
@@ -1,0 +1,24 @@
+-- AICO-184: a top-up buys raw upstream spend at the multiplier in force when it
+-- was paid. `raw_capacity_micro_usd` is the raw counterpart of the wallet's
+-- cumulative `balance_micro_usd`, so no later multiplier change can revalue
+-- money already paid.
+ALTER TABLE "user_wallets" ADD COLUMN IF NOT EXISTS "raw_capacity_micro_usd" bigint DEFAULT 0 NOT NULL;--> statement-breakpoint
+
+-- Backfill from the AICO-180 checkpoint using each wallet's own rate, which is
+-- exactly the key limit that wallet is enforcing right now:
+--   keyLimit = baseline + (balance - billedBefore) / M_checkpoint
+-- so nobody's spendable capacity moves at deploy time. floor() matches
+-- `removeMultiplierMicroUsd` — never hand out more headroom than was paid for.
+UPDATE "user_wallets"
+SET "raw_capacity_micro_usd" = "usage_baseline_micro_usd" + floor(
+  GREATEST(0, "balance_micro_usd" - "billed_usage_before_baseline_micro_usd")::numeric
+    * 10000 / GREATEST(1, "checkpoint_multiplier_bp")
+)
+WHERE "balance_micro_usd" > 0;--> statement-breakpoint
+
+-- The per-wallet checkpoint is subsumed: capacity is fixed at payment time, so
+-- there is no rate left to rebase. `member_budgets` are allowances rather than
+-- payments and keep theirs.
+ALTER TABLE "user_wallets" DROP COLUMN IF EXISTS "usage_baseline_micro_usd";--> statement-breakpoint
+ALTER TABLE "user_wallets" DROP COLUMN IF EXISTS "billed_usage_before_baseline_micro_usd";--> statement-breakpoint
+ALTER TABLE "user_wallets" DROP COLUMN IF EXISTS "checkpoint_multiplier_bp";

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1036,6 +1036,13 @@
       "when": 1787900000000,
       "tag": "0147_aico_usage_multiplier",
       "breakpoints": true
+    },
+    {
+      "idx": 148,
+      "version": "7",
+      "when": 1788000000000,
+      "tag": "0148_aico_wallet_raw_capacity",
+      "breakpoints": true
     }
   ],
   "version": "6"

--- a/packages/database/src/models/aicoBilling.ts
+++ b/packages/database/src/models/aicoBilling.ts
@@ -17,7 +17,11 @@ import {
 } from '../schemas/aicoOrganization';
 import { users } from '../schemas/user';
 import type { LobeChatDatabase } from '../type';
-import { assertValidMultiplierBp, DEFAULT_USAGE_MULTIPLIER_BP } from '../utils/aicoMoney';
+import {
+  assertValidMultiplierBp,
+  DEFAULT_USAGE_MULTIPLIER_BP,
+  rawCapacityFromDeposit,
+} from '../utils/aicoMoney';
 
 /**
  * Iranian mobile → E.164 normalization, duplicated (not imported) from
@@ -167,12 +171,19 @@ export class AicoBillingModel {
         const balanceBeforeMicroUsd = Number(before?.balanceMicroUsd ?? 0);
         const balanceBeforeToman = Number(before?.balanceToman ?? 0);
 
+        // AICO-184: the deposit buys raw upstream spend once, at the rate in
+        // force right now. Read inside the transaction so a concurrent
+        // multiplier change either applies to this top-up or does not.
+        const multiplierBp = await this.getUsageMultiplierBp(tx);
+        const rawCapacityAdded = rawCapacityFromDeposit(params.amountMicroUsd, multiplierBp);
+
         const [wallet] = await tx
           .update(userWallets)
           .set({
             balanceMicroUsd: sql`${userWallets.balanceMicroUsd} + ${params.amountMicroUsd}`,
             balanceToman: sql`${userWallets.balanceToman} + ${params.amountToman}`,
             isActive: true,
+            rawCapacityMicroUsd: sql`${userWallets.rawCapacityMicroUsd} + ${rawCapacityAdded}`,
           })
           .where(eq(userWallets.userId, params.userId))
           .returning();
@@ -191,6 +202,9 @@ export class AicoBillingModel {
             description: params.description ?? 'Manual credit',
             fxRateTomanPerUsd: params.fxRateTomanPerUsd,
             gatewayRefId: params.idempotencyKey ?? null,
+            // The rate this money was bought at — a later multiplier change
+            // must never be able to re-derive it.
+            metadata: { multiplierBp, rawCapacityAddedMicroUsd: rawCapacityAdded },
             type: 'manual_credit',
             userId: params.userId,
           })
@@ -251,24 +265,6 @@ export class AicoBillingModel {
    * platform multiplier changed since this wallet was last synced, so usage up
    * to `usageBaselineMicroUsd` keeps the rate it was billed at.
    */
-  updateUserWalletCheckpoint = async (params: {
-    billedUsageBeforeBaselineMicroUsd: number;
-    checkpointMultiplierBp: number;
-    usageBaselineMicroUsd: number;
-    userId: string;
-  }) => {
-    const [row] = await this.db
-      .update(userWallets)
-      .set({
-        billedUsageBeforeBaselineMicroUsd: params.billedUsageBeforeBaselineMicroUsd,
-        checkpointMultiplierBp: params.checkpointMultiplierBp,
-        usageBaselineMicroUsd: params.usageBaselineMicroUsd,
-      })
-      .where(eq(userWallets.userId, params.userId))
-      .returning();
-    return row;
-  };
-
   listUserTransactions = async (userId: string, limit = 50) => {
     return this.db.query.walletTransactions.findMany({
       where: eq(walletTransactions.userId, userId),
@@ -357,29 +353,29 @@ export class AicoBillingModel {
 
   // ─── Usage multiplier config (AICO-180) ────────────────────────────
 
-  getUsageMultiplierConfig = async () => {
-    const existing = await this.db.query.platformUsageMultiplierConfig.findFirst({
+  getUsageMultiplierConfig = async (db: LobeChatDatabase = this.db) => {
+    const existing = await db.query.platformUsageMultiplierConfig.findFirst({
       where: eq(platformUsageMultiplierConfig.id, 'default'),
     });
     if (existing) return existing;
 
-    const [created] = await this.db
+    const [created] = await db
       .insert(platformUsageMultiplierConfig)
       .values({ id: 'default', multiplierBp: DEFAULT_USAGE_MULTIPLIER_BP })
       .onConflictDoNothing()
       .returning();
     return (
       created ??
-      (await this.db.query.platformUsageMultiplierConfig.findFirst({
+      (await db.query.platformUsageMultiplierConfig.findFirst({
         where: eq(platformUsageMultiplierConfig.id, 'default'),
       }))!
     );
   };
 
   /** Basis-point multiplier in force right now. Never throws — billing must not wedge. */
-  getUsageMultiplierBp = async (): Promise<number> => {
+  getUsageMultiplierBp = async (db: LobeChatDatabase = this.db): Promise<number> => {
     try {
-      const config = await this.getUsageMultiplierConfig();
+      const config = await this.getUsageMultiplierConfig(db);
       const bp = Number(config?.multiplierBp ?? DEFAULT_USAGE_MULTIPLIER_BP);
       return Number.isFinite(bp) && bp > 0 ? bp : DEFAULT_USAGE_MULTIPLIER_BP;
     } catch {

--- a/packages/database/src/schemas/aicoOrganization.ts
+++ b/packages/database/src/schemas/aicoOrganization.ts
@@ -361,22 +361,12 @@ export const userWallets = pgTable(
     /** Soft-delete freeze of non-zero personal balance pending refund/recovery. */
     frozenMicroUsd: bigint('frozen_micro_usd', { mode: 'number' }).notNull().default(0),
     /**
-     * AICO-180 usage-multiplier checkpoint. `usageBaselineMicroUsd` is
-     * OpenRouter's raw usage counter at the last multiplier change and
-     * `billedUsageBeforeBaselineMicroUsd` what had been billed by then, so a
-     * multiplier change never reprices usage already charged at the old rate.
+     * AICO-184. Raw upstream spend this wallet has bought, accumulated as
+     * `deposit / M_at_payment` on every top-up. `balanceMicroUsd` is what the
+     * user paid; this is what it buys, so a later multiplier change cannot
+     * revalue money already paid. Doubles as the OpenRouter key limit.
      */
-    usageBaselineMicroUsd: bigint('usage_baseline_micro_usd', { mode: 'number' })
-      .notNull()
-      .default(0),
-    billedUsageBeforeBaselineMicroUsd: bigint('billed_usage_before_baseline_micro_usd', {
-      mode: 'number',
-    })
-      .notNull()
-      .default(0),
-    checkpointMultiplierBp: bigint('checkpoint_multiplier_bp', { mode: 'number' })
-      .notNull()
-      .default(12_000),
+    rawCapacityMicroUsd: bigint('raw_capacity_micro_usd', { mode: 'number' }).notNull().default(0),
     lastSyncedAt: timestamptz('last_synced_at'),
     createdAt: createdAt(),
     updatedAt: updatedAt(),

--- a/packages/database/src/utils/aicoMoney.ts
+++ b/packages/database/src/utils/aicoMoney.ts
@@ -306,3 +306,64 @@ export const rebaseCheckpoint = (params: {
     usageBaselineMicroUsd: raw,
   };
 };
+
+/**
+ * AICO-184 wallet capacity. A top-up buys raw upstream spend once, at the
+ * multiplier in force when it was paid, and no later change to the platform
+ * multiplier may revalue it.
+ *
+ * `rawCapacityMicroUsd` accumulates `deposit / M_at_payment` across every
+ * top-up, so it is the raw counterpart of the wallet's cumulative
+ * `balanceMicroUsd` and doubles as the OpenRouter key limit.
+ */
+export const rawCapacityFromDeposit = (
+  depositMicroUsd: number,
+  bp: number | null | undefined,
+): number => removeMultiplierMicroUsd(depositMicroUsd, bp);
+
+/**
+ * The rate a wallet actually bought at, blended across its top-ups:
+ * `balance / rawCapacity`. Falls back to the platform rate for a wallet that
+ * has bought nothing yet (a trial key funds the key without crediting the
+ * wallet), so usage is still billed rather than shown as free.
+ */
+export const blendedMultiplierBp = (params: {
+  balanceMicroUsd: number;
+  fallbackBp: number | null | undefined;
+  rawCapacityMicroUsd: number;
+}): number => {
+  const balance = Math.trunc(Number(params.balanceMicroUsd ?? 0));
+  const capacity = Math.trunc(Number(params.rawCapacityMicroUsd ?? 0));
+  if (!Number.isFinite(balance) || !Number.isFinite(capacity) || balance <= 0 || capacity <= 0) {
+    return safeBp(params.fallbackBp);
+  }
+  return Math.round((balance * MULTIPLIER_BP_SCALE) / capacity);
+};
+
+/**
+ * Billed usage from OpenRouter's raw counter at the wallet's blended rate.
+ * Reaches `balanceMicroUsd` exactly when raw usage reaches capacity, so
+ * remaining still lands on zero when the wallet is spent.
+ */
+export const billedUsageFromCapacity = (params: {
+  balanceMicroUsd: number;
+  fallbackBp: number | null | undefined;
+  rawCapacityMicroUsd: number;
+  rawUsageMicroUsd: number;
+}): number => {
+  const raw = Math.max(0, Math.trunc(Number(params.rawUsageMicroUsd ?? 0)));
+  const capacity = Math.max(0, Math.trunc(Number(params.rawCapacityMicroUsd ?? 0)));
+  const balance = Math.max(0, Math.trunc(Number(params.balanceMicroUsd ?? 0)));
+  if (raw <= 0) return 0;
+  // Spending the whole capacity bills the whole balance — never a rounding
+  // cent more or less, whatever the blend divides to.
+  if (capacity > 0 && balance > 0 && raw >= capacity) return balance;
+  return applyMultiplierMicroUsd(
+    raw,
+    blendedMultiplierBp({
+      balanceMicroUsd: balance,
+      fallbackBp: params.fallbackBp,
+      rawCapacityMicroUsd: capacity,
+    }),
+  );
+};

--- a/packages/database/src/utils/aicoUsageMultiplier.test.ts
+++ b/packages/database/src/utils/aicoUsageMultiplier.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   applyMultiplierMicroUsd,
   assertValidMultiplierBp,
+  billedUsageFromCapacity,
   billedUsageFromRaw,
+  blendedMultiplierBp,
   keyLimitFromBilled,
+  rawCapacityFromDeposit,
   rebaseCheckpoint,
   removeMultiplierMicroUsd,
   type UsageMultiplierCheckpoint,
@@ -115,5 +118,64 @@ describe('a multiplier change does not reprice past usage (AICO-180 regression)'
         bp: checkpoint.checkpointMultiplierBp,
       }),
     ).toBe(9 * USD);
+  });
+});
+
+describe('a multiplier change does not revalue money already paid (AICO-184 regression)', () => {
+  it('gives each top-up the rate that was in force when it was paid', () => {
+    // $1.20 at 1.2x, then the platform moves to 1.5x, then $1.50 at 1.5x.
+    const capacity =
+      rawCapacityFromDeposit(1_200_000, 12_000) + rawCapacityFromDeposit(1_500_000, 15_000);
+
+    // Each purchase bought a dollar of upstream spend and keeps it.
+    expect(capacity).toBe(2_000_000);
+
+    // What AICO-180 did instead: divide the whole $2.70 by the current rate,
+    // silently revaluing the first top-up down to $0.80.
+    expect(removeMultiplierMicroUsd(2_700_000, 15_000)).toBe(1_800_000);
+  });
+
+  it('bills usage at the blend of the rates actually bought at', () => {
+    const balanceMicroUsd = 2_700_000;
+    const rawCapacityMicroUsd = 2_000_000;
+
+    expect(blendedMultiplierBp({ balanceMicroUsd, fallbackBp: 15_000, rawCapacityMicroUsd })).toBe(
+      13_500,
+    );
+
+    const billed = (rawUsageMicroUsd: number) =>
+      billedUsageFromCapacity({
+        balanceMicroUsd,
+        fallbackBp: 15_000,
+        rawCapacityMicroUsd,
+        rawUsageMicroUsd,
+      });
+
+    expect(billed(0)).toBe(0);
+    expect(billed(1_000_000)).toBe(1_350_000);
+    // Spending the capacity bills the balance exactly — no rounding drift.
+    expect(billed(2_000_000)).toBe(2_700_000);
+    expect(billed(2_500_000)).toBe(2_700_000);
+  });
+
+  it('lowering the multiplier does not inflate capacity either', () => {
+    // Paid $1.50 at 1.5x; the platform then drops to 1.2x.
+    const capacity = rawCapacityFromDeposit(1_500_000, 15_000);
+    expect(capacity).toBe(1_000_000);
+    // AICO-180 would have handed out $1.25 of spend for the same $1.50.
+    expect(removeMultiplierMicroUsd(1_500_000, 12_000)).toBe(1_250_000);
+  });
+
+  it('falls back to the platform rate for a wallet that has bought nothing', () => {
+    // A trial funds the key without crediting the wallet — usage must still be
+    // billed rather than shown as free.
+    expect(
+      billedUsageFromCapacity({
+        balanceMicroUsd: 0,
+        fallbackBp: 12_000,
+        rawCapacityMicroUsd: 0,
+        rawUsageMicroUsd: 1_000_000,
+      }),
+    ).toBe(1_200_000);
   });
 });


### PR DESCRIPTION
#### 🔗 Related Issue

Fixes #335

Plane: [AICO-184](https://plane.panafor.com/panaforai/browse/AICO-184)

#### 💡 Background and Solution

A wallet's **unspent** balance was divided by whatever the multiplier is at sync time, not the rate it was bought at:

| step | paid balance | key limit (upstream capacity) |
| --- | --- | --- |
| multiplier 1.2, top up $1.20 | $1.20 | `1.20 / 1.2` = $1.00 |
| admin sets 1.5, nothing spent | $1.20 | `1.20 / 1.5` = **$0.80** ← revalued |
| top up $1.50 | $2.70 | `2.70 / 1.5` = **$1.80** |

The user paid **$2.70** and could spend **$1.80**. The AICO-180 checkpoint pinned the rate for usage already *metered*; it said nothing about money already *paid*, and with zero usage `billedBefore` is 0 so the whole balance floated with the admin's setting. Lowering the rate over-credited by the same mechanism, and nothing looked wrong in the UI — remaining still read $2.70 and still hit $0 when the $1.80 ran out.

**Now:** a top-up buys raw upstream spend once, at the rate in force when it was paid.

```
$1.20 / 1.2  +  $1.50 / 1.5  =  $1.00 + $1.00  =  $2.00
```

`user_wallets.raw_capacity_micro_usd` accumulates `deposit / M_at_payment` and **is** the OpenRouter key limit outright — the current multiplier never enters that calculation, which is what makes it impossible for a rate change to touch money already paid.

Usage bills at the blend the wallet actually bought at (`balance / rawCapacity`). That reaches the balance exactly when capacity runs out, so a full spend bills the full balance to the micro-USD instead of drifting by a rounding cent, and `remaining = balance − usage` becomes exact rather than something that needed OpenRouter's `limit_remaining` to correct it.

#### 📝 Changes

- **Schema / migration `0148`** — adds `raw_capacity_micro_usd`; **drops** the three AICO-180 checkpoint columns from `user_wallets`. The rate is fixed at payment, so there is nothing left to rebase and the checkpoint is redundant. `member_budgets` are allowances rather than payments and keep theirs.
- **Backfill** — from each wallet's own checkpoint, `baseline + (balance − billedBefore) / M_checkpoint`, which is exactly the key limit it is enforcing today, so **nobody's spendable capacity moves at deploy time**. (More precise than the `balance / M_current` the issue sketched, which would have shifted wallets that had already spent something.)
- `manualCreditUser` — converts at the rate read **inside** the transaction, so a concurrent multiplier change either applies to a top-up or does not; stamps `multiplierBp` and `rawCapacityAddedMicroUsd` on the wallet transaction so the purchased rate can never be re-derived from a later setting.
- `keyService` — `ensureUserKey` uses capacity directly; `getUserRemaining` bills at the blend; the wallet checkpoint sync and its now-dead raw-usage reader are removed.
- `aicoMoney` — `rawCapacityFromDeposit`, `blendedMultiplierBp`, `billedUsageFromCapacity`.

#### ⚠️ Behaviour notes

- **Blended, not oldest-first.** Someone who topped up at 1.2 and again at 1.5 has later usage billed at the blended 1.35 rather than draining the cheaper $1.20 first. Total capacity is identical either way; only the rate at which the displayed remaining falls differs. Strict FIFO would need a per-deposit lot table — not worth it, per the issue.
- **Trial keys.** A trial funds the key without crediting the wallet, so capacity is 0 there and the blend falls back to the current platform rate — trial usage is still billed rather than shown as free. Trial key limits still convert at the current rate, which is correct: a trial is a grant, not a purchase.

#### ✅ Verification

- `bun run check` → lint clean, **31 passed / 1 skipped**
- `packages/database` aico + aiInfra + utils → **17 files passed**
- `apps/server` openrouter + aico suites (serialized) → only the 8 pre-existing env-dependent failures in `chatBypassProduction` / `phase3.releaseGate`, unchanged from `canary`. Run in parallel these suites also produce `beforeEach` hook timeouts from shared-test-DB contention; `--fileParallelism=false` clears them.
- `bun run check --type` → **201 errors vs a 206 `canary` baseline** (five fewer — the test's mock client was missing `deleteKey`, which was already erroring on canary)

Regression tests: the `$1.20 @ 1.2 + $1.50 @ 1.5 → $2.00 not $1.80` case, the reverse (a rate drop must not inflate capacity), the blend reaching the balance exactly at full spend, the trial fallback, and an end-to-end pass through the real key service asserting a $2.00 key limit and $1.35 billed for $1.00 of raw spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
