### PR TITLE
🐛 fix(chat): attach direction plugin on editor init so initial text gets the right side

### DIFF
--- a/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.test.tsx
+++ b/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, cleanup, render } from '@testing-library/react';
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+  ParagraphNode,
+  TextNode,
+} from 'lexical';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ReactAutoDirectionPlugin from './ReactAutoDirectionPlugin';
+
+const captured = vi.hoisted(() => ({ handlers: {} as Record<string, (...args: any[]) => void> }));
+
+const mockEditor = vi.hoisted(() => ({
+  getLexicalEditor: vi.fn<() => LexicalEditor | null>(() => null),
+  off: vi.fn(),
+  on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+    captured.handlers[event] = handler;
+  }),
+  once: vi.fn((event: string, handler: (...args: any[]) => void) => {
+    captured.handlers[event] = handler;
+  }),
+}));
+
+vi.mock('@lobehub/editor', () => ({
+  useLexicalComposerContext: () => [mockEditor],
+}));
+
+const createPersianEditor = (): LexicalEditor => {
+  const editor = createEditor({
+    nodes: [ParagraphNode, TextNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+  // Persian content carrying the inode `ltr` default, as the importer leaves it.
+  editor.update(
+    () => {
+      const root = $getRoot();
+      root.clear();
+      root.setDirection('ltr');
+      const paragraph = $createParagraphNode();
+      paragraph.setDirection('ltr');
+      paragraph.append($createTextNode('سلام دنیا'));
+      root.append(paragraph);
+    },
+    { discrete: true },
+  );
+  return editor;
+};
+
+const readRootAndBlock = (editor: LexicalEditor) =>
+  editor.getEditorState().read(() => {
+    const root = $getRoot();
+    const block = root.getFirstChild() as unknown as {
+      getDirection: () => unknown;
+    } | null;
+    return { block: block?.getDirection() ?? null, root: root.getDirection() };
+  });
+
+const flushUpdates = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  captured.handlers = {};
+  mockEditor.getLexicalEditor.mockImplementation(() => null);
+});
+
+describe('ReactAutoDirectionPlugin', () => {
+  it('attaches on initialized when the inner editor is not ready at mount', async () => {
+    render(<ReactAutoDirectionPlugin />);
+
+    // The inner editor is created later (setRootElement in another effect),
+    // so the plugin must wait instead of giving up.
+    expect(mockEditor.once).toHaveBeenCalledWith('initialized', expect.any(Function));
+
+    const lexicalEditor = createPersianEditor();
+    mockEditor.getLexicalEditor.mockImplementation(() => lexicalEditor);
+
+    await act(async () => {
+      captured.handlers['initialized'](lexicalEditor);
+      await flushUpdates();
+    });
+
+    expect(readRootAndBlock(lexicalEditor)).toEqual({ block: 'rtl', root: null });
+  });
+
+  it('attaches immediately when the inner editor already exists', async () => {
+    const lexicalEditor = createPersianEditor();
+    mockEditor.getLexicalEditor.mockImplementation(() => lexicalEditor);
+
+    render(<ReactAutoDirectionPlugin />);
+    await act(async () => {
+      await flushUpdates();
+    });
+
+    expect(mockEditor.once).not.toHaveBeenCalled();
+    expect(readRootAndBlock(lexicalEditor)).toEqual({ block: 'rtl', root: null });
+  });
+
+  it('re-reconciles on programmatic content swaps', async () => {
+    const lexicalEditor = createPersianEditor();
+    mockEditor.getLexicalEditor.mockImplementation(() => lexicalEditor);
+
+    render(<ReactAutoDirectionPlugin />);
+    await act(async () => {
+      await flushUpdates();
+    });
+    expect(mockEditor.on).toHaveBeenCalledWith('documentChange', expect.any(Function));
+
+    // A later setDocument lands with stale directions again…
+    lexicalEditor.update(
+      () => {
+        $getRoot().setDirection('ltr');
+      },
+      { discrete: true },
+    );
+
+    await act(async () => {
+      captured.handlers['documentChange']();
+      await flushUpdates();
+    });
+
+    expect(readRootAndBlock(lexicalEditor).root).toBeNull();
+  });
+});

--- a/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
+++ b/src/features/ChatInput/InputEditor/ReactAutoDirectionPlugin.tsx
@@ -1,65 +1,63 @@
 import { useLexicalComposerContext } from '@lobehub/editor';
-import { $getRoot, $isElementNode } from 'lexical';
+import type { LexicalEditor } from 'lexical';
 import { type FC, useEffect } from 'react';
 
-import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
-
-const AUTO_DIR_TAG = 'chat-input-auto-direction';
+import { AUTO_DIR_TAG, reconcileEditorDirection } from './reconcileEditorDirection';
 
 /**
- * Sets each top-level block's Lexical direction from the first strong character.
- * Also clears a forced root `ltr` (from @lobehub/editor inode defaults) so
- * paragraphs can use auto / explicit rtl without inheriting LTR.
+ * Keeps every top-level block's Lexical direction on its own first strong
+ * character (per-block first-strong, matching `unicode-bidi: plaintext` in
+ * CSS), and the root directionless — also clears the forced root `ltr` from
+ * @lobehub/editor inode defaults. See `./reconcileEditorDirection` for the rule.
+ *
+ * Wiring matters more than the rule here: the inner Lexical editor is created
+ * asynchronously (`setRootElement`, in another component's effect), so
+ * `getLexicalEditor()` is still null when this effect first runs. Attaching
+ * only when it is non-null would silently disable the plugin forever — every
+ * imported paragraph would keep the inode `ltr` default whatever language it
+ * starts with. Hence the `initialized` subscription below.
  */
 const ReactAutoDirectionPlugin: FC = () => {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    const lexicalEditor = editor.getLexicalEditor();
-    if (!lexicalEditor) return;
+    let detachUpdateListener: (() => void) | undefined;
 
-    return lexicalEditor.registerUpdateListener(({ editorState, tags }) => {
-      if (tags.has(AUTO_DIR_TAG)) return;
+    const attach = (lexicalEditor: LexicalEditor) => {
+      // Content applied before this point (initialContent, migrated home
+      // fallback value) never passed the listener — fix it up front so it
+      // does not wait for the next keystroke.
+      reconcileEditorDirection(lexicalEditor);
+      detachUpdateListener?.();
+      detachUpdateListener = lexicalEditor.registerUpdateListener(({ tags }) => {
+        if (tags.has(AUTO_DIR_TAG)) return;
 
-      let needsUpdate = false;
-
-      editorState.read(() => {
-        const root = $getRoot();
-        if (root.getDirection() !== null) {
-          needsUpdate = true;
-          return;
-        }
-
-        for (const child of root.getChildren()) {
-          if (!$isElementNode(child) || child.isInline()) continue;
-          const next = getTextDirectionFromFirstStrong(child.getTextContent());
-          if (child.getDirection() !== next) {
-            needsUpdate = true;
-            return;
-          }
-        }
+        reconcileEditorDirection(lexicalEditor);
       });
+    };
 
-      if (!needsUpdate) return;
+    const ready = editor.getLexicalEditor();
+    if (ready) {
+      attach(ready);
+    } else {
+      editor.once('initialized', attach);
+    }
 
-      lexicalEditor.update(
-        () => {
-          const root = $getRoot();
-          if (root.getDirection() !== null) {
-            root.setDirection(null);
-          }
+    // Programmatic content swaps (draft restore, saved state) go through
+    // `setDocument`, which must not depend on update-listener timing to end
+    // up with the right direction.
+    const handleDocumentChange = () => {
+      const lexicalEditor = editor.getLexicalEditor();
+      if (lexicalEditor) reconcileEditorDirection(lexicalEditor);
+    };
+    editor.on('documentChange', handleDocumentChange);
 
-          for (const child of root.getChildren()) {
-            if (!$isElementNode(child) || child.isInline()) continue;
-            const next = getTextDirectionFromFirstStrong(child.getTextContent());
-            if (child.getDirection() !== next) {
-              child.setDirection(next);
-            }
-          }
-        },
-        { tag: AUTO_DIR_TAG },
-      );
-    });
+    return () => {
+      // `once` auto-removes after firing; `off` is a no-op if it never did.
+      editor.off('initialized', attach);
+      editor.off('documentChange', handleDocumentChange);
+      detachUpdateListener?.();
+    };
   }, [editor]);
 
   return null;

--- a/src/features/ChatInput/InputEditor/reconcileEditorDirection.test.ts
+++ b/src/features/ChatInput/InputEditor/reconcileEditorDirection.test.ts
@@ -1,0 +1,157 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  createEditor,
+  type LexicalEditor,
+  ParagraphNode,
+  TextNode,
+} from 'lexical';
+import { describe, expect, it } from 'vitest';
+
+import { reconcileEditorDirection } from './reconcileEditorDirection';
+
+const createTestEditor = (): LexicalEditor =>
+  createEditor({
+    nodes: [ParagraphNode, TextNode],
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+/** Set block text the way an importer / draft restore would: no directions fixed. */
+const setParagraphs = (editor: LexicalEditor, texts: string[]) => {
+  editor.update(
+    () => {
+      const root = $getRoot();
+      root.clear();
+      for (const text of texts) {
+        const paragraph = $createParagraphNode();
+        if (text) paragraph.append($createTextNode(text));
+        root.append(paragraph);
+      }
+    },
+    { discrete: true },
+  );
+};
+
+/** Force every direction to a stale value, simulating a missed update. */
+const resetDirections = (
+  editor: LexicalEditor,
+  rootDir: 'ltr' | 'rtl' | null,
+  blockDir: 'ltr' | 'rtl' | null,
+) => {
+  editor.update(
+    () => {
+      const root = $getRoot();
+      root.setDirection(rootDir);
+      for (const child of root.getChildren()) {
+        if ($isElementNode(child) && !child.isInline()) child.setDirection(blockDir);
+      }
+    },
+    { discrete: true },
+  );
+};
+
+const readDirections = (editor: LexicalEditor) =>
+  editor.getEditorState().read(() => {
+    const root = $getRoot();
+    return {
+      blocks: root
+        .getChildren()
+        .filter((child) => $isElementNode(child) && !child.isInline())
+        .map((child) => ($isElementNode(child) ? child.getDirection() : null)),
+      root: root.getDirection(),
+    };
+  });
+
+/** Reconcile applies via a regular (non-discrete) update: let it flush. */
+const flushUpdates = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe('reconcileEditorDirection', () => {
+  it('gives initial English content ltr immediately (no keystroke needed)', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['h']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['ltr'], root: null });
+  });
+
+  it('gives initial Persian content rtl immediately', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['سلام']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['rtl'], root: null });
+  });
+
+  it('keeps an English-first line ltr when a later word is Persian', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['Hello سلام']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['ltr'], root: null });
+  });
+
+  it('keeps per-block directions in multi-paragraph text', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['Hello', 'سلام دنیا']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['ltr', 'rtl'], root: null });
+  });
+
+  it('fixes a stale block direction instead of leaving it', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['hello']);
+    resetDirections(editor, null, 'rtl');
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor).blocks).toEqual(['ltr']);
+  });
+
+  it('clears a forced root direction so blocks resolve on their own', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['سلام']);
+    resetDirections(editor, 'ltr', null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['rtl'], root: null });
+  });
+
+  it('leaves empty and neutral-only content directionless', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['', '123 ...']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(false);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: [null, null], root: null });
+  });
+
+  it('is a no-op once settled', async () => {
+    const editor = createTestEditor();
+    setParagraphs(editor, ['Hello سلام']);
+    resetDirections(editor, null, null);
+
+    expect(reconcileEditorDirection(editor)).toBe(true);
+    await flushUpdates();
+    expect(reconcileEditorDirection(editor)).toBe(false);
+    await flushUpdates();
+    expect(readDirections(editor)).toEqual({ blocks: ['ltr'], root: null });
+  });
+});

