### PR TITLE
🐛 fix(branding): default BRANDING_PROVIDER to the real managed provider id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,9 +73,11 @@
 # BRANDING_LOGO_URL=/icons/icon-192x192.png
 # NEXT_PUBLIC_BRANDING_LOGO_URL=/icons/icon-192x192.png
 
-# Managed provider id used in model settings (defaults to "official").
-# BRANDING_PROVIDER=official
-# NEXT_PUBLIC_BRANDING_PROVIDER=official
+# Provider id of the managed offering (defaults to "aico"). This is a provider
+# id compared against real provider keys, not a display name — set BRANDING_NAME
+# for that. Must be a provider the runtime knows, e.g. "aico" or "openrouter".
+# BRANDING_PROVIDER=aico
+# NEXT_PUBLIC_BRANDING_PROVIDER=aico
 
 # Optional public marketing/docs site (defaults to APP_URL).
 # BRANDING_SITE_URL=https://example.com

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1176,7 +1176,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
           payload: {
             messages: [{ content: 'Hello', role: 'user' }],
             model: 'deepseek-v4-pro',
-            provider: 'lobehub',
+            provider: BRANDING_PROVIDER,
             tools: [],
           },
           type: 'call_llm' as const,
@@ -1192,7 +1192,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
         maxAttempts: 1,
         model: 'deepseek-v4-pro',
         outputTokens: 25_617,
-        provider: 'lobehub',
+        provider: BRANDING_PROVIDER,
         toolCallCount: 0,
       });
       expect(mockStreamManager.publishStreamEvent).not.toHaveBeenCalledWith(
@@ -2218,31 +2218,31 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
         expect(mockFindPlanDocuments).not.toHaveBeenCalled();
       });
 
