### PR TITLE
🐛 fix(models): keep default OpenRouter embedding enabled on every path

### DIFF
--- a/apps/server/src/services/openrouter/modelCatalogSync.test.ts
+++ b/apps/server/src/services/openrouter/modelCatalogSync.test.ts
@@ -53,7 +53,8 @@ describe('OpenRouterModelCatalogSyncService', () => {
     expect(status).toMatchObject({
       lastStatus: 'success',
       lastTriggeredBy: 'manual:admin-1',
-      modelCount: 3,
+      // Fetched models + injected default embedding card
+      modelCount: 4,
     });
 
     const catalog = new OpenRouterModelCatalogModel(db);
@@ -79,6 +80,12 @@ describe('OpenRouterModelCatalogSyncService', () => {
           id: 'google/gemini-3.1-flash-image-preview:image',
           parameters: { prompt: { default: '' } },
           type: 'image',
+        }),
+        expect.objectContaining({
+          displayName: 'Text Embedding 3 Small',
+          enabled: true,
+          id: 'openai/text-embedding-3-small',
+          type: 'embedding',
         }),
       ]),
     );

--- a/packages/database/src/models/__tests__/openrouterModelCatalog.test.ts
+++ b/packages/database/src/models/__tests__/openrouterModelCatalog.test.ts
@@ -217,6 +217,37 @@ describe('OpenRouterModelCatalogModel', () => {
     });
   });
 
