### PR TITLE
🐛 fix(settings): default AI Art image count to 1 instead of 0

### DIFF
--- a/src/components/FormInput/FormSliderWithInput.tsx
+++ b/src/components/FormInput/FormSliderWithInput.tsx
@@ -1,6 +1,8 @@
 import { type SliderWithInputProps } from '@lobehub/ui';
 import { SliderWithInput } from '@lobehub/ui';
-import { memo, useEffect, useState } from 'react';
+import { memo } from 'react';
+
+import { useClampedSliderValue } from './useClampedSliderValue';
 
 interface FormSliderWithInputProps extends Omit<SliderWithInputProps, 'onChange' | 'value'> {
   onChange?: (value: number) => void;
@@ -10,14 +12,11 @@ interface FormSliderWithInputProps extends Omit<SliderWithInputProps, 'onChange'
 /**
  * Form-integrated slider with delayed onChange behavior.
  * Only triggers onChange on blur to prevent excessive updates during user interaction.
+ * The value stays clamped to [min, max] (see `useClampedSliderValue`).
  */
 const FormSliderWithInput = memo<FormSliderWithInputProps>(
-  ({ onChange, value: defaultValue, ...props }) => {
-    const [value, setValue] = useState(defaultValue ?? 0);
-
-    useEffect(() => {
-      setValue(defaultValue ?? 0);
-    }, [defaultValue]);
+  ({ onChange, value: defaultValue, min, max, ...props }) => {
+    const [value, setValue] = useClampedSliderValue(defaultValue, min, max);
 
     return (
       <SliderWithInput
@@ -30,6 +29,8 @@ const FormSliderWithInput = memo<FormSliderWithInputProps>(
           }
         }}
         {...props}
+        max={max}
+        min={min}
         value={value}
       />
     );

--- a/src/components/FormInput/useClampedSliderValue.test.ts
+++ b/src/components/FormInput/useClampedSliderValue.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { clampSliderValue, useClampedSliderValue } from './useClampedSliderValue';
+
+describe('clampSliderValue', () => {
+  it('falls back to min instead of 0 when no value is provided', () => {
+    expect(clampSliderValue(undefined, 1, 20)).toBe(1);
+  });
+
+  it('falls back to 1 when neither value nor min is provided', () => {
+    expect(clampSliderValue(undefined)).toBe(1);
+  });
+
+  it('clamps a stored value below min up to min', () => {
+    expect(clampSliderValue(0, 1, 20)).toBe(1);
+  });
+
+  it('clamps a stored value above max down to max', () => {
+    expect(clampSliderValue(99, 1, 20)).toBe(20);
+  });
+
+  it('keeps an in-range value untouched', () => {
+    expect(clampSliderValue(4, 1, 20)).toBe(4);
+  });
+});
+
+describe('useClampedSliderValue', () => {
+  it('starts clamped when the initial value is out of range', () => {
+    const { result } = renderHook(() => useClampedSliderValue(0, 1, 20));
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('re-clamps when the external value updates', () => {
+    const { result, rerender } = renderHook(({ value }) => useClampedSliderValue(value, 1, 20), {
+      initialProps: { value: 4 as number | undefined },
+    });
+    expect(result.current[0]).toBe(4);
+
+    rerender({ value: undefined });
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('clamps writes through the setter', () => {
+    const { result } = renderHook(() => useClampedSliderValue(4, 1, 20));
+    act(() => {
+      result.current[1](0);
+    });
+    expect(result.current[0]).toBe(1);
+  });
+});

--- a/src/components/FormInput/useClampedSliderValue.ts
+++ b/src/components/FormInput/useClampedSliderValue.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Clamp a slider value into [min, max].
+ *
+ * A missing value falls back to `min` (the AI Art image count starts at 1,
+ * never 0), and stored strays outside the range are pulled back in so the
+ * slider can neither display nor commit an out-of-range value.
+ */
+export const clampSliderValue = (next: number | undefined, min?: number, max?: number): number => {
+  const fallback = min ?? 1;
+  if (typeof next !== 'number' || Number.isNaN(next)) return fallback;
+  if (typeof min === 'number' && next < min) return min;
+  if (typeof max === 'number' && next > max) return max;
+  return next;
+};
+
+/**
+ * Slider state that stays inside [min, max]: the initial value is clamped,
+ * external updates re-clamp, and writes through the setter are clamped too.
+ */
+export const useClampedSliderValue = (
+  defaultValue: number | undefined,
+  min?: number,
+  max?: number,
+) => {
+  const [value, setRawValue] = useState(() => clampSliderValue(defaultValue, min, max));
+
+  useEffect(() => {
+    setRawValue(clampSliderValue(defaultValue, min, max));
+  }, [defaultValue, min, max]);
+
+  return [value, (next: number) => setRawValue(clampSliderValue(next, min, max))] as const;
+};


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| Service Model > AI Art > default number of images initially shows **0** (below the slider's own `min=1`; a blur then persists the invalid 0, making it sticky) | Shows **1**; missing or out-of-range values are clamped into `[min, max]` for display and commit |

`FormSliderWithInput` (used only by the AI Art image-count setting) fell back to a hardcoded `0` when the field value was missing (`useState(defaultValue ?? 0)`) and passed stored strays through untouched — so the slider could display and save `0` despite `min={1}`.

- Extracts the range logic into `useClampedSliderValue` (`clampSliderValue` + hook): missing → `min` (defaults to 1), below min → min, above max → max.
- `FormSliderWithInput` now uses the hook; wiring (blur-to-commit etc.) unchanged.
- Hook tests in `useClampedSliderValue.test.ts` (`.test.ts` per the testing skill's no-new-component-tests rule; equivalent render assertions failed 3/4 on the old code).

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check` on all three files: lint clean, 8 tests passed, no advisories.

#### Related Issue

No matching issue found.