### PR TITLE
🐛 fix(branding): make BRANDING_* env overrides reach the SPA bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@
 # ########### Branding / White-label ####
 # #######################################
 
+# Each setting below has two forms. The bare name (BRANDING_NAME) is read by the
+# Node server at runtime. The NEXT_PUBLIC_ twin is the ONLY form that reaches the
+# browser: it is inlined into the SPA bundle at BUILD time, so a prebuilt image
+# must be rebuilt for a change to show up in the client. Set both, to the same
+# value, or the client and server will render different branding.
+
 # Product name shown across the UI, metadata, and desktop user-agent.
 # BRANDING_NAME=Panachat
 # NEXT_PUBLIC_BRANDING_NAME=Panachat
@@ -67,15 +73,25 @@
 # BRANDING_LOGO_URL=/icons/icon-192x192.png
 # NEXT_PUBLIC_BRANDING_LOGO_URL=/icons/icon-192x192.png
 
-# Official provider id used in model settings (defaults to "official").
+# Managed provider id used in model settings (defaults to "official").
 # BRANDING_PROVIDER=official
+# NEXT_PUBLIC_BRANDING_PROVIDER=official
 
 # Optional public marketing/docs site (defaults to APP_URL).
 # BRANDING_SITE_URL=https://example.com
 # NEXT_PUBLIC_BRANDING_SITE_URL=https://example.com
 
+# Brand mark / emoji used in auth emails and similar surfaces.
+# BRANDING_EMOJI=🐦‍🔥
+# NEXT_PUBLIC_BRANDING_EMOJI=🐦‍🔥
+
 # Optional support contact email for in-app copy.
 # BRANDING_SUPPORT_EMAIL=support@example.com
+# NEXT_PUBLIC_BRANDING_SUPPORT_EMAIL=support@example.com
+
+# Optional business contact email for in-app copy.
+# BRANDING_BUSINESS_EMAIL=hello@example.com
+# NEXT_PUBLIC_BRANDING_BUSINESS_EMAIL=hello@example.com
 
 # #######################################
 # ######### AI Provider Service #########

--- a/packages/business/const/package.json
+++ b/packages/business/const/package.json
@@ -5,5 +5,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "main": "./src/index.ts"
+  "main": "./src/index.ts",
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'"
+  },
+  "devDependencies": {
+    "vite-tsconfig-paths": "^6.1.1"
+  }
 }