+  it('backfills the default embedding model on the serve path for catalogs synced before the injection', async () => {
+    const now = new Date();
+    // Simulate a catalog synced before the embedding injection: rows written
+    // directly, bypassing replaceCatalog, so no embedding row exists.
+    await db.insert(openrouterModelCatalog).values([
+      {
+        displayName: 'GPT-A',
+        enabled: true,
+        id: 'openai/gpt-a',
+        payload: {},
+        releasedAt: '2025-01-01',
+        syncedAt: now,
+        type: 'chat',
+      },
+      {
+        displayName: 'Panachat Auto',
+        enabled: true,
+        id: 'openrouter/auto',
+        payload: {},
+        syncedAt: now,
+        type: 'chat',
+      },
+    ]);
+
+    const rows = await catalog.listAsProviderModels();
+    expect(rows.find((r) => r.id === 'openai/text-embedding-3-small')).toMatchObject({
+      enabled: true,
+      type: 'embedding',
+    });
+  });
+
   it('reseeds default enabled flags from existing rows', async () => {
     const now = new Date();
     await db.insert(openrouterModelCatalog).values([

--- a/packages/database/src/models/openrouterModelCatalog.ts
+++ b/packages/database/src/models/openrouterModelCatalog.ts
@@ -85,6 +85,23 @@ const EMBEDDING_CATALOG_CARDS: OpenRouterCatalogModelInput[] = [
   },
 ];
 
+/**
+ * Serve-path twin of {@link EMBEDDING_CATALOG_CARDS}: the exact card
+ * `replaceCatalog` persists, so a stale catalog backfills byte-identical rows.
+ */
+const EMBEDDING_PROVIDER_CARDS: AiProviderModelListItem[] = EMBEDDING_CATALOG_CARDS.map((card) => ({
+  abilities: {},
+  contextWindowTokens: card.contextWindowTokens,
+  description: card.description,
+  displayName: card.displayName,
+  enabled: true,
+  id: card.id,
+  pricing: card.pricing,
+  releasedAt: card.releasedAt,
+  source: AiModelSourceEnum.Remote,
+  type: normalizeAiModelType(card.type),
+}));
+
 export class OpenRouterModelCatalogModel {
   private db: LobeChatDatabase;
 
@@ -166,7 +183,13 @@ export class OpenRouterModelCatalogModel {
       } as AiProviderModelListItem;
     });
 
-    if (mapped.some((m) => m.id === OPENROUTER_AUTO_MODEL_ID)) return mapped;
+    if (mapped.some((m) => m.id === OPENROUTER_AUTO_MODEL_ID)) {
+      // Serve path must be self-healing: a catalog synced before the embedding
+      // injection (or never re-synced) has no embedding rows, which leaves the
+      // memory-embedding default disabled. Backfill the same cards
+      // `replaceCatalog` injects at sync time.
+      return ensureOpenRouterModels(mapped, EMBEDDING_PROVIDER_CARDS);
+    }
 
     return [
       {
@@ -179,7 +202,7 @@ export class OpenRouterModelCatalogModel {
         source: AiModelSourceEnum.Remote,
         type: 'chat',
       } as AiProviderModelListItem,
-      ...mapped,
+      ...ensureOpenRouterModels(mapped, EMBEDDING_PROVIDER_CARDS),
     ];
   };
 

--- a/packages/model-bank/src/aiModels/openrouter.ts
+++ b/packages/model-bank/src/aiModels/openrouter.ts
@@ -3,7 +3,7 @@ import {
   nanoBananaParameters,
   nanoBananaProParameters,
 } from '../const/imageParameters';
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import type { AIChatModelCard, AIEmbeddingModelCard, AIImageModelCard } from '../types/aiModel';
 
 // https://openrouter.ai/docs/api-reference/list-available-models
 const openrouterChatModels: AIChatModelCard[] = [
@@ -920,6 +920,50 @@ const openrouterImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...openrouterChatModels, ...openrouterImageModels];
+/**
+ * Embedding siblings for the managed OpenRouter surface.
+ *
+ * Service Model memory-embedding (and knowledge base) default to
+ * `openai/text-embedding-3-small` under `provider=openrouter`. Without these
+ * static entries the managed provider has no `type: 'embedding'` cards until a
+ * remote catalog fetch runs, so the default renders as disabled out of the box.
+ */
+const openrouterEmbeddingModels: AIEmbeddingModelCard[] = [
+  {
+    contextWindowTokens: 8192,
+    description:
+      'An efficient, cost-effective next-generation embedding model for retrieval and RAG scenarios.',
+    displayName: 'Text Embedding 3 Small',
+    enabled: true,
+    id: 'openai/text-embedding-3-small',
+    maxDimension: 1536,
+    pricing: {
+      currency: 'USD',
+      units: [{ name: 'textInput', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2024-01-25',
+    type: 'embedding',
+  },
+  {
+    contextWindowTokens: 8192,
+    description: 'The most capable embedding model for English and non-English tasks.',
+    displayName: 'Text Embedding 3 Large',
+    enabled: true,
+    id: 'openai/text-embedding-3-large',
+    maxDimension: 3072,
+    pricing: {
+      currency: 'USD',
+      units: [{ name: 'textInput', rate: 0.13, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2024-01-25',
+    type: 'embedding',
+  },
+];
+
+export const allModels = [
+  ...openrouterChatModels,
+  ...openrouterImageModels,
+  ...openrouterEmbeddingModels,
+];
 
 export default allModels;

--- a/src/services/aiModel/index.test.ts
+++ b/src/services/aiModel/index.test.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_PROVIDER } from '@lobechat/business-const';
+import { DEFAULT_EMBEDDING_PROVIDER, DEFAULT_PROVIDER } from '@lobechat/business-const';
 import { DEFAULT_SETTINGS } from '@lobechat/config';
-import { DEFAULT_MINI_MODEL, DEFAULT_MODEL } from '@lobechat/const';
+import { DEFAULT_EMBEDDING_MODEL, DEFAULT_MINI_MODEL, DEFAULT_MODEL } from '@lobechat/const';
 import { LOBE_DEFAULT_MODEL_LIST } from 'model-bank';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -131,5 +131,19 @@ describe('Default model configuration', () => {
       `DEFAULT_MINI_MODEL "${DEFAULT_MINI_MODEL}" not found in LOBE_DEFAULT_MODEL_LIST`,
     ).toBeDefined();
     expect(match!.enabled, `DEFAULT_MINI_MODEL "${DEFAULT_MINI_MODEL}" is not enabled`).toBe(true);
+  });
+
+  it('DEFAULT_EMBEDDING_MODEL should be enabled under DEFAULT_EMBEDDING_PROVIDER', () => {
+    const match = LOBE_DEFAULT_MODEL_LIST.find(
+      (m) => m.id === DEFAULT_EMBEDDING_MODEL && m.providerId === DEFAULT_EMBEDDING_PROVIDER,
+    );
+    expect(
+      match,
+      `DEFAULT_EMBEDDING_MODEL "${DEFAULT_EMBEDDING_PROVIDER}/${DEFAULT_EMBEDDING_MODEL}" not found in LOBE_DEFAULT_MODEL_LIST`,
+    ).toBeDefined();
+    expect(
+      match!.enabled,
+      `DEFAULT_EMBEDDING_MODEL "${DEFAULT_EMBEDDING_PROVIDER}/${DEFAULT_EMBEDDING_MODEL}" is not enabled`,
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Service Model > Memory Embedding default (`openrouter/openai/text-embedding-3-small`) renders as **Disabled** | Default resolves as enabled in every path: stale catalog, empty catalog + offline, and normal sync |

#333 fixed the default id and injects the embedding card at sync time, but two gaps remained:

1. **Stale catalog (the live bug):** `listAsProviderModels` (serve path, hit on every model list) never injected the embedding cards — only `replaceCatalog` (sync path) did. Any catalog synced before #333, or never re-synced, still serves zero embedding models, so the default stays disabled. Fixed by backfilling `EMBEDDING_PROVIDER_CARDS` in `listAsProviderModels`, mirroring the existing AUTO-card backfill.
2. **Empty catalog + offline:** the static model-bank fallback had zero `type: 'embedding'` cards for `openrouter`. Fixed by shipping `openai/text-embedding-3-small` + `large` (`enabled: true`) in `openrouter.ts`, mirroring the existing static `:image` precedent.

Also fixes `modelCatalogSync.test.ts`, which #333 left red (`modelCount` 3 → 4).

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- New serve-path regression test fails before the fix (`undefined` instead of the embedding card) and passes after.
- `bun run check --test` on both touched areas: 10 passed (8 catalog model tests + 2 sync service tests).
- New `DEFAULT_EMBEDDING_MODEL`-enabled regression test in `src/services/aiModel/index.test.ts` passes; the 2 other failures there are pre-existing on the clean tree.

#### Related Issue

No matching issue found.