### PR TITLE
🔧 fix(types): clear all root type errors and gate type-check in CI

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,43 @@
+name: Type Check
+
+# The only quality gate that runs on PRs in this fork: every upstream CI
+# workflow (test.yml, pr-build-*.yml) is workflow_dispatch-only here, which is
+# how the root type-check drifted to 201 errors across 76 files unnoticed.
+# Keep this green — a new type error must fail the PR, not accumulate.
+on:
+  pull_request:
+    branches:
+      - canary
+      - main
+  push:
+    branches:
+      - canary
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Type check
+        run: pnpm type-check
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192

--- a/apps/server/src/routers/lambda/userMemories.ts
+++ b/apps/server/src/routers/lambda/userMemories.ts
@@ -127,7 +127,8 @@ const searchUserMemories = async (
     getServerDefaultFilesConfig().embeddingModel || DEFAULT_USER_MEMORY_EMBEDDING_MODEL_ITEM;
   const billingModel = new AicoBillingModel(ctx.serverDB);
   const billingContext = await resolvePreferredGenerationBilling(
-    (userId) => billingModel.getUserWallet(userId),
+    // getUserWallet resolves `undefined` when absent; the helper's contract is `null`.
+    async (userId) => (await billingModel.getUserWallet(userId)) ?? null,
     ctx.userId,
   );
   const modelRuntime = await initModelRuntimeFromDB(ctx.serverDB, ctx.userId, provider, undefined, {
@@ -176,7 +177,7 @@ const getEmbeddingRuntime = async (serverDB: LobeChatDatabase, userId: string) =
   const resolvedProvider = ENABLE_BUSINESS_FEATURES ? BRANDING_PROVIDER : provider;
   const billingModel = new AicoBillingModel(serverDB);
   const billingContext = await resolvePreferredGenerationBilling(
-    (uid) => billingModel.getUserWallet(uid),
+    async (uid) => (await billingModel.getUserWallet(uid)) ?? null,
     userId,
   );
   const agentRuntime = await initModelRuntimeFromDB(serverDB, userId, resolvedProvider, undefined, {

--- a/apps/server/src/services/aico/aico.phase3.releaseGate.test.ts
+++ b/apps/server/src/services/aico/aico.phase3.releaseGate.test.ts
@@ -337,12 +337,12 @@ describe('Phase 3 Journey 7 — operational recovery probes', () => {
     });
     await keys.ensureUserKey(ownerId);
     const wallet = await billing.getOrCreateUserWallet(ownerId);
-    expect(wallet.openrouterKeyHash).toBeTruthy();
+    expect(wallet.openrouterKeyCiphertext).toBeTruthy();
 
     const prev = process.env.KEY_VAULTS_SECRET;
     process.env.KEY_VAULTS_SECRET = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZXc='; // different
     const keys2 = new AicoOpenRouterKeyService(testDB, client);
-    const plaintext = await keys2.decryptKey(wallet.openrouterKeyHash!);
+    const plaintext = await keys2.decryptKey(wallet.openrouterKeyCiphertext!);
     process.env.KEY_VAULTS_SECRET = prev;
     expect(plaintext).toBeNull();
   });
@@ -431,9 +431,12 @@ describe('Phase 3 Journey 3 — tRPC IDOR (attacker)', () => {
     });
     await expect(
       stranger.allocateMemberCredit({
-        amountUsd: 1,
+        // amountUsd is a decimal USD *string* throughout the billing surface.
+        amountUsd: '1',
         orgId: created.id,
         orgMemberId: 'fake',
+        // Required by the procedure — no silent default (AICO-140).
+        period: 'daily',
       }),
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });

--- a/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
+++ b/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
@@ -267,7 +267,9 @@ describe('Aico OpenRouter failure injection (Phase 2)', () => {
       userId,
     });
     await billing.updateUserOpenRouterKey({
-      encryptedKey: 'not-valid-ciphertext',
+      // The field is `ciphertext`; `encryptedKey` was silently dropped, so the
+      // corrupt value never reached the wallet this test is probing.
+      ciphertext: 'not-valid-ciphertext',
       keyId: 'corrupt-id',
       userId,
     });

--- a/apps/server/src/services/openrouter/getUserRemaining.test.ts
+++ b/apps/server/src/services/openrouter/getUserRemaining.test.ts
@@ -26,6 +26,9 @@ class ControllableOpenRouterClient implements OpenRouterManagementClient {
       limitRemaining: params.limitUsd,
       name: params.name,
       usage: 0,
+      usageDaily: 0,
+      usageMonthly: 0,
+      usageWeekly: 0,
     };
     this.keys.set(hash, row);
     return { ...row };

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -67,7 +67,9 @@ export class AicoOpenRouterKeyService {
     }
     if (this._client) return this._client;
     const created = createOpenRouterManagementClient();
-    (this as { _client: OpenRouterManagementClient })._client = created;
+    // Lazily memoise onto the private field; cast through `unknown` because a
+    // private member never structurally overlaps a public one.
+    (this as unknown as { _client: OpenRouterManagementClient })._client = created;
     return created;
   }
 

--- a/apps/server/src/services/openrouter/remoteManagementClient.test.ts
+++ b/apps/server/src/services/openrouter/remoteManagementClient.test.ts
@@ -8,6 +8,15 @@ import {
   RemoteOpenRouterManagementClient,
 } from './management';
 
+/**
+ * `aicoEnv` is a readonly t3-env object. These tests deliberately mutate it to
+ * exercise the product-vs-control-plane branches; the writes work at runtime,
+ * only the declared type forbids them. Mutability is confined to this view.
+ */
+const mutableAicoEnv = aicoEnv as {
+  -readonly [K in keyof typeof aicoEnv]: (typeof aicoEnv)[K];
+};
+
 vi.mock('@/envs/aico', () => ({
   aicoEnv: {
     AICO_CONTROL_PLANE_SERVICE_TOKEN: undefined as string | undefined,
@@ -112,11 +121,11 @@ describe('RemoteOpenRouterManagementClient', () => {
 describe('createOpenRouterManagementClient product / control-plane rules', () => {
   beforeEach(() => {
     __resetOpenRouterManagementClientForTests();
-    aicoEnv.AICO_CONTROL_PLANE_SERVICE_TOKEN = undefined;
-    aicoEnv.AICO_CONTROL_PLANE_URL = undefined;
-    aicoEnv.AICO_IS_CONTROL_PLANE = false;
-    aicoEnv.AICO_OPENROUTER_MOCK = false;
-    aicoEnv.OPENROUTER_MANAGEMENT_API_KEY = undefined;
+    mutableAicoEnv.AICO_CONTROL_PLANE_SERVICE_TOKEN = undefined;
+    mutableAicoEnv.AICO_CONTROL_PLANE_URL = undefined;
+    mutableAicoEnv.AICO_IS_CONTROL_PLANE = false;
+    mutableAicoEnv.AICO_OPENROUTER_MOCK = false;
+    mutableAicoEnv.OPENROUTER_MANAGEMENT_API_KEY = undefined;
   });
 
   afterEach(() => {
@@ -125,8 +134,8 @@ describe('createOpenRouterManagementClient product / control-plane rules', () =>
   });
 
   it('uses remote client when control plane URL + token are set', () => {
-    aicoEnv.AICO_CONTROL_PLANE_URL = 'http://localhost:3020';
-    aicoEnv.AICO_CONTROL_PLANE_SERVICE_TOKEN = 'tok';
+    mutableAicoEnv.AICO_CONTROL_PLANE_URL = 'http://localhost:3020';
+    mutableAicoEnv.AICO_CONTROL_PLANE_SERVICE_TOKEN = 'tok';
     const client = createOpenRouterManagementClient({});
     expect(client).toBeInstanceOf(RemoteOpenRouterManagementClient);
   });
@@ -135,7 +144,7 @@ describe('createOpenRouterManagementClient product / control-plane rules', () =>
     const prevNode = process.env.NODE_ENV;
     try {
       (process.env as { NODE_ENV?: string }).NODE_ENV = 'production';
-      aicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-should-not-be-here';
+      mutableAicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-should-not-be-here';
       expect(() => createOpenRouterManagementClient({})).toThrow(
         /must not be set on the product server/,
       );
@@ -148,7 +157,7 @@ describe('createOpenRouterManagementClient product / control-plane rules', () =>
     const prevNode = process.env.NODE_ENV;
     try {
       (process.env as { NODE_ENV?: string }).NODE_ENV = 'development';
-      aicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-should-not-be-here';
+      mutableAicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-should-not-be-here';
       expect(() => createOpenRouterManagementClient({})).toThrow(
         /must not be set on the product server/,
       );
@@ -168,8 +177,8 @@ describe('createOpenRouterManagementClient product / control-plane rules', () =>
   });
 
   it('control plane may use local management key', () => {
-    aicoEnv.AICO_IS_CONTROL_PLANE = true;
-    aicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-control';
+    mutableAicoEnv.AICO_IS_CONTROL_PLANE = true;
+    mutableAicoEnv.OPENROUTER_MANAGEMENT_API_KEY = 'sk-or-v1-control';
     const client = createOpenRouterManagementClient({});
     expect(client.constructor.name).toContain('Http');
   });

--- a/apps/server/src/services/sms/impls/debug.otpLogging.test.ts
+++ b/apps/server/src/services/sms/impls/debug.otpLogging.test.ts
@@ -31,6 +31,6 @@ describe('SmsService AUTH_SMS_DEBUG_OTP production gate (MON-001)', () => {
     vi.stubEnv('AUTH_SMS_DEBUG_OTP', '1');
     const { SmsService } = await import('../index');
     const service = new SmsService();
-    expect((service as { debugMirror: unknown }).debugMirror).toBeNull();
+    expect((service as unknown as { debugMirror: unknown }).debugMirror).toBeNull();
   });
 });

--- a/apps/server/src/services/sms/impls/productionFailClosed.test.ts
+++ b/apps/server/src/services/sms/impls/productionFailClosed.test.ts
@@ -9,14 +9,14 @@ describe('createSmsServiceImpl production fail-closed', () => {
   it('throws in production without KAVENEGAR_API_KEY', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('KAVENEGAR_API_KEY', '');
-    const { createSmsServiceImpl } = await import('./impls/index');
+    const { createSmsServiceImpl } = await import('./index');
     expect(() => createSmsServiceImpl()).toThrow(/KAVENEGAR_API_KEY/);
   });
 
   it('refuses Debug impl in production', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('KAVENEGAR_API_KEY', 'test-key');
-    const { createSmsServiceImpl, SmsImplType } = await import('./impls/index');
+    const { createSmsServiceImpl, SmsImplType } = await import('./index');
     expect(() => createSmsServiceImpl(SmsImplType.Debug)).toThrow(/SMS_DEBUG_FORBIDDEN/);
   });
 });

--- a/locales/en-US/messenger.json
+++ b/locales/en-US/messenger.json
@@ -192,7 +192,7 @@
   "verify.error.unlinkBeforeRelink": "This {{appName}} account is already linked to another account on this platform. Disconnect it in Settings → Messenger before linking a new one.",
   "verify.signInCta": "Sign in to continue",
   "verify.signInRequired": "Please sign in to {{appName}} to confirm the link.",
-  "verify.success.backTo{{appName}}": "Back to {{appName}}",
+  "verify.success.backToApp": "Back to {{appName}}",
   "verify.success.description": "Your account is now connected to {{platform}}. Open {{platform}} and send your first message.",
   "verify.success.openBot": "Open in {{platform}}",
   "verify.success.title": "Linked successfully!"

--- a/locales/fa-IR/messenger.json
+++ b/locales/fa-IR/messenger.json
@@ -192,7 +192,7 @@
   "verify.error.unlinkBeforeRelink": "این حساب پاناچت قبلاً به یک حساب تلگرام دیگر متصل شده است. ابتدا آن را در تنظیمات → پیام‌رسان قطع کنید تا بتوانید حساب جدیدی را متصل کنید.",
   "verify.signInCta": "برای ادامه وارد شوید",
   "verify.signInRequired": "لطفاً وارد پاناچت شوید تا لینک را تأیید کنید.",
-  "verify.success.backTo{{appName}}": "بازگشت به پاناچت",
+  "verify.success.backToApp": "بازگشت به {{appName}}",
   "verify.success.description": "حساب شما اکنون به {{platform}} متصل شده است. {{platform}} را باز کنید و اولین پیام خود را ارسال کنید.",
   "verify.success.openBot": "باز کردن در {{platform}}",
   "verify.success.title": "با موفقیت لینک شد!"

--- a/locales/fr-FR/messenger.json
+++ b/locales/fr-FR/messenger.json
@@ -192,7 +192,7 @@
   "verify.error.unlinkBeforeRelink": "Ce compte Panachat est déjà lié à un autre compte Telegram. Déconnectez-le dans Paramètres → Messagerie avant d'en lier un nouveau.",
   "verify.signInCta": "Connectez-vous pour continuer",
   "verify.signInRequired": "Veuillez vous connecter à Panachat pour confirmer la liaison.",
-  "verify.success.backTo{{appName}}": "Retour à Panachat",
+  "verify.success.backToApp": "Retour à {{appName}}",
   "verify.success.description": "Votre compte est maintenant connecté à {{platform}}. Ouvrez {{platform}} et envoyez votre premier message.",
   "verify.success.openBot": "Ouvrir dans {{platform}}",
   "verify.success.title": "Liaison réussie !"

--- a/locales/zh-CN/messenger.json
+++ b/locales/zh-CN/messenger.json
@@ -192,7 +192,7 @@
   "verify.error.unlinkBeforeRelink": "此 {{appName}} 账户已链接到当前平台上的另一个账户。请先在 设置 → Messenger 中断开后再链接新账户。",
   "verify.signInCta": "登录以继续",
   "verify.signInRequired": "请登录 {{appName}} 以确认绑定。",
-  "verify.success.backTo{{appName}}": "回到 {{appName}}",
+  "verify.success.backToApp": "回到 {{appName}}",
   "verify.success.description": "你的账号已连接到 {{platform}}。打开 {{platform}} 并发送你的第一条消息。",
   "verify.success.openBot": "在 {{platform}} 中打开",
   "verify.success.title": "绑定成功！"

--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -45,7 +45,21 @@ export const BRANDING_SITE_URL = readBrandingEnv('BRANDING_SITE_URL', '');
 /** Product logo URL used by ProductLogo / metadata. Defaults to the favicon_io PWA icon. */
 export const BRANDING_LOGO_URL = readBrandingEnv('BRANDING_LOGO_URL', '/icons/icon-192x192.png');
 
-export const BRANDING_URL = {
+/**
+ * Unset by default. Typed as optional strings rather than literal `undefined`
+ * so consumers can narrow them (`SOCIAL_URL.discord?.trim()`) and a white-label
+ * deployment can populate them — a literal `undefined` type collapses those
+ * expressions to `never`.
+ */
+type OptionalUrl = string | undefined;
+
+export const BRANDING_URL: {
+  help: OptionalUrl;
+  privacy: OptionalUrl;
+  subscription: OptionalUrl;
+  support: OptionalUrl;
+  terms: OptionalUrl;
+} = {
   help: undefined,
   privacy: undefined,
   subscription: undefined,
@@ -53,7 +67,13 @@ export const BRANDING_URL = {
   terms: undefined,
 };
 
-export const SOCIAL_URL = {
+export const SOCIAL_URL: {
+  discord: OptionalUrl;
+  github: OptionalUrl;
+  medium: OptionalUrl;
+  x: OptionalUrl;
+  youtube: OptionalUrl;
+} = {
   discord: undefined,
   github: undefined,
   medium: undefined,
@@ -61,11 +81,15 @@ export const SOCIAL_URL = {
   youtube: undefined,
 };
 
-export const FILE_URL = {
+export const FILE_URL: { importFromNotionGuide: OptionalUrl } = {
   importFromNotionGuide: undefined,
 };
 
-export const BRANDING_EMAIL = {
+export const BRANDING_EMAIL: {
+  business: string;
+  replyTo: OptionalUrl;
+  support: string;
+} = {
   business: readBrandingEnv('BRANDING_BUSINESS_EMAIL', ''),
   replyTo: undefined,
   support: readBrandingEnv('BRANDING_SUPPORT_EMAIL', ''),

--- a/packages/database/src/models/__tests__/aico.financialConcurrency.test.ts
+++ b/packages/database/src/models/__tests__/aico.financialConcurrency.test.ts
@@ -123,13 +123,15 @@ describe('Aico financial concurrency & money invariants (Phase 2)', () => {
     (serverDB as { transaction: typeof serverDB.transaction }).transaction = async (fn) =>
       originalTransaction(async (tx) => {
         const originalFindFirst = tx.query.organizations.findFirst.bind(tx.query.organizations);
-        tx.query.organizations.findFirst = async (opts) => {
+        // Monkeypatching drizzle's overloaded query builder — the stub only
+        // needs to satisfy the runtime call, not the full generic signature.
+        tx.query.organizations.findFirst = (async (opts: never) => {
           const row = await originalFindFirst(opts);
           if (row && row.id === org.id) {
             return { ...row, walletBalanceMicroUsd: usd(100) };
           }
           return row;
-        };
+        }) as typeof tx.query.organizations.findFirst;
         return fn(tx);
       });
 
@@ -550,7 +552,7 @@ describe('AICO-105 FIN-003 credit/allocate idempotency keys', () => {
       orgId: org.id,
     });
 
-    expect(second.transaction.id).toBe(first.transaction.id);
+    expect(second.transaction!.id).toBe(first.transaction!.id);
     expect(Number(second.organization.walletBalanceMicroUsd)).toBe(usd(10));
   });
 
@@ -575,7 +577,7 @@ describe('AICO-105 FIN-003 credit/allocate idempotency keys', () => {
       periodAmountMicroUsd: usd(10),
     });
 
-    expect(second.transaction.id).toBe(first.transaction.id);
+    expect(second.transaction!.id).toBe(first.transaction!.id);
     const orgRow = await orgModel.getById(org.id);
     expect(Number(orgRow?.walletBalanceMicroUsd)).toBe(usd(40));
     const budget = await orgModel.getMemberBudget(memberA.id);
@@ -619,8 +621,8 @@ describe('AICO-105 FIN-005 wallet tx balance audit trail', () => {
       period: 'daily',
       periodAmountMicroUsd: usd(20),
     });
-    expect(allocated.transaction.balanceBeforeMicroUsd).toBe(usd(50));
-    expect(allocated.transaction.balanceAfterMicroUsd).toBe(usd(30));
+    expect(allocated.transaction!.balanceBeforeMicroUsd).toBe(usd(50));
+    expect(allocated.transaction!.balanceAfterMicroUsd).toBe(usd(30));
 
     const reclaimed = await orgModel.reclaimMemberRemainingCredit({
       createdByUserId: ownerId,

--- a/packages/database/src/models/__tests__/aico.multiOrgMigration.test.ts
+++ b/packages/database/src/models/__tests__/aico.multiOrgMigration.test.ts
@@ -176,8 +176,10 @@ describe('Aico migration & schema safety (Phase 2)', () => {
 
   it('AICO-P1-015: recordUsage can write rows but chat path does not call it (probe after manual record)', async () => {
     await billing.recordUsage({
+      billingSource: 'personal',
       completionTokens: 10,
-      costUsd: 0.01,
+      // recordUsage takes micro-USD, not USD: 0.01 USD = 10_000 micro-USD.
+      costMicroUsd: 10_000,
       modelId: 'openai/gpt-4o-mini',
       promptTokens: 5,
       totalTokens: 15,

--- a/packages/database/src/models/openrouterModelCatalog.ts
+++ b/packages/database/src/models/openrouterModelCatalog.ts
@@ -99,7 +99,9 @@ const EMBEDDING_PROVIDER_CARDS: AiProviderModelListItem[] = EMBEDDING_CATALOG_CA
   pricing: card.pricing,
   releasedAt: card.releasedAt,
   source: AiModelSourceEnum.Remote,
-  type: normalizeAiModelType(card.type),
+  // These are embedding cards by construction; normalizeAiModelType widens to
+  // `string | undefined` for unrecognised input.
+  type: (normalizeAiModelType(card.type) ?? 'embedding') as AiProviderModelListItem['type'],
 }));
 
 export class OpenRouterModelCatalogModel {

--- a/packages/database/src/models/organization.ts
+++ b/packages/database/src/models/organization.ts
@@ -474,9 +474,15 @@ export class OrganizationModel {
     });
   };
 
+  /**
+   * Adds or re-roles a member. Despite the name this is the only membership
+   * creation path, so the role accepts the full OrgMemberRole union (matching
+   * updateMemberRole) rather than just the manager roles; it already writes
+   * whatever role is passed and defaults to 'admin'.
+   */
   assignManager = async (params: {
     orgId: string;
-    role?: 'owner' | 'admin';
+    role?: OrgMemberRole;
     userId: string;
   }): Promise<OrganizationMemberItem> => {
     const role = params.role ?? 'admin';

--- a/packages/locales/src/default/messenger.ts
+++ b/packages/locales/src/default/messenger.ts
@@ -256,7 +256,7 @@ export default {
     'This {{appName}} account is already linked to another account on this platform. Disconnect it in Settings → Messenger before linking a new one.',
   'verify.signInCta': 'Sign in to continue',
   'verify.signInRequired': 'Please sign in to {{appName}} to confirm the link.',
-  'verify.success.backTo{{appName}}': 'Back to {{appName}}',
+  'verify.success.backToApp': 'Back to {{appName}}',
   'verify.success.description':
     'Your account is now connected to {{platform}}. Open {{platform}} and send your first message.',
   'verify.success.openBot': 'Open in {{platform}}',

--- a/packages/locales/src/resources.ts
+++ b/packages/locales/src/resources.ts
@@ -132,7 +132,9 @@ export const localeOptions: LocaleOptions = [
 ] as LocaleOptions;
 
 export const visibleLocaleOptions = localeOptions.filter((option) =>
-  VISIBLE_LOCALES.includes(option.value),
+  // VISIBLE_LOCALES is a narrow tuple, so `includes` would only accept its own
+  // members; widen it to test membership across all locale options.
+  (VISIBLE_LOCALES as readonly string[]).includes(option.value),
 );
 
 export const supportLocales: string[] = [...locales, 'en', 'zh'];

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.ts
@@ -331,7 +331,7 @@ async function generateByChatModel(
     }
   }
 
-  const response = await client.chat.completions.create({
+  const response = (await client.chat.completions.create({
     messages: [
       {
         content,
@@ -348,7 +348,12 @@ async function generateByChatModel(
     // cost badge (which reads modelUsage.cost) has something to show. Ignored
     // by OpenAI-compatible endpoints that don't recognize the field.
     usage: { include: true },
-  } as Parameters<typeof client.chat.completions.create>[0]);
+    // `stream: false` above is erased by the params cast, so the overload
+    // resolves to `ChatCompletion | Stream<ChatCompletionChunk>`. This call is
+    // non-streaming by construction.
+  } as Parameters<
+    typeof client.chat.completions.create
+  >[0])) as OpenAI.Chat.Completions.ChatCompletion;
 
   log('Chat API response: %O', response);
 

--- a/packages/model-runtime/src/core/usageConverters/utils/resolveImageSinglePrice.ts
+++ b/packages/model-runtime/src/core/usageConverters/utils/resolveImageSinglePrice.ts
@@ -1,4 +1,4 @@
-import type { Pricing } from 'model-bank';
+import type { Pricing, PricingUnit } from 'model-bank';
 
 export interface ImageSinglePriceResult {
   approximatePrice?: number;
@@ -49,7 +49,10 @@ export const resolveImageSinglePrice = (pricing?: Pricing): ImageSinglePriceResu
   // Estimate a rough per-image cost so Create still shows *something* instead
   // of nothing; this is deliberately an approximation, never an exact price.
   const imageOutputUnit = pricing.units.find(
-    (unit) => unit.name === 'imageOutput' && unit.strategy === 'fixed',
+    // Predicate form so the result narrows to the fixed-rate variant; a plain
+    // boolean callback leaves the union intact and `rate` unreachable.
+    (unit): unit is Extract<PricingUnit, { strategy: 'fixed' }> =>
+      unit.name === 'imageOutput' && unit.strategy === 'fixed',
   );
   if (imageOutputUnit && imageOutputUnit.unit === 'millionTokens') {
     return {

--- a/packages/model-runtime/src/providers/openrouter/index.test.ts
+++ b/packages/model-runtime/src/providers/openrouter/index.test.ts
@@ -60,7 +60,9 @@ describe('LobeOpenRouterAI - custom features', () => {
       // Deliberately NOT a custom createImage: the factory does not forward
       // `pricingContext` to custom impls, so routing through the shared
       // createOpenAICompatibleImage is what keeps billing behaviour identical.
-      expect(params.createImage).toBeUndefined();
+      // Accessed through a widened view: the property is intentionally absent
+      // from the params type, which is exactly what this asserts.
+      expect((params as { createImage?: unknown }).createImage).toBeUndefined();
     });
 
     it('should have chatCompletion configuration', () => {

--- a/packages/model-runtime/src/providers/openrouter/openRouterPricing.ts
+++ b/packages/model-runtime/src/providers/openrouter/openRouterPricing.ts
@@ -346,6 +346,9 @@ interface VideoSkuRate {
   score: number;
 }
 
+/** A SKU row before the rate has been proven numeric. */
+type VideoSkuCandidate = Omit<VideoSkuRate, 'rate'> & { rate: number | undefined };
+
 const comboKey = (resolution?: string, generateAudio?: boolean) =>
   `${resolution ?? ''}|${generateAudio === undefined ? '' : String(generateAudio)}`;
 
@@ -455,9 +458,12 @@ export const resolveOpenRouterVideoPricing = (
   const entries = Object.entries(model.pricing_skus ?? {});
   const defaultResolution = getDefaultVideoResolution(model.supported_resolutions);
 
-  const secondCandidates: VideoSkuRate[] = entries
+  // Typed as candidates, not VideoSkuRate: `rate` is only proven numeric by the
+  // predicate filter below, and the optional props must stay optional for that
+  // predicate to be assignable to its parameter.
+  const secondCandidates = entries
     .filter(([key]) => isVideoSecondSku(key))
-    .map(([key, value]) => ({
+    .map(([key, value]): VideoSkuCandidate => ({
       generateAudio: extractSkuAudio(key),
       rate: priceFromVideoSecondSku(key, value),
       resolution: extractSkuResolution(key),
@@ -481,9 +487,9 @@ export const resolveOpenRouterVideoPricing = (
     };
   }
 
-  const tokenCandidates: VideoSkuRate[] = entries
+  const tokenCandidates = entries
     .filter(([key]) => isVideoTokenSku(key))
-    .map(([key, value]) => ({
+    .map(([key, value]): VideoSkuCandidate => ({
       generateAudio: extractSkuAudio(key),
       rate: formatPrice(value),
       resolution: extractSkuResolution(key),

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -707,8 +707,11 @@ const processModelCard = (
  * @param provider Provider type (optional, used to prioritize matching corresponding local configuration, will only attempt to override enabled from local configuration when provider is provided)
  * @returns Processed model card list
  */
-export const processModelList = async (
-  modelList: Array<{ [key: string]: unknown; id: string }>,
+export const processModelList = async <T extends { id: string }>(
+  // Generic rather than an index-signature shape: `interface` declarations have
+  // no implicit index signature, so provider model-card interfaces are not
+  // assignable to `{ [key: string]: unknown; id: string }`.
+  modelList: T[],
   config: ModelProcessorConfig,
   provider?: ModelProviderKey,
 ): Promise<ChatModelCard[]> => {
@@ -764,8 +767,10 @@ export const processModelList = async (
  * @param providerid Optional provider ID, used to get its local configuration file
  * @returns Processed model card list
  */
-export const processMultiProviderModelList = async (
-  modelList: Array<{ [key: string]: unknown; id: string }>,
+export const processMultiProviderModelList = async <T extends { id: string }>(
+  // Generic for the same reason as processModelList: `interface` declarations
+  // carry no implicit index signature.
+  modelList: T[],
   providerid?: ModelProviderKey,
 ): Promise<ChatModelCard[]> => {
   const { loadModels } =

--- a/packages/trpc/src/lambda/context.test.ts
+++ b/packages/trpc/src/lambda/context.test.ts
@@ -473,7 +473,8 @@ describe('createLambdaContext', () => {
       mockId: process.env.MOCK_DEV_USER_ID,
       nodeEnv: process.env.NODE_ENV,
     };
-    process.env.NODE_ENV = 'development';
+    // NODE_ENV is readonly in the ambient types; the write works at runtime.
+    (process.env as { NODE_ENV?: string }).NODE_ENV = 'development';
     process.env.AICO_IS_CONTROL_PLANE = '1';
     process.env.ENABLE_MOCK_DEV_USER = '1';
     process.env.MOCK_DEV_USER_ID = 'user_mock_admin';
@@ -488,7 +489,7 @@ describe('createLambdaContext', () => {
       expect(context.adminId).toBeNull();
       expect(mockGetSession).not.toHaveBeenCalled();
     } finally {
-      process.env.NODE_ENV = prev.nodeEnv;
+      (process.env as { NODE_ENV?: string }).NODE_ENV = prev.nodeEnv;
       if (prev.isCp === undefined) delete process.env.AICO_IS_CONTROL_PLANE;
       else process.env.AICO_IS_CONTROL_PLANE = prev.isCp;
       if (prev.mock === undefined) delete process.env.ENABLE_MOCK_DEV_USER;

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -30,6 +30,9 @@ const manifest = async (): Promise<MetadataRoute.Manifest> => {
       import('@/libs/metadata/manifest'),
     ]);
 
+  // Next's MetadataRoute.Manifest omits several values the web-app-manifest spec
+  // allows (notably display_override: 'tabbed' and cache_busting_mode), so the
+  // generated manifest is wider than its type.
   return manifestModule.generate({
     description: `${BRANDING_NAME} is a work-and-lifestyle space to find, build, and collaborate with agent teams that grow with you.`,
     icons: [
@@ -100,7 +103,7 @@ const manifest = async (): Promise<MetadataRoute.Manifest> => {
             url: '/screenshots/shot-5.desktop.png',
           },
         ],
-  });
+  }) as MetadataRoute.Manifest;
 };
 
 export default manifest;

--- a/src/business/client/features/AccountDeletion/index.tsx
+++ b/src/business/client/features/AccountDeletion/index.tsx
@@ -15,7 +15,7 @@ export default function AccountDeletion() {
 
   return (
     <Flexbox gap={12} style={{ maxWidth: 420 }}>
-      <Text strong>{t('danger.clear.confirm')}</Text>
+      <Text strong>{t('accountDeletion.title')}</Text>
       <Text type="secondary">
         Deleting your account blocks reusing the same phone/email for another free trial.
       </Text>

--- a/src/business/client/resolveAicoErrorMessage.ts
+++ b/src/business/client/resolveAicoErrorMessage.ts
@@ -7,7 +7,17 @@ import { toast } from '@lobehub/ui/base-ui';
 
 import { buildPhoneVerifyRedirectUrl } from '@/libs/better-auth/phone';
 
-type LooseT = (key: string, options?: { defaultValue?: string }) => string;
+/**
+ * Structural stand-in for react-i18next's `TFunction`.
+ *
+ * `TFunction<Ns>` is a heavily overloaded type whose key parameter is a literal
+ * union of that namespace's keys, so it is not assignable to a plain
+ * `(key: string) => string`. These helpers only ever forward a key and options
+ * through, and are called from many namespaces, so the parameters are
+ * intentionally loose — the useful contract is the `string` return.
+ */
+
+type LooseT = (key: any, options?: any) => string;
 
 /** Pull a likely error-code string out of TRPC / Error / ChatMessageError shapes. */
 export const extractErrorCodeCandidate = (error: unknown): string => {

--- a/src/components/Branding/BrandedModelIcon.tsx
+++ b/src/components/Branding/BrandedModelIcon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ModelIcon } from '@lobehub/icons';
-import { memo } from 'react';
+import { type CSSProperties, memo } from 'react';
 
 import { ProductLogo } from '@/components/Branding/ProductLogo';
 
@@ -10,6 +10,8 @@ import { isBrandedOpenRouterModelId } from './brandedModelId';
 type BrandedModelIconProps = {
   model: string;
   size?: number;
+  /** Forwarded to the rendered icon — call sites use it for layout/spacing. */
+  style?: CSSProperties;
   type?: 'mono' | 'color' | 'avatar';
 };
 
@@ -17,18 +19,18 @@ type BrandedModelIconProps = {
  * Model avatar that swaps OpenRouter-namespace models (`openrouter/...`)
  * to the product favicon when custom branding is on.
  */
-export const BrandedModelIcon = memo<BrandedModelIconProps>(({ model, size = 32, type }) => {
+export const BrandedModelIcon = memo<BrandedModelIconProps>(({ model, size = 32, style, type }) => {
   if (isBrandedOpenRouterModelId(model)) {
     return (
       <ProductLogo
         size={size}
-        style={{ flex: 'none', height: size, width: size }}
+        style={{ flex: 'none', height: size, width: size, ...style }}
         type={type === 'mono' ? 'mono' : 'flat'}
       />
     );
   }
 
-  return <ModelIcon model={model} size={size} type={type} />;
+  return <ModelIcon model={model} size={size} style={style} type={type} />;
 });
 
 BrandedModelIcon.displayName = 'BrandedModelIcon';

--- a/src/components/Branding/BrandedProviderCombine.tsx
+++ b/src/components/Branding/BrandedProviderCombine.tsx
@@ -19,7 +19,10 @@ type BrandedProviderCombineProps = ComponentProps<typeof ProviderCombine> & {
  * Every other provider keeps its own vendor wordmark.
  */
 export const BrandedProviderCombine = memo<BrandedProviderCombineProps>(
-  ({ provider, size = 24, ...rest }) => {
+  // `type` is pulled out of rest: ProviderCombine accepts 'color', which
+  // ProductLogo does not, and forwarding it would also override the 'flat' we
+  // deliberately pass below.
+  ({ provider, size = 24, type: _type, ...rest }) => {
     const branded =
       isBrandedOpenRouterProvider(provider) ||
       Boolean(isCustomBranding && provider && provider.trim().toLowerCase() === 'lobehub');

--- a/src/features/AicoBilling/BillingSourceSwitcher.tsx
+++ b/src/features/AicoBilling/BillingSourceSwitcher.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import { toastAicoError } from '@/business/client/resolveAicoErrorMessage';
 import ActionDropdown from '@/features/ChatInput/ActionBar/components/ActionDropdown';
+import { type LooseTFunction } from '@/types/looseTranslation';
 
 import { type AicoBillingContext, type AicoBillingSource, formatRemainingUsd } from './types';
 import { useAicoBillingSources } from './useAicoBillingSources';
@@ -60,10 +61,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const sourceLabel = (
-  source: AicoBillingSource,
-  t: (key: string, opts?: Record<string, string>) => string,
-): string => {
+const sourceLabel = (source: AicoBillingSource, t: LooseTFunction): string => {
   if (source.source === 'personal') return t('billing.personal');
   return source.organizationName || t('billing.organization');
 };

--- a/src/features/AicoBilling/FxTopupFields.tsx
+++ b/src/features/AicoBilling/FxTopupFields.tsx
@@ -6,6 +6,8 @@ import { type FormInstance } from 'antd/es/form';
 import { createStaticStyles } from 'antd-style';
 import { useTranslation } from 'react-i18next';
 
+import { type LooseTFunction } from '@/types/looseTranslation';
+
 import { groupedNumberInputProps } from './groupedNumberInput';
 
 export type FxTopupChargeField = 'toman' | 'usd';
@@ -99,6 +101,8 @@ export const FxTopupFields = ({
   usdLabelKey = 'wallet.amountUsd',
 }: FxTopupFieldsProps) => {
   const { t } = useTranslation('aico');
+  // Label keys arrive as props, so they are not in the namespace's literal key union.
+  const translate = t as LooseTFunction;
   const amountToman = Form.useWatch('amountToman', form);
   const amountUsd = Form.useWatch('amountUsd', form);
 
@@ -111,7 +115,7 @@ export const FxTopupFields = ({
         {fxSource ? <span className={styles.fxSource}>{fxSource}</span> : null}
       </div>
       <div className={styles.row}>
-        <Form.Item label={t(tomanLabelKey)} name="amountToman" style={{ marginBottom: 0 }}>
+        <Form.Item label={translate(tomanLabelKey)} name="amountToman" style={{ marginBottom: 0 }}>
           <InputNumber
             {...groupedNumberInputProps}
             disabled={disabled}
@@ -121,12 +125,12 @@ export const FxTopupFields = ({
             onChange={(value) => {
               onChargeFieldChange('toman');
               if (value != null && fxRate) {
-                form.setFieldValue('amountUsd', Number((value / fxRate).toFixed(6)));
+                form.setFieldValue('amountUsd', Number((Number(value) / fxRate).toFixed(6)));
               }
             }}
           />
         </Form.Item>
-        <Form.Item label={t(usdLabelKey)} name="amountUsd" style={{ marginBottom: 0 }}>
+        <Form.Item label={translate(usdLabelKey)} name="amountUsd" style={{ marginBottom: 0 }}>
           <InputNumber
             {...groupedNumberInputProps}
             disabled={disabled}
@@ -136,7 +140,7 @@ export const FxTopupFields = ({
             onChange={(value) => {
               onChargeFieldChange('usd');
               if (value != null && fxRate) {
-                form.setFieldValue('amountToman', Math.floor(value * fxRate));
+                form.setFieldValue('amountToman', Math.floor(Number(value) * fxRate));
               }
             }}
           />

--- a/src/features/AicoBilling/useFundsBlockedComposerCue.test.ts
+++ b/src/features/AicoBilling/useFundsBlockedComposerCue.test.ts
@@ -4,13 +4,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useFundsBlockedComposerCue } from './useFundsBlockedComposerCue';
 
 const playFundsBlockedSound = vi.fn();
-const useAicoBillingChatGate = vi.fn(() => ({
-  blocked: false,
-  blockReason: null,
-  showTrialCta: false,
-  trialActive: false,
-  trialAvailable: false,
-}));
+const useAicoBillingChatGate = vi.fn(
+  (): {
+    blocked: boolean;
+    // Widened from the default-return `null` so tests can supply a real reason.
+    blockReason: string | null;
+    showTrialCta: boolean;
+    trialActive: boolean;
+    trialAvailable: boolean;
+  } => ({
+    blocked: false,
+    blockReason: null,
+    showTrialCta: false,
+    trialActive: false,
+    trialAvailable: false,
+  }),
+);
 const useFundsBlockedSoundEnabled = vi.fn(() => false);
 const syncFundsBlockedSoundFlagFromUrl = vi.fn();
 

--- a/src/features/AicoWallet/index.tsx
+++ b/src/features/AicoWallet/index.tsx
@@ -29,6 +29,7 @@ import { useClientDataSWR } from '@/libs/swr';
 import { lambdaClient } from '@/libs/trpc/client';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
+import { type LooseTFunction } from '@/types/looseTranslation';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   sourceActive: css`
@@ -64,7 +65,7 @@ const sourceToContext = (source: AicoBillingSource): AicoBillingContext =>
     ? { source: 'personal' }
     : { organizationId: source.organizationId, source: 'organization' };
 
-const sourceTitle = (source: AicoBillingSource, t: (key: string) => string): string => {
+const sourceTitle = (source: AicoBillingSource, t: LooseTFunction): string => {
   if (source.source === 'personal') return t('billing.personal');
   return source.organizationName || t('billing.organization');
 };

--- a/src/features/Auth/LegalDocument/index.tsx
+++ b/src/features/Auth/LegalDocument/index.tsx
@@ -7,6 +7,8 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { type LooseTFunction } from '@/types/looseTranslation';
+
 const styles = createStaticStyles(({ css, cssVar }) => ({
   back: css`
     display: inline-block;
@@ -96,6 +98,9 @@ const LegalDocument = memo<LegalDocumentProps>(({ kind }) => {
     orgName: ORG_NAME,
     supportEmail: BRANDING_EMAIL.support || undefined,
   };
+  // Section keys are built at runtime from `kind`/`section`, so they are not in
+  // the namespace's literal key union that `TFunction` requires.
+  const translate = t as LooseTFunction;
 
   return (
     <Flexbox className={styles.shell} gap={24}>
@@ -130,9 +135,9 @@ const LegalDocument = memo<LegalDocumentProps>(({ kind }) => {
         return (
           <section className={styles.section} key={section}>
             <Text strong style={{ fontSize: 16 }}>
-              {t(titleKey, vars)}
+              {translate(titleKey, vars)}
             </Text>
-            <p className={styles.body}>{t(bodyKey, vars)}</p>
+            <p className={styles.body}>{translate(bodyKey, vars)}</p>
           </section>
         );
       })}

--- a/src/features/Auth/SignIn/useSignIn.ts
+++ b/src/features/Auth/SignIn/useSignIn.ts
@@ -19,6 +19,7 @@ import {
   normalizeIranianPhoneNumber,
 } from '@/libs/better-auth/phone';
 import { isBuiltinProvider, normalizeProviderId } from '@/libs/better-auth/utils/client';
+import { type LooseTFunction } from '@/types/looseTranslation';
 import { buildOnboardingRedirectUrl, sanitizeRedirectPath } from '@/utils/onboardingRedirect';
 
 import { EMAIL_REGEX, USERNAME_REGEX } from './SignInEmailStep';
@@ -42,11 +43,7 @@ interface ResolvedEmailResult {
   identifierType: 'email' | 'username';
 }
 
-const mapPhoneOtpError = (
-  code: string | undefined,
-  fallback: string,
-  t: (key: string) => string,
-) => {
+const mapPhoneOtpError = (code: string | undefined, fallback: string, t: LooseTFunction) => {
   switch (code) {
     case 'INVALID_OTP': {
       return t('betterAuth.verifyPhone.errors.invalidOtp');

--- a/src/features/Auth/VerifyPhone/useVerifyPhone.ts
+++ b/src/features/Auth/VerifyPhone/useVerifyPhone.ts
@@ -11,6 +11,7 @@ import {
   formatIranianPhoneForDisplay,
   normalizeIranianPhoneNumber,
 } from '@/libs/better-auth/phone';
+import { type LooseTFunction } from '@/types/looseTranslation';
 import { sanitizeRedirectPath } from '@/utils/onboardingRedirect';
 
 type Step = 'phone' | 'otp';
@@ -24,7 +25,7 @@ type SessionUserPhone = {
   phoneNumberVerified?: boolean | null;
 };
 
-const mapOtpError = (code: string | undefined, fallback: string, t: (key: string) => string) => {
+const mapOtpError = (code: string | undefined, fallback: string, t: LooseTFunction) => {
   switch (code) {
     case 'INVALID_OTP': {
       return t('betterAuth.verifyPhone.errors.invalidOtp');

--- a/src/features/AuthShell/createAuthI18n.ts
+++ b/src/features/AuthShell/createAuthI18n.ts
@@ -103,7 +103,10 @@ const loadFaNamespace = async (ns: AuthI18nNamespace) => {
 };
 
 /** Exported for regression tests — auth SPA must load fa-IR / zh-CN, not fall back to English. */
-export const loadAuthNamespace = async (lng: string, ns: string) => {
+export const loadAuthNamespace = async (
+  lng: string,
+  ns: string,
+): Promise<Record<string, unknown>> => {
   const safeNamespace = isAllowedNamespace(ns) ? ns : 'auth';
   const normalizedLocale = normalizeLocale(lng);
   const english = defaultResources[safeNamespace] as Record<string, unknown>;

--- a/src/features/CommandMenu/MainMenu.tsx
+++ b/src/features/CommandMenu/MainMenu.tsx
@@ -174,22 +174,28 @@ const MainMenu = memo(() => {
         >
           {t('cmdk.submitIssue')}
         </CommandItem>
-        <CommandItem
-          icon={<Star />}
-          keywords={t('cmdk.keywords.starGitHub').split(' ')}
-          value="star-github"
-          onSelect={() => handleExternalLink(SOCIAL_URL.github)}
-        >
-          {t('cmdk.starOnGitHub')}
-        </CommandItem>
-        <CommandItem
-          icon={<DiscordIcon />}
-          keywords={t('cmdk.keywords.discord').split(' ')}
-          value="discord"
-          onSelect={() => handleExternalLink(SOCIAL_URL.discord)}
-        >
-          {t('cmdk.communitySupport')}
-        </CommandItem>
+        {/* SOCIAL_URL entries are unset unless a deployment configures them —
+            don't offer a command that opens nowhere. */}
+        {SOCIAL_URL.github && (
+          <CommandItem
+            icon={<Star />}
+            keywords={t('cmdk.keywords.starGitHub').split(' ')}
+            value="star-github"
+            onSelect={() => handleExternalLink(SOCIAL_URL.github as string)}
+          >
+            {t('cmdk.starOnGitHub')}
+          </CommandItem>
+        )}
+        {SOCIAL_URL.discord && (
+          <CommandItem
+            icon={<DiscordIcon />}
+            keywords={t('cmdk.keywords.discord').split(' ')}
+            value="discord"
+            onSelect={() => handleExternalLink(SOCIAL_URL.discord as string)}
+          >
+            {t('cmdk.communitySupport')}
+          </CommandItem>
+        )}
       </Command.Group>
     </>
   );

--- a/src/features/Conversation/Error/resolveManagedKeyErrorDescription.ts
+++ b/src/features/Conversation/Error/resolveManagedKeyErrorDescription.ts
@@ -1,15 +1,15 @@
 import { resolveAicoErrorCode } from '@lobechat/business-const';
-import type { TFunction } from 'i18next';
 
 import { resolveAicoErrorMessage } from '@/business/client/resolveAicoErrorMessage';
 import type { AicoBillingChatBlockReason, AicoBillingSource } from '@/features/AicoBilling/types';
+import { type LooseTFunction } from '@/types/looseTranslation';
 
 export const resolveManagedKeyErrorDescription = (params: {
   activeSource: AicoBillingSource | undefined;
   blockReason: AicoBillingChatBlockReason | null;
   serverErrorCode?: string;
   showTrialCta: boolean;
-  t: TFunction<'aico'>;
+  t: LooseTFunction;
 }): string => {
   const { activeSource, blockReason, serverErrorCode, showTrialCta, t } = params;
 

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -10,6 +10,7 @@ import { BrandedModelIcon } from '@/components/Branding/BrandedModelIcon';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
+import { type LooseTFunction } from '@/types/looseTranslation';
 import { formatNumber } from '@/utils/format';
 
 import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
@@ -82,7 +83,7 @@ type DetailRow = { key: string; label: string; value: string };
 const buildUsageDetailRows = (
   usage: ModelUsage | undefined,
   performance: ModelPerformance | undefined,
-  t: (key: string) => string,
+  t: LooseTFunction,
 ): DetailRow[] => {
   if (!usage) return [];
 
@@ -132,7 +133,9 @@ const buildUsageDetailRows = (
 };
 
 interface MessageCostBadgeProps {
-  metadata?: Record<string, unknown> | null;
+  // Callers pass `MessageMetadata`, an interface — interfaces have no implicit
+  // index signature, so `Record<string, unknown>` does not accept them.
+  metadata?: object | null;
   model?: string | null;
   performance?: ModelPerformance;
   provider?: string | null;

--- a/src/features/Conversation/Messages/components/resolveMessageCost.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageCost.ts
@@ -3,10 +3,12 @@ import { type ModelUsage } from '@lobechat/types';
 /** Prefer structured `usage.cost`; fall back to deprecated flat `metadata.cost`. */
 export const resolveMessageCost = (
   usage?: ModelUsage,
-  metadata?: Record<string, unknown> | null,
+  // `object` rather than `Record<string, unknown>`: callers pass the
+  // `MessageMetadata` interface, which carries no implicit index signature.
+  metadata?: object | null,
 ): number | undefined => {
   if (typeof usage?.cost === 'number' && Number.isFinite(usage.cost)) return usage.cost;
-  const legacy = metadata?.cost;
+  const legacy = (metadata as { cost?: unknown } | null | undefined)?.cost;
   if (typeof legacy === 'number' && Number.isFinite(legacy)) return legacy;
   return undefined;
 };

--- a/src/features/Home/InputArea/EditorInput.test.tsx
+++ b/src/features/Home/InputArea/EditorInput.test.tsx
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import HomeEditorInput from './EditorInput';
 
-const getBusinessChatInputSendAreaPrefix = vi.fn(() => <div data-testid="aico-billing-switcher" />);
+const getBusinessChatInputSendAreaPrefix = vi.fn((..._args: unknown[]) => (
+  <div data-testid="aico-billing-switcher" />
+));
 const useBusinessChatInputAlerts = vi.fn(() => <div data-testid="aico-funds-blocked-alert" />);
 
 vi.mock('@/business/client/hooks/useBusinessChatInputSendAreaPrefix', () => ({

--- a/src/features/Messenger/Verify/Body/shared.tsx
+++ b/src/features/Messenger/Verify/Body/shared.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { BRANDING_NAME } from '@lobechat/business-const';
 import { Block, Flexbox, Icon, Text } from '@lobehub/ui';
 import { Button, Select, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -360,7 +361,7 @@ export const SuccessCard = memo<SuccessCardProps>(({ openBotUrl, platform, platf
           size="large"
           type={openBotUrl ? 'default' : 'primary'}
         >
-          {t('verify.success.backToLobeHub')}
+          {t('verify.success.backToApp', { appName: BRANDING_NAME })}
         </Button>
       </Flexbox>
     </Flexbox>

--- a/src/features/ModelSwitchPanel/components/Footer.tsx
+++ b/src/features/ModelSwitchPanel/components/Footer.tsx
@@ -29,7 +29,7 @@ export const Footer: FC<FooterProps> = ({ onOpenChange }) => {
 
   return (
     <Flexbox className={styles.footer} padding={8}>
-      <Button block icon={<Icon icon={PlusIcon} />} variant="filled" onClick={handleAddModel}>
+      <Button block icon={<Icon icon={PlusIcon} />} type="fill" onClick={handleAddModel}>
         {t('ModelSwitchPanel.addModel.button')}
       </Button>
     </Flexbox>

--- a/src/features/ResourceManager/components/Header/hooks/useNotionImport.tsx
+++ b/src/features/ResourceManager/components/Header/hooks/useNotionImport.tsx
@@ -32,7 +32,11 @@ const useNotionImport = ({
   const handleOpenNotionGuide = useCallback(() => {
     createGuideModal({
       cancelText: t('header.actions.notionGuide.cancel'),
-      cover: <GuideVideo height={269} src={FILE_URL.importFromNotionGuide} width={358} />,
+      // The guide video is optional branding asset — omit the cover when unset
+      // rather than rendering a video with no source.
+      cover: FILE_URL.importFromNotionGuide ? (
+        <GuideVideo height={269} src={FILE_URL.importFromNotionGuide} width={358} />
+      ) : undefined,
       desc: t('header.actions.notionGuide.desc'),
       okText: t('header.actions.notionGuide.ok'),
       onOk: () => {

--- a/src/features/User/UserPanel/useMenu.tsx
+++ b/src/features/User/UserPanel/useMenu.tsx
@@ -123,7 +123,7 @@ export const useMenu = () => {
     },
 
     ...(isLogin ? settings : []),
-    ...businessMenuItems,
+    ...(businessMenuItems ?? []),
     ...(userPanel.showDataImporter && isLogin
       ? [
           {

--- a/src/hooks/useFetchAiImageConfig.test.ts
+++ b/src/hooks/useFetchAiImageConfig.test.ts
@@ -14,8 +14,8 @@ describe('resolvePreferredImageModel', () => {
     const list: EnabledProviderWithModels[] = [
       {
         children: [
-          { displayName: 'Other', id: 'black-forest-labs/flux' },
-          { displayName: 'Nano Banana 2', id: DEFAULT_AI_IMAGE_MODEL },
+          { abilities: {}, displayName: 'Other', id: 'black-forest-labs/flux' },
+          { abilities: {}, displayName: 'Nano Banana 2', id: DEFAULT_AI_IMAGE_MODEL },
         ],
         id: 'openrouter',
         name: 'OpenRouter',
@@ -34,8 +34,8 @@ describe('resolvePreferredImageModel', () => {
     const list: EnabledProviderWithModels[] = [
       {
         children: [
-          { displayName: 'Flux', id: 'flux/schnell' },
-          { displayName: 'Nano Banana', id: 'custom/nano-banana:image' },
+          { abilities: {}, displayName: 'Flux', id: 'flux/schnell' },
+          { abilities: {}, displayName: 'Nano Banana', id: 'custom/nano-banana:image' },
         ],
         id: 'fal',
         name: 'Fal',
@@ -52,7 +52,7 @@ describe('resolvePreferredImageModel', () => {
   it('falls back to the first enabled model when nothing Nano Banana-like exists', () => {
     const list: EnabledProviderWithModels[] = [
       {
-        children: [{ displayName: 'Flux', id: 'flux/schnell' }],
+        children: [{ abilities: {}, displayName: 'Flux', id: 'flux/schnell' }],
         id: 'fal',
         name: 'Fal',
         source: 'builtin',

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -281,13 +281,16 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
           type: 'string',
         },
       },
+      // `fields` is typed against better-auth's base User columns only, so the
+      // phoneNumber plugin's field is not in the allowed key union even though
+      // the mapping is honoured at runtime.
       fields: {
         image: 'avatar',
         // NOTE: use drizzle filed instead of db field, so use fullName instead of full_name
         name: 'fullName',
         // phoneNumber plugin field → existing users.phone column (see migration 0055)
         phoneNumber: 'phone',
-      },
+      } as Record<string, string>,
       modelName: 'users',
     },
 

--- a/src/libs/better-auth/phone.aico.final.test.ts
+++ b/src/libs/better-auth/phone.aico.final.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeIranianPhoneNumber } from '../phone';
+import { normalizeIranianPhoneNumber } from './phone';
 
 describe('normalizeIranianPhoneNumber (final remediation)', () => {
   it('accepts UI local form 09…', () => {

--- a/src/libs/better-auth/plugins/aico-ban-message.ts
+++ b/src/libs/better-auth/plugins/aico-ban-message.ts
@@ -1,4 +1,5 @@
 import { APIError } from 'better-auth/api';
+import { type UserWithRole } from 'better-auth/plugins';
 import { type BetterAuthPlugin } from 'better-auth/types';
 
 /**
@@ -15,7 +16,12 @@ export const aicoBanMessage = (): BetterAuthPlugin => ({
             create: {
               async before(session, ctx) {
                 if (!ctx) return;
-                const user = await ctx.context.internalAdapter.findUserById(session.userId);
+                // findUserById is typed against better-auth's base User, which
+                // has no ban columns — those come from the admin plugin, whose
+                // UserWithRole declares them.
+                const user = (await ctx.context.internalAdapter.findUserById(
+                  session.userId,
+                )) as UserWithRole | null;
                 if (!user?.banned) return;
 
                 if (user.banExpires && new Date(user.banExpires).getTime() < Date.now()) {

--- a/src/libs/better-auth/plugins/auth-abuse-signal.ts
+++ b/src/libs/better-auth/plugins/auth-abuse-signal.ts
@@ -19,7 +19,7 @@ export const authAbuseSignal = (): BetterAuthPlugin => ({
   hooks: {
     before: [
       {
-        matcher: (ctx) => OTP_VERIFY_PATHS.has(ctx.path),
+        matcher: (ctx) => !!ctx.path && OTP_VERIFY_PATHS.has(ctx.path),
         handler: createAuthMiddleware(async (ctx) => {
           const forwarded = ctx.headers?.get?.('x-forwarded-for');
           const ip =

--- a/src/libs/better-auth/plugins/password-policy.ts
+++ b/src/libs/better-auth/plugins/password-policy.ts
@@ -25,7 +25,7 @@ export const passwordPolicy = (): BetterAuthPlugin => ({
   hooks: {
     before: [
       {
-        matcher: (ctx) => PASSWORD_PATHS.has(ctx.path),
+        matcher: (ctx) => !!ctx.path && PASSWORD_PATHS.has(ctx.path),
         handler: createAuthMiddleware(async (ctx) => {
           const password = passwordFromBody(ctx.body as Record<string, unknown> | undefined);
           if (password === null) return;

--- a/src/libs/metadata/manifest.ts
+++ b/src/libs/metadata/manifest.ts
@@ -41,7 +41,7 @@ export class Manifest {
       cache_busting_mode: 'all',
       categories: ['productivity', 'design', 'development', 'education'],
       description,
-      display: 'standalone',
+      display: 'standalone' as const,
       display_override: ['tabbed'],
       edge_side_panel: {
         preferred_width: 480,

--- a/src/routes/(main)/agent/channel/detail/Footer.tsx
+++ b/src/routes/(main)/agent/channel/detail/Footer.tsx
@@ -275,7 +275,15 @@ const Footer = memo<FooterProps>(
                   components={{ bold: <strong /> }}
                   i18nKey="channel.endpointUrlHint"
                   ns="agent"
-                  values={{ fieldName: 'Event Subscription URL', name: platformDef.name }}
+                  // i18next types `values` as an intersection of every key's
+                  // params in the namespace, so a per-key object never satisfies
+                  // it. This key only interpolates fieldName and name.
+                  values={
+                    {
+                      fieldName: 'Event Subscription URL',
+                      name: platformDef.name,
+                    } as never
+                  }
                 />
               }
             />

--- a/src/routes/(main)/community/(detail)/model/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Header.tsx
@@ -34,12 +34,16 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
   const { description, identifier, releasedAt, displayName, type, abilities, contextWindowTokens } =
     useDetailContext();
   const { mobile = isMobile } = useResponsive();
+  // `identifier` is optional on the detail context but always present for a
+  // rendered model page; fall back to an empty id rather than passing undefined
+  // into helpers that require a string.
+  const modelId = identifier ?? '';
   const { t } = useTranslation('models');
 
   return (
     <Flexbox gap={12}>
       <Flexbox horizontal align={'flex-start'} gap={16} width={'100%'}>
-        <BrandedModelIcon model={identifier} size={mobile ? 48 : 64} />
+        <BrandedModelIcon model={modelId} size={mobile ? 48 : 64} />
         <Flexbox
           flex={1}
           gap={4}
@@ -71,9 +75,9 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
                 as={'h1'}
                 ellipsis={{ rows: 1 }}
                 style={{ fontSize: mobile ? 18 : 24, margin: 0 }}
-                title={identifier}
+                title={modelId}
               >
-                {displayName || formatBrandedModelId(identifier)}
+                {displayName || formatBrandedModelId(modelId)}
               </Text>
             </Flexbox>
             <Flexbox horizontal align={'center'} gap={6}>
@@ -81,7 +85,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
             </Flexbox>
           </Flexbox>
           <Flexbox horizontal align={'center'} gap={4}>
-            <span>{formatBrandedModelId(identifier)}</span>
+            <span>{formatBrandedModelId(modelId)}</span>
             <Icon icon={DotIcon} />
             <ModelInfoTags
               directionReverse

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/index.tsx
@@ -18,7 +18,7 @@ const ActionButton = memo(() => {
       <ChatWithModel />
       <ShareButton
         meta={{
-          avatar: <BrandedModelIcon model={identifier} size={64} type={'avatar'} />,
+          avatar: <BrandedModelIcon model={identifier ?? ''} size={64} type={'avatar'} />,
           desc: description,
           hashtags: providers?.map((item) => item.name) || [],
           title: displayName || identifier,

--- a/src/routes/(main)/settings/about/features/About.tsx
+++ b/src/routes/(main)/settings/about/features/About.tsx
@@ -26,6 +26,42 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const About = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { t } = useTranslation('common');
 
+  // SOCIAL_URL entries are undefined unless a deployment configures them, so
+  // filter before rendering — an unbranded build must not show dead links to
+  // upstream's social accounts.
+  const socialItems = [
+    {
+      href: BLOG,
+      icon: SiRss,
+      label: t('blog'),
+      value: 'blog',
+    },
+    {
+      href: SOCIAL_URL.github,
+      icon: SiGithub,
+      label: 'GitHub',
+      value: 'feedback',
+    },
+    {
+      href: SOCIAL_URL.discord,
+      icon: SiDiscord,
+      label: 'Discord',
+      value: 'discord',
+    },
+    {
+      href: SOCIAL_URL.x,
+      icon: SiX as any,
+      label: 'X / Twitter',
+      value: 'x',
+    },
+
+    {
+      href: SOCIAL_URL.youtube,
+      icon: SiYoutube,
+      label: 'YouTube',
+      value: 'youtube',
+    },
+  ].filter((item): item is typeof item & { href: string } => !!item.href);
   return (
     <Form.Group
       collapsible={false}
@@ -37,43 +73,7 @@ const About = memo<{ mobile?: boolean }>(({ mobile }) => {
       <Flexbox gap={20} paddingBlock={20} width={'100%'}>
         <Version mobile={mobile} />
         <Divider style={{ marginBlock: 0 }} />
-        <AboutList
-          grid
-          ItemRender={ItemCard}
-          items={[
-            {
-              href: BLOG,
-              icon: SiRss,
-              label: t('blog'),
-              value: 'blog',
-            },
-            {
-              href: SOCIAL_URL.github,
-              icon: SiGithub,
-              label: 'GitHub',
-              value: 'feedback',
-            },
-            {
-              href: SOCIAL_URL.discord,
-              icon: SiDiscord,
-              label: 'Discord',
-              value: 'discord',
-            },
-            {
-              href: SOCIAL_URL.x,
-              icon: SiX as any,
-              label: 'X / Twitter',
-              value: 'x',
-            },
-
-            {
-              href: SOCIAL_URL.youtube,
-              icon: SiYoutube,
-              label: 'YouTube',
-              value: 'youtube',
-            },
-          ]}
-        />
+        <AboutList grid ItemRender={ItemCard} items={socialItems} />
         <Divider style={{ marginBlock: 0 }} />
         <div className={styles.title}>{t('contact')}</div>
         <AboutList

--- a/src/services/message/__tests__/updateMessageError.superjson.test.ts
+++ b/src/services/message/__tests__/updateMessageError.superjson.test.ts
@@ -74,7 +74,7 @@ describe('MessageService.updateMessageError + superjson', () => {
 
     const payload = vi.mocked(lambdaClient.message.update.mutate).mock.calls[0][0];
     const roundTripped = superjson.deserialize(superjson.serialize(payload)) as typeof payload;
-    expect(roundTripped.value.error.type).toBe('InvalidProviderAPIKey');
+    expect(roundTripped.value.error!.type).toBe('InvalidProviderAPIKey');
   });
 
   it('normalizes error on updateMessage so optimistic paths stay safe', async () => {

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -14,6 +14,7 @@ import {
   type UpdateMessageRAGParams,
   type UpdateMessageResult,
 } from '@lobechat/types';
+import { ChatErrorType } from '@lobechat/types';
 import { type HeatmapsProps } from '@lobehub/charts';
 
 import { lambdaClient } from '@/libs/trpc/client';
@@ -44,7 +45,10 @@ export const toPlainChatMessageError = (
     return {
       body: value instanceof Error ? { message: value.message, name: value.name } : value,
       message: typeof raw.message === 'string' ? raw.message : undefined,
-      type: 'ApplicationRuntimeError',
+      // 'ApplicationRuntimeError' was not a member of ChatErrorType — it exists
+      // nowhere else in the codebase, so this fallback emitted a type no consumer
+      // could match. UnknownChatFetchError is the canonical catch-all.
+      type: ChatErrorType.UnknownChatFetchError,
     };
   }
 

--- a/src/types/looseTranslation.ts
+++ b/src/types/looseTranslation.ts
@@ -1,0 +1,14 @@
+/**
+ * Structural stand-in for react-i18next's `TFunction`.
+ *
+ * `TFunction<Ns>` narrows its key parameter to a literal union of that
+ * namespace's keys, so it is *not* assignable to a hand-written
+ * `(key: string) => string`. Helpers that merely forward a key and options
+ * through — and that are called from several namespaces, or look keys up
+ * dynamically — should accept this instead of declaring their own signature.
+ *
+ * The useful part of the contract is the `string` return; the parameters are
+ * deliberately loose.
+ */
+
+export type LooseTFunction = (key: any, options?: any) => string;

--- a/src/utils/locale/runtimeErrorMessage.ts
+++ b/src/utils/locale/runtimeErrorMessage.ts
@@ -4,7 +4,10 @@ import { getErrorCodeSpec } from '@lobechat/model-runtime';
  * Loose `t` shape that accepts any key / vars — the type-safe key inference in
  * `i18next.CustomTypeOptions` doesn't help here because we look up dynamically.
  */
-type LooseT = (key: string, vars?: Record<string, unknown>) => string;
+// Parameters are intentionally loose: `TFunction<Ns>` narrows its key to that
+// namespace's literal union, so it is not assignable to `(key: string) => string`.
+
+type LooseT = (key: any, vars?: any) => string;
 
 /**
  * Resolve the localized message for an error type, routing between the new


### PR DESCRIPTION
Fixes issue 6: type-checking did not prevent changes from being merged.

> [!IMPORTANT]
> **Stacked on #344** — based on `fix/control-plane-client-typing`, which removed 41 of the errors. Merge #344 first; the base then retargets to `canary` automatically. Review only the top commit.

### Why the errors accumulated

`bun run type-check` exited 1 with **201 errors across 76 files**. The cause is broader than the report suggested: **no quality gate runs on pull requests in this fork at all**. Every upstream CI workflow — `test.yml`, `pr-build-docker.yml`, `pr-build-desktop.yml` — has been switched to `workflow_dispatch`-only here. The only type-check anywhere ran inside `apps/desktop`.

So this adds a new Aico-owned `Type Check` workflow that runs on PRs to `canary`/`main`, and brings the tree to **zero errors** so it can go green immediately.

### Correcting the report

"Most errors are i18n-related `TFunction` noise" did not hold. Measured over the 201: `TS2345` ×65, `TS2339` ×44, `TS2322` ×34, `TS2540` ×13. Roughly a fifth mentioned i18n at all. The rest hid real defects.

### Real bugs found

- **A locale key was mangled by a find/replace.** `'verify.success.backTo{{appName}}'` — a `LobeHub` → `{{appName}}` sweep rewrote the *key name* itself, so the messenger verify button rendered its own raw key as its label. Renamed to `backToApp` and properly interpolated across the default source and 4 locales.
- **`toPlainChatMessageError` emitted a nonexistent error type.** Its fallback was `'ApplicationRuntimeError'`, a string that appears nowhere else in the codebase, so no consumer could ever match it. Now `ChatErrorType.UnknownChatFetchError`.
- **`BrandedModelIcon` silently dropped `style`.** Six call sites passed layout/spacing (`flex`, `boxShadow`, `marginRight`, `zIndex`) that never applied.
- **A base-ui `Button` was given an antd prop.** `variant="filled"` isn't in base-ui's `ButtonProps`, so the fill styling never rendered; the equivalent is `type="fill"`.
- **`keyFailureInjection.test` wrote the wrong field.** `encryptedKey` instead of `ciphertext`, so the corrupt value never reached the wallet the test exists to probe.
- **`multiOrgMigration.test` called a stale `recordUsage` signature** — `costUsd` (the API takes `costMicroUsd`) and no `billingSource`.
- **Two test files imported modules by a wrong relative path** (`'../phone'`, `'./impls/index'`) *from inside the very directories they name*. 8 tests that could not have been running now run and pass.
- **`SOCIAL_URL` / `BRANDING_URL` / `FILE_URL` were typed as literal `undefined`**, so `SOCIAL_URL.discord?.trim()` was `never.trim()`. Typed as optional strings; the About page, command menu and Notion guide now omit unconfigured links rather than rendering dead ones — the right behaviour for a white-label build.

### Recurring causes, fixed once at the source

- `processModelList` / `processMultiProviderModelList` required an index-signature parameter shape. `interface` declarations carry no implicit index signature, which broke **14 provider modules**. Both are now generic over `T extends { id: string }`.
- `TFunction<Ns>` narrows its key to that namespace's literal union, so it never satisfies a hand-written `(key: string) => string`. Added a shared `LooseTFunction` type for helpers that only forward keys through, replacing several ad-hoc signatures.

### Reviewer notes

- Test-only accommodations are deliberately narrow and each carries a comment explaining why: mutable views over readonly t3-env objects, casts through `unknown` for private members, non-null assertions where a test has already established the value. No blanket `any` casts.
- `src/business/client/features/AccountDeletion/index.tsx` gets a one-line key fix here (`danger.clear.confirm` doesn't exist). #340 replaces that component wholesale and will supersede it.
- This PR touches `packages/business/const/src/branding.ts`, as do #342 and #343, but on different lines — expect a clean merge.
- The gate runs type-check only. Adding the test suite would land red, because ~8 pre-existing env-dependent tests (`AICO_OPENROUTER_MOCK`, `KEY_VAULTS_SECRET`) fail locally and in CI. Worth a follow-up.

#### Test

```
bun run type-check   # 201 errors → 0
```

No behaviour regressions. Across every affected test file the failure count is unchanged or lower:

| File | Before | After |
| --- | --- | --- |
| `aico.phase3.releaseGate.test.ts` | 5 failed | **3 failed** |
| `createImage.test.ts` | failing | **41/41 pass** |
| `phone.aico.final` + `productionFailClosed` | couldn't run | **8/8 pass** |
| `userMemories`, `getUserRemaining`, `manifest` | unchanged | unchanged |

`bun run check` reports 3 lint warnings, all pre-existing in lines this PR does not touch.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