--- a/src/features/ChatInput/InputEditor/reconcileEditorDirection.ts
+++ b/src/features/ChatInput/InputEditor/reconcileEditorDirection.ts
@@ -1,0 +1,59 @@
+import { $getRoot, $isElementNode, type LexicalEditor } from 'lexical';
+
+import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
+
+export const AUTO_DIR_TAG = 'chat-input-auto-direction';
+
+/**
+ * Direction system (single rule everywhere): per-block first-strong —
+ * `unicode-bidi: plaintext` in CSS. Each paragraph resolves from its own
+ * first strong character, so an English-first line stays left even when a
+ * later word is Persian, and vice versa.
+ *
+ * This function is the whole rule, extracted so it can run both on updates
+ * and once on mount (and so tests can drive it without a live editor).
+ *
+ * @returns whether anything was out of date (i.e. an update was applied).
+ */
+export const reconcileEditorDirection = (lexicalEditor: LexicalEditor): boolean => {
+  let needsUpdate = false;
+
+  lexicalEditor.getEditorState().read(() => {
+    const root = $getRoot();
+    if (root.getDirection() !== null) {
+      needsUpdate = true;
+      return;
+    }
+
+    for (const child of root.getChildren()) {
+      if (!$isElementNode(child) || child.isInline()) continue;
+      const next = getTextDirectionFromFirstStrong(child.getTextContent());
+      if (child.getDirection() !== next) {
+        needsUpdate = true;
+        return;
+      }
+    }
+  });
+
+  if (!needsUpdate) return false;
+
+  lexicalEditor.update(
+    () => {
+      const root = $getRoot();
+      if (root.getDirection() !== null) {
+        root.setDirection(null);
+      }
+
+      for (const child of root.getChildren()) {
+        if (!$isElementNode(child) || child.isInline()) continue;
+        const next = getTextDirectionFromFirstStrong(child.getTextContent());
+        if (child.getDirection() !== next) {
+          child.setDirection(next);
+        }
+      }
+    },
+    { tag: AUTO_DIR_TAG },
+  );
+
+  return true;
+};