-      it.each([
-        { items: [], updatedAt: 'canonical-clear' },
-        [],
-      ])('treats canonical and legacy empty message states as clear tombstones', async (todos) => {
-        mockFindPlanDocuments.mockResolvedValue([
-          {
-            metadata: {
-              todos: { items: [{ status: 'todo', text: 'Stale metadata task' }] },
+      it.each([{ items: [], updatedAt: 'canonical-clear' }, []])(
+        'treats canonical and legacy empty message states as clear tombstones',
+        async (todos) => {
+          mockFindPlanDocuments.mockResolvedValue([
+            {
+              metadata: {
+                todos: { items: [{ status: 'todo', text: 'Stale metadata task' }] },
+              },
+              updatedAt: new Date(),
             },
-            updatedAt: new Date(),
-          },
-        ]);
+          ]);
 
-        const content = await callWithMessages(
-          [
-            { content: 'cleared', pluginState: { todos }, role: 'tool' },
-            { content: 'Continue', role: 'user' },
-          ],
-          stateWithLobeAgent(),
-        );
+          const content = await callWithMessages(
+            [
+              { content: 'cleared', pluginState: { todos }, role: 'tool' },
+              { content: 'Continue', role: 'user' },
+            ],
+            stateWithLobeAgent(),
+          );
 
-        expect(content).not.toContain('<todo_context>');
-        expect(content).not.toContain('Stale metadata task');
-        expect(mockFindPlanDocuments).not.toHaveBeenCalled();
-      });
+          expect(content).not.toContain('<todo_context>');
+          expect(content).not.toContain('Stale metadata task');
+          expect(mockFindPlanDocuments).not.toHaveBeenCalled();
+        },
+      );
 
       it.each([
         {
@@ -5391,7 +5391,7 @@ describe('RuntimeExecutors', { timeout: 60_000 }, () => {
           messages: [{ content: 'Hello', role: 'user' }],
           model: 'gpt-4',
           parentMessageId: 'parent-msg-123',
-          provider: 'lobehub',
+          provider: BRANDING_PROVIDER,
           tools: [],
         },
         type: 'call_llm' as const,

--- a/apps/server/src/services/aico/brandingProvider.test.ts
+++ b/apps/server/src/services/aico/brandingProvider.test.ts
@@ -1,0 +1,31 @@
+import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { describe, expect, it } from 'vitest';
+
+import { AicoManagedPolicy } from './managedPolicy';
+
+/**
+ * `BRANDING_PROVIDER` is a provider **id**, compared against real provider keys
+ * — not a display name. It previously defaulted to `'official'`, which matched
+ * no provider anywhere, so every `provider === BRANDING_PROVIDER` guard was
+ * permanently false: the deprecated-managed-model rejection in the image/video
+ * routers never fired, `noRetryProviders` never matched, and managed pricing
+ * checks never applied.
+ *
+ * Nothing else catches that, because a wrong id fails silently — the guards just
+ * never run. This pins the default to an id the managed layer actually knows.
+ */
+describe('BRANDING_PROVIDER is a real managed provider id', () => {
+  it('is recognised by the managed-provider guard', () => {
+    expect(AicoManagedPolicy.isManagedProvider(BRANDING_PROVIDER)).toBe(true);
+  });
+
+  it('resolves to a runtime provider that can actually serve traffic', () => {
+    expect(AicoManagedPolicy.resolveRuntimeProvider(BRANDING_PROVIDER)).toBe('openrouter');
+  });
+
+  it('defaults to the branded alias rather than the raw upstream provider', () => {
+    // Guards against silently collapsing the branded alias into 'openrouter',
+    // which would change what aicoBilling persists as providerId.
+    expect(BRANDING_PROVIDER).toBe('aico');
+  });
+});

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -113,9 +113,18 @@ export const BRANDING_EMAIL = {
   ),
 };
 
+/**
+ * Provider **id** of the managed offering — compared against real provider keys,
+ * not a display name (that's {@link BRANDING_NAME}).
+ *
+ * Defaults to `aico`, the branded alias that `managedPolicy` / `chatGuard`
+ * resolve to `openrouter` and that `aicoBilling` persists as `providerId`. The
+ * previous default, `official`, matched no provider anywhere, so every
+ * `provider === BRANDING_PROVIDER` guard was permanently false.
+ */
 export const BRANDING_PROVIDER = brandingValue(
   process.env.BRANDING_PROVIDER ?? process.env.NEXT_PUBLIC_BRANDING_PROVIDER,
-  'official',
+  'aico',
 );
 
 export const APPLE_APP_STORE_ID = '';


### PR DESCRIPTION
Fixes issue 5: `BRANDING_PROVIDER` defaulted to a provider id that does not exist.

> [!IMPORTANT]
> **Stacked on #342** — based on `fix/branding-env-spa-bundle`, not `canary`, because both PRs edit `branding.ts`. Merge #342 first; this PR's base will then retarget to `canary` automatically. Review only the top commit.

### The problem

`BRANDING_PROVIDER` defaulted to `'official'`. There is no `official` provider under `packages/model-runtime/src/providers/`, and it's set in no env example (`.env.example` had only a commented-out `# BRANDING_PROVIDER=official`). Every `provider === BRANDING_PROVIDER` guard was therefore permanently false — and it failed *silently*, because the guards simply never ran:

- [image/index.ts:121](apps/server/src/routers/lambda/image/index.ts:121) and [video/index.ts:117](apps/server/src/routers/lambda/video/index.ts:117) never rejected retired managed model ids, so callers got an opaque downstream failure instead of `LobeHubModelDeprecated`.
- [ServerLLMTransport.ts:53](apps/server/src/modules/AgentRuntime/adapters/ServerLLMTransport.ts:53) — `noRetryProviders: [BRANDING_PROVIDER]` never matched, so managed-provider errors were retried instead of failing fast.
- Managed pricing / UI checks in [useModelDetailPanel.ts:321](src/features/ModelSwitchPanel/hooks/useModelDetailPanel.ts:321) and [aiInfra/index.ts:503](packages/database/src/repositories/aiInfra/index.ts:503) never applied.

### Why `'aico'`

It's the id the code already implements: [managedPolicy.ts:62-66](apps/server/src/services/aico/managedPolicy.ts:62) and [chatGuard.ts:36-43](apps/server/src/services/aico/chatGuard.ts:36) treat `'aico'` as the branded alias resolving to `'openrouter'`, and [aicoBilling.ts:371](apps/server/src/routers/lambda/aicoBilling.ts:371) **persists** `providerId: 'aico'` to the database.

`BRANDING_PROVIDER` is a provider **id** compared against real provider keys, not a display name — "Panafor" is the brand name (`BRANDING_NAME`). Keeping the two separate means no data migration for existing rows. `.env.example` now says this explicitly, since the old comment invited exactly this confusion.

### Two long-broken tests, now meaningful

`RuntimeExecutors.test.ts` had two failing tests hardcoding `provider: 'lobehub'` — upstream's branding provider. They've been red in this fork ever since the default diverged, and they are precisely the tests covering the retry guard. One was retrying 6 times and asserting it shouldn't. They now use `BRANDING_PROVIDER` and pass: **145/147 → 147/147**.

### Reviewer notes

- `ProviderMenu/Item.tsx` keeps its explicit `id === 'aico'` branch. My plan called for removing it as a workaround, but on reading it's a union of *all* branded runtime provider ids — it stays correct if an operator overrides `BRANDING_PROVIDER`, so removing it would add risk for no gain.
- `packages/openapi/src/services/provider.service.test.ts:44` mocks `BRANDING_PROVIDER: 'lobehub'` — left alone, it mocks the constant explicitly rather than relying on the default.
- The new `brandingProvider.test.ts` pins the invariant rather than mocking the whole image router: a wrong id produces no error of its own, so the durable guard is "the default must be an id the managed layer recognises."
- `RuntimeExecutors.test.ts` also picked up an incidental prettier reflow of an unrelated `it.each` block, applied automatically by lint-staged.

| Before | After |
| ------ | ----- |
| `BRANDING_PROVIDER = 'official'`, matching no provider | `'aico'`, the alias `managedPolicy` resolves to `openrouter` |
| Retired managed model → opaque downstream error | rejected with `LobeHubModelDeprecated` |
| Managed-provider errors retried (observed: 6 attempts) | fail fast via `noRetryProviders` |

#### Test

```
✓ apps/server/src/services/aico/brandingProvider.test.ts (3 tests)
✓ apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts (147 tests)
```

All 3 new tests fail against the previous `'official'` default. Across `services/aico`, `aiProvider` and `toolExecution`: **11 failures before this change, 8 after** — it fixes 3 and breaks none; the remaining 8 are pre-existing env-dependent tests (`AICO_OPENROUTER_MOCK`, `KEY_VAULTS_SECRET`) unrelated to branding. `bun run check` lint-clean, 153 tests passing. `bun run type-check`: 201 before and after.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