--- a/packages/business/const/src/branding.bundle.test.ts
+++ b/packages/business/const/src/branding.bundle.test.ts
@@ -1,0 +1,100 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the SPA bundle, not the Node runtime.
+ *
+ * `branding.test.ts` runs under Node, where `process.env` is a real object, so a
+ * dynamic `process.env[name]` lookup works there and every assertion passes —
+ * which is precisely why the client-side breakage went unnoticed. The browser
+ * bundle is different: vite/esbuild replaces `process.env` with `{}` and injects
+ * one define per `NEXT_PUBLIC_*` key, so only *statically analysable* reads
+ * survive. A variable key compiles to `({})[name]` and always yields undefined.
+ *
+ * So the only way to catch a regression is to bundle the module the way the SPA
+ * does and assert the override actually lands in the output.
+ */
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+const BRANDING_ENTRY = path.join(dir, 'branding.ts');
+// OFFICIAL_URL / OFFICIAL_SITE live in @lobechat/const and had the same defect.
+const URL_ENTRY = path.resolve(dir, '../../../const/src/url.ts');
+
+const bundleWithSpaDefines = async (entry: string, defines: Record<string, string>) => {
+  const result: any = await build({
+    build: {
+      // Dependencies are bundled in (not externalised) so the output can be
+      // evaluated standalone from a data: URL.
+      lib: { entry, fileName: 'out', formats: ['es'] },
+      minify: false,
+      write: false,
+    },
+    define: {
+      ...defines,
+      // Mirrors plugins/vite/sharedRendererConfig.ts: a bare `process.env`
+      // fallback so browser runtime access doesn't crash.
+      'process.env': '{}',
+    },
+    logLevel: 'silent',
+  });
+
+  return result[0].output[0].code as string;
+};
+
+/**
+ * Evaluate the bundled output in isolation. Asserting on the *evaluated export*
+ * rather than on substrings matters: the hardcoded fallbacks legitimately remain
+ * in the bundle as fallback arguments, so a text search cannot distinguish
+ * "override applied" from "fallback used".
+ */
+const evaluateBundle = async (code: string) =>
+  import(`data:text/javascript;base64,${Buffer.from(code).toString('base64')}`);
+
+describe('branding constants survive SPA bundling', () => {
+  it('applies NEXT_PUBLIC_ branding overrides in the client bundle', async () => {
+    const code = await bundleWithSpaDefines(BRANDING_ENTRY, {
+      'process.env.NEXT_PUBLIC_BRANDING_NAME': JSON.stringify('BrandProbe'),
+      'process.env.NEXT_PUBLIC_BRANDING_PROVIDER': JSON.stringify('provider-probe'),
+    });
+
+    const bundled = await evaluateBundle(code);
+
+    expect(bundled.BRANDING_NAME).toBe('BrandProbe');
+    expect(bundled.BRANDING_PROVIDER).toBe('provider-probe');
+    // Derived values must follow the override, not the hardcoded fallback.
+    expect(bundled.BRANDING_CLOUD_NAME).toBe('BrandProbe Cloud');
+    expect(bundled.ORG_NAME).toBe('BrandProbe');
+  });
+
+  it('falls back cleanly when no override is defined', async () => {
+    const bundled = await evaluateBundle(await bundleWithSpaDefines(BRANDING_ENTRY, {}));
+
+    expect(bundled.BRANDING_NAME).toBe('Panachat');
+  });
+
+  it('applies NEXT_PUBLIC_APP_URL so OFFICIAL_URL is not pinned to localhost', async () => {
+    const code = await bundleWithSpaDefines(URL_ENTRY, {
+      'process.env.NEXT_PUBLIC_APP_URL': JSON.stringify('https://chat.example.com'),
+    });
+
+    const bundled = await evaluateBundle(code);
+
+    expect(bundled.OFFICIAL_URL).toBe('https://chat.example.com');
+    expect(bundled.OFFICIAL_SITE).toBe('https://chat.example.com');
+  });
+
+  it.each([
+    ['branding.ts', BRANDING_ENTRY],
+    ['const/url.ts', URL_ENTRY],
+  ])('reads env with statically analysable keys in %s', async (_name, entry) => {
+    const output = await bundleWithSpaDefines(entry, {});
+
+    // A dynamic lookup survives bundling as an index against the substituted
+    // empty object. Nothing in these modules should read env by variable key.
+    expect(output).not.toMatch(/process_env_default\s*\[/);
+    expect(output).not.toMatch(/\{\s*\}\s*\[/);
+  });
+});

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -2,37 +2,67 @@
 // if you want to use it in the commercial usage
 // please contact us for more information: hello@lobehub.com
 
-const readBrandingEnv = (name: string, fallback: string) => {
-  const publicKey = `NEXT_PUBLIC_${name}`;
-  const value = process.env[name] ?? process.env[publicKey];
-
-  return value?.trim() || fallback;
-};
+/**
+ * Every env read below MUST be written out as a literal `process.env.X` (or
+ * `process.env['X']`) expression, once per variable.
+ *
+ * The SPA is bundled by esbuild with `'process.env': '{}'` plus one define per
+ * `NEXT_PUBLIC_*` key (see `plugins/vite/sharedRendererConfig.ts`). esbuild
+ * substitutes only *statically analysable* keys: a lookup whose key is a
+ * variable — as in the previous `readBrandingEnv(name)` helper, which did
+ * `process.env[name]` — compiles to `({})[name]` and is therefore always
+ * `undefined` in the browser. That silently pinned the client to the fallbacks
+ * below while the Node server read the real values, so branding diverged
+ * between server and client.
+ *
+ * Note this means client-side branding is baked in at BUILD time and only via
+ * the `NEXT_PUBLIC_*` twin — a private `BRANDING_*` var is deliberately never
+ * exposed to the browser bundle.
+ */
+const brandingValue = (value: string | undefined, fallback: string) => value?.trim() || fallback;
 
 /** Default product name shown across the UI, metadata, and API client headers. */
-export const BRANDING_NAME = readBrandingEnv('BRANDING_NAME', 'Panachat');
+export const BRANDING_NAME = brandingValue(
+  process.env.BRANDING_NAME ?? process.env.NEXT_PUBLIC_BRANDING_NAME,
+  'Panachat',
+);
 
 /**
  * Persian display name for fa-* locales (UI copy, logos, i18n `{{appName}}`).
  * Falls back to {@link BRANDING_NAME} when unset.
  */
-export const BRANDING_NAME_FA = readBrandingEnv('BRANDING_NAME_FA', 'پاناچت');
+export const BRANDING_NAME_FA = brandingValue(
+  process.env.BRANDING_NAME_FA ?? process.env.NEXT_PUBLIC_BRANDING_NAME_FA,
+  'پاناچت',
+);
 
 /** Brand mark / emoji used in auth emails and similar surfaces. */
-export const BRANDING_EMOJI = readBrandingEnv('BRANDING_EMOJI', '🐦‍🔥');
+export const BRANDING_EMOJI = brandingValue(
+  process.env.BRANDING_EMOJI ?? process.env.NEXT_PUBLIC_BRANDING_EMOJI,
+  '🐦‍🔥',
+);
 
 /** Organization / legal entity name used in copyright and structured data. */
-export const ORG_NAME = readBrandingEnv('ORG_NAME', BRANDING_NAME);
+export const ORG_NAME = brandingValue(
+  process.env.ORG_NAME ?? process.env.NEXT_PUBLIC_ORG_NAME,
+  BRANDING_NAME,
+);
 
 /** Persian organization name for fa-* locales. */
-export const ORG_NAME_FA = readBrandingEnv('ORG_NAME_FA', BRANDING_NAME_FA);
+export const ORG_NAME_FA = brandingValue(
+  process.env.ORG_NAME_FA ?? process.env.NEXT_PUBLIC_ORG_NAME_FA,
+  BRANDING_NAME_FA,
+);
 
 /** Hosted cloud offering name, e.g. "Panachat Cloud". */
-export const BRANDING_CLOUD_NAME = readBrandingEnv('BRANDING_CLOUD_NAME', `${BRANDING_NAME} Cloud`);
+export const BRANDING_CLOUD_NAME = brandingValue(
+  process.env.BRANDING_CLOUD_NAME ?? process.env.NEXT_PUBLIC_BRANDING_CLOUD_NAME,
+  `${BRANDING_NAME} Cloud`,
+);
 
 /** Persian cloud offering name for fa-* locales. */
-export const BRANDING_CLOUD_NAME_FA = readBrandingEnv(
-  'BRANDING_CLOUD_NAME_FA',
+export const BRANDING_CLOUD_NAME_FA = brandingValue(
+  process.env.BRANDING_CLOUD_NAME_FA ?? process.env.NEXT_PUBLIC_BRANDING_CLOUD_NAME_FA,
   `ابر ${BRANDING_NAME_FA}`,
 );
 
@@ -40,10 +70,16 @@ export const BRANDING_CLOUD_NAME_FA = readBrandingEnv(
 export const LOBE_CHAT_CLOUD = BRANDING_CLOUD_NAME;
 
 /** Public marketing / docs site URL (defaults to APP_URL when unset). */
-export const BRANDING_SITE_URL = readBrandingEnv('BRANDING_SITE_URL', '');
+export const BRANDING_SITE_URL = brandingValue(
+  process.env.BRANDING_SITE_URL ?? process.env.NEXT_PUBLIC_BRANDING_SITE_URL,
+  '',
+);
 
 /** Product logo URL used by ProductLogo / metadata. Defaults to the favicon_io PWA icon. */
-export const BRANDING_LOGO_URL = readBrandingEnv('BRANDING_LOGO_URL', '/icons/icon-192x192.png');
+export const BRANDING_LOGO_URL = brandingValue(
+  process.env.BRANDING_LOGO_URL ?? process.env.NEXT_PUBLIC_BRANDING_LOGO_URL,
+  '/icons/icon-192x192.png',
+);
 
 export const BRANDING_URL = {
   help: undefined,
@@ -66,12 +102,21 @@ export const FILE_URL = {
 };
 
 export const BRANDING_EMAIL = {
-  business: readBrandingEnv('BRANDING_BUSINESS_EMAIL', ''),
+  business: brandingValue(
+    process.env.BRANDING_BUSINESS_EMAIL ?? process.env.NEXT_PUBLIC_BRANDING_BUSINESS_EMAIL,
+    '',
+  ),
   replyTo: undefined,
-  support: readBrandingEnv('BRANDING_SUPPORT_EMAIL', ''),
+  support: brandingValue(
+    process.env.BRANDING_SUPPORT_EMAIL ?? process.env.NEXT_PUBLIC_BRANDING_SUPPORT_EMAIL,
+    '',
+  ),
 };
 
-export const BRANDING_PROVIDER = readBrandingEnv('BRANDING_PROVIDER', 'official');
+export const BRANDING_PROVIDER = brandingValue(
+  process.env.BRANDING_PROVIDER ?? process.env.NEXT_PUBLIC_BRANDING_PROVIDER,
+  'official',
+);
 
 export const APPLE_APP_STORE_ID = '';
 

--- a/packages/business/const/vitest.config.mts
+++ b/packages/business/const/vitest.config.mts
@@ -1,0 +1,13 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths({ projects: ['../../../tsconfig.json'] })],
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'node',
+  },
+});

--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -1,15 +1,24 @@
 import urlJoin from 'url-join';
 
-const readEnvUrl = (name: string, fallback: string) => {
-  const value = process.env[name] ?? process.env[`NEXT_PUBLIC_${name}`];
-  return value?.trim() || fallback;
-};
+/**
+ * Keys must be written out literally — a `process.env[name]` lookup with a
+ * variable key is not statically analysable, so esbuild leaves it as
+ * `({})[name]` in the SPA bundle and it always reads `undefined`. See the note
+ * in `@lobechat/business-const`'s `branding.ts` for the full explanation.
+ */
+const envUrl = (value: string | undefined, fallback: string) => value?.trim() || fallback;
 
 const defaultAppUrl =
   process.env.NODE_ENV === 'development' ? 'http://localhost:3010' : 'http://localhost:3210';
 
-export const OFFICIAL_URL = readEnvUrl('APP_URL', defaultAppUrl);
-export const OFFICIAL_SITE = readEnvUrl('BRANDING_SITE_URL', OFFICIAL_URL);
+export const OFFICIAL_URL = envUrl(
+  process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL,
+  defaultAppUrl,
+);
+export const OFFICIAL_SITE = envUrl(
+  process.env.BRANDING_SITE_URL ?? process.env.NEXT_PUBLIC_BRANDING_SITE_URL,
+  OFFICIAL_URL,
+);
 export const OFFICIAL_DOMAIN = (() => {
   try {
     return new URL(OFFICIAL_SITE).hostname;


### PR DESCRIPTION
Fixes issue 4: all `BRANDING_*` env overrides were silently ignored in the SPA bundle.

### Root cause

`readBrandingEnv` read env through `process.env[name]` with a **variable** key. esbuild can only substitute statically analysable keys, so under the SPA's `'process.env': '{}'` define ([sharedRendererConfig.ts:386](plugins/vite/sharedRendererConfig.ts:386)) that compiled to `({})[name]` and always returned `undefined`. The client silently used the hardcoded fallbacks (`Panachat`, `پاناچت`, `official`) while the Node server read the real values — branding diverged between server and client across the 113 `src/` files importing `@lobechat/business-const`.

> [!NOTE]
> One correction to the report: the cause is the **dynamic key**, not the bracket form. I verified esbuild substitutes `process.env['LITERAL_KEY']` fine — only a variable key defeats it.

A second detail that shapes the fix: the define map inlines **only `NEXT_PUBLIC_*`** keys ([sharedRendererConfig.ts:369-373](plugins/vite/sharedRendererConfig.ts:369)), deliberately, so private env never lands in a browser bundle. Switching to the dot form is therefore necessary but not sufficient — each constant must reference a literal `NEXT_PUBLIC_` name. `.env.example` already documented those twins, so this restores the intended design rather than inventing one.

### Also fixed: `OFFICIAL_URL`

`@lobechat/const`'s `url.ts` had the identical defect. Because vite explicitly defines `process.env.APP_URL`, this meant `OFFICIAL_URL` ignored it and pinned every derived docs / privacy / terms / download link in the SPA to `http://localhost:3210` in production builds.

### Why this went unnoticed

Two independent reasons, both fixed here:

1. `branding.test.ts` runs under Node, where `process.env` is a real object and the dynamic lookup works — so it passed identically before and after.
2. It never actually ran. `packages/business/const` had no owning vitest config, and the root config excludes `packages/**`. `bun run check --test` reported: `tests skipped (not matched by owning vitest config)`.

The package now has a vitest config, so its 3 existing tests run for the first time, plus a new `branding.bundle.test.ts` that bundles the modules through vite with the SPA's own defines and asserts on the **evaluated exports** — a substring search can't distinguish "override applied" from "fallback used", since fallback literals legitimately remain in the output.

### Reviewer notes

- **Deployment implication, now documented in `.env.example`:** the `NEXT_PUBLIC_` twin is inlined at **build** time. A prebuilt image must be rebuilt for client-side branding to change, and both forms should be set to the same value or client and server will disagree. Making runtime `BRANDING_*` reach the client would need the `window.__SERVER_CONFIG__` channel and a runtime-aware accessor at 113 call sites — worth a separate issue, not folded in here.
- Added the missing `NEXT_PUBLIC_` twins for `BRANDING_PROVIDER`, `BRANDING_EMOJI`, `BRANDING_SUPPORT_EMAIL`, `BRANDING_BUSINESS_EMAIL`.
- `BRANDING_PROVIDER`'s bogus `'official'` default (issue 5) is deliberately **not** touched here — it's a behaviour change and belongs in its own PR.

| Before | After |
| ------ | ----- |
| `process.env[name]` → `({})[name]` → always `undefined` in the browser | literal `process.env.X` per variable, inlined by the define map |
| Client stuck on `Panachat` / `پاناچت` regardless of env | client renders the configured brand, matching the server |
| SPA `OFFICIAL_URL` pinned to `localhost:3210` in production | honours `APP_URL` / `NEXT_PUBLIC_APP_URL` |
| `packages/business/const` tests never executed | package has a vitest config; 22 tests run |

#### Test

End-to-end against a real SPA build — the decisive check, since the bug is invisible to Node-run tests:

```
NEXT_PUBLIC_BRANDING_NAME=BrandProbe bun run build:spa
grep -rl "BrandProbe" dist/
```

**0 hits before this change, 1 hit after** (`dist/desktop/assets/app-const-*.js`).

The new bundle tests fail 4/5 against the old code and pass 5/5 after. `bun run check` is lint-clean, 22 tests passing in the package. `bun run type-check`: 201 errors before and after — no new errors, none in the changed files (the pre-existing count is issue 6, handled separately).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