--- a/src/features/Conversation/Markdown/index.tsx
+++ b/src/features/Conversation/Markdown/index.tsx
@@ -4,7 +4,7 @@ import { memo, useMemo } from 'react';
 
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
-import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
+import { extractTextFromReactNode, getTextDirectionFromFirstStrong } from '@/utils/textDirection';
 
 const MarkdownMessage = memo<MarkdownProps>(
   ({
@@ -20,10 +20,13 @@ const MarkdownMessage = memo<MarkdownProps>(
       userGeneralSettingsSelectors.config,
     );
 
-    // Match chat input: base direction from first strong char so Persian replies
-    // align RTL even when the UI locale is English (and vice versa).
+    // Match chat input: base direction from the first strong character so
+    // Persian replies align RTL even when the UI locale is English (and vice
+    // versa). Children can be span arrays mid-stream, so read the words out of
+    // the tree instead of only accepting a plain string — a missed direction
+    // here falls back to the page direction and the whole message jumps edge.
     const autoDir = useMemo(
-      () => (typeof children === 'string' ? getTextDirectionFromFirstStrong(children) : null),
+      () => getTextDirectionFromFirstStrong(extractTextFromReactNode(children)),
       [children],
     );
 

--- a/src/utils/textDirection.test.ts
+++ b/src/utils/textDirection.test.ts
@@ -1,6 +1,7 @@
+import { createElement, Fragment } from 'react';
 import { describe, expect, it } from 'vitest';
 
-import { getTextDirectionFromFirstStrong } from './textDirection';
+import { extractTextFromReactNode, getTextDirectionFromFirstStrong } from './textDirection';
 
 describe('getTextDirectionFromFirstStrong', () => {
   it('returns rtl when the first strong character is Persian/Arabic', () => {
@@ -26,5 +27,40 @@ describe('getTextDirectionFromFirstStrong', () => {
     expect(getTextDirectionFromFirstStrong('')).toBeNull();
     expect(getTextDirectionFromFirstStrong('   ')).toBeNull();
     expect(getTextDirectionFromFirstStrong('123')).toBeNull();
+  });
+});
+
+describe('extractTextFromReactNode', () => {
+  it('passes plain strings through', () => {
+    expect(extractTextFromReactNode('سلام world')).toBe('سلام world');
+  });
+
+  it('joins arrays such as stream-animation spans', () => {
+    expect(extractTextFromReactNode(['Hello', ' ', 'سلام'])).toBe('Hello سلام');
+  });
+
+  it('reads through elements, fragments and nesting', () => {
+    const node = createElement(
+      Fragment,
+      null,
+      createElement('span', null, 'Hello'),
+      ' ',
+      createElement('span', null, createElement('b', null, 'سلام')),
+    );
+    expect(extractTextFromReactNode(node)).toBe('Hello سلام');
+  });
+
+  it('ignores nullish, boolean and unknown children', () => {
+    expect(extractTextFromReactNode(null)).toBe('');
+    expect(extractTextFromReactNode(undefined)).toBe('');
+    expect(extractTextFromReactNode(false)).toBe('');
+    expect(extractTextFromReactNode([null, 'hi', false])).toBe('hi');
+  });
+
+  it('keeps first-strong order across node boundaries', () => {
+    // Persian word wrapped in its own span must not steal the direction when
+    // the message starts with English.
+    const node = [createElement('span', null, 'Hello'), createElement('span', null, 'سلام')];
+    expect(getTextDirectionFromFirstStrong(extractTextFromReactNode(node))).toBe('ltr');
   });
 });

--- a/src/utils/textDirection.ts
+++ b/src/utils/textDirection.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 export type TextDirection = 'ltr' | 'rtl' | null;
 
 /**
@@ -15,4 +17,20 @@ export const getTextDirectionFromFirstStrong = (text: string): TextDirection => 
     if (LTR_STRONG.test(char)) return 'ltr';
   }
   return null;
+};
+
+/**
+ * Concatenate the text of a ReactNode tree (plain strings, arrays, fragments,
+ * elements such as stream-animation spans). Lets message-level `dir` resolve
+ * from the actual words even when children are not a single string — otherwise
+ * the direction silently falls back to the page direction mid-stream.
+ */
+export const extractTextFromReactNode = (node: ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractTextFromReactNode).join('');
+  if (typeof node === 'object' && 'props' in node) {
+    return extractTextFromReactNode((node as { props?: { children?: ReactNode } }).props?.children);
+  }
+  return '';
 };


### PR DESCRIPTION
Keeps the per-block first-strong system (`unicode-bidi: plaintext`): each line resolves direction from its own first strong character, so an English-first line stays left even when a later word is Persian.

### Cause

`ReactAutoDirectionPlugin` attached its update listener only when `editor.getLexicalEditor()` was already non-null inside its own effect. The inner Lexical editor is created asynchronously (`setRootElement`, in another component's effect), so at plugin-effect time it is still null and the plugin returned early — permanently dead. Imported paragraphs then kept the inode `direction: 'ltr'` default whatever language they start with, until a keystroke happened to clear it. That is why initial content (restored draft, home fallback value, `initialContent`) sat on the wrong side: a single `h` rendered at the right edge, Persian initial content at the left.

Verified in Chromium against the real editor fork + real plugin + composer CSS on an RTL page (no typing):

| mount content | before | after |
| --- | --- | --- |
| `h` | ltr | ltr |
| `Hello سلام` | ltr | ltr |
| `سلام دنیا` | ltr (wrong) | rtl |

### Changes

- **`ReactAutoDirectionPlugin`**: subscribe to the kernel `initialized` event when the inner editor is not ready yet; reconcile once on attach; re-reconcile on programmatic `documentChange` swaps (draft restore / saved state). Rule itself extracted to `reconcileEditorDirection` (testable without a live editor).
- **`Markdown/index.tsx`**: `dir` now resolves from the words even when children are span arrays, via new `extractTextFromReactNode` — otherwise direction silently fell back to the page direction.
- Untouched and verified correct: `textDirection` helper, composer CSS, home fallback (`dir=auto` + plaintext), user rich-text renderer.

### Tests

- `reconcileEditorDirection.test.ts` (8 tests): rule behavior incl. English-first mixed line stays ltr, stale dirs fixed, idempotent.
- `ReactAutoDirectionPlugin.test.tsx` (3 tests): attaches via `initialized` when the editor is not ready, attaches immediately when it is, re-reconciles on `documentChange`. All 3 **fail against the old plugin** (verified by stashing the fix) and pass after.
- `textDirection.test.ts` +5 tests for the ReactNode extractor.
- `bun run check` lint-clean, 21 tests pass; no type errors in changed files (remaining `--type` failures are pre-existing in unrelated files).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

Fixes #355