### PR TITLE
🐛 fix(chat): align directionless composer content to the page side

### DIFF
--- a/src/features/ChatInput/InputEditor/reconcileEditorDirection.test.ts
+++ b/src/features/ChatInput/InputEditor/reconcileEditorDirection.test.ts
@@ -133,14 +133,29 @@ describe('reconcileEditorDirection', () => {
     expect(readDirections(editor)).toEqual({ blocks: ['rtl'], root: null });
   });
 
-  it('leaves empty and neutral-only content directionless', async () => {
+  it('falls back to ltr for empty content on a left-to-right page', async () => {
     const editor = createTestEditor();
     setParagraphs(editor, ['', '123 ...']);
     resetDirections(editor, null, null);
 
-    expect(reconcileEditorDirection(editor)).toBe(false);
+    expect(reconcileEditorDirection(editor)).toBe(true);
     await flushUpdates();
-    expect(readDirections(editor)).toEqual({ blocks: [null, null], root: null });
+    expect(readDirections(editor)).toEqual({ blocks: ['ltr', 'ltr'], root: null });
+  });
+
+  it('aligns empty content to the right on a right-to-left page', async () => {
+    document.dir = 'rtl';
+    try {
+      const editor = createTestEditor();
+      setParagraphs(editor, ['']);
+      resetDirections(editor, null, null);
+
+      expect(reconcileEditorDirection(editor)).toBe(true);
+      await flushUpdates();
+      expect(readDirections(editor)).toEqual({ blocks: ['rtl'], root: null });
+    } finally {
+      document.dir = '';
+    }
   });
 
   it('is a no-op once settled', async () => {

--- a/src/features/ChatInput/InputEditor/reconcileEditorDirection.ts
+++ b/src/features/ChatInput/InputEditor/reconcileEditorDirection.ts
@@ -5,6 +5,19 @@ import { getTextDirectionFromFirstStrong } from '@/utils/textDirection';
 export const AUTO_DIR_TAG = 'chat-input-auto-direction';
 
 /**
+ * Direction for content with no strong character (empty box, digits only).
+ * Chrome resolves a directionless empty block to LTR unconditionally, so
+ * follow the page instead: an empty composer sits on the UI's side (right in
+ * fa-IR) and the first strong character visibly takes over from there.
+ * Composer code runs client-side only.
+ */
+export const getNeutralDirection = (): 'ltr' | 'rtl' =>
+  typeof document !== 'undefined' && document.dir === 'rtl' ? 'rtl' : 'ltr';
+
+const getBlockDirection = (text: string): 'ltr' | 'rtl' =>
+  getTextDirectionFromFirstStrong(text) ?? getNeutralDirection();
+
+/**
  * Direction system (single rule everywhere): per-block first-strong —
  * `unicode-bidi: plaintext` in CSS. Each paragraph resolves from its own
  * first strong character, so an English-first line stays left even when a
@@ -27,7 +40,7 @@ export const reconcileEditorDirection = (lexicalEditor: LexicalEditor): boolean 
 
     for (const child of root.getChildren()) {
       if (!$isElementNode(child) || child.isInline()) continue;
-      const next = getTextDirectionFromFirstStrong(child.getTextContent());
+      const next = getBlockDirection(child.getTextContent());
       if (child.getDirection() !== next) {
         needsUpdate = true;
         return;
@@ -46,7 +59,7 @@ export const reconcileEditorDirection = (lexicalEditor: LexicalEditor): boolean 
 
       for (const child of root.getChildren()) {
         if (!$isElementNode(child) || child.isInline()) continue;
-        const next = getTextDirectionFromFirstStrong(child.getTextContent());
+        const next = getBlockDirection(child.getTextContent());
         if (child.getDirection() !== next) {
           child.setDirection(next);
         }


### PR DESCRIPTION
Follow-up to #356. That PR fixed initial *content*; this fixes initial *emptiness*.

### Cause

Chrome resolves a directionless empty block to LTR unconditionally (verified: empty `p[dir=auto]` in an RTL page computes `ltr`). So an empty composer sat left even in the Persian UI, and typing the first letter caused no visible flip — the box only appeared to react on the second letter.

### Changes

- `reconcileEditorDirection`: when block text has no strong character (empty, digits/punctuation only), fall back to the page direction (`document.dir`) instead of leaving the block directionless — right in fa-IR, left in en-US. First strong character still takes over immediately (verified: empty `rtl` → `H` flips to `ltr` on the first keystroke, `Hi سلام` stays `ltr`).
- Tests: neutral fallback for ltr page (default) and rtl page (`document.dir = 'rtl'`).

Verified in Chromium against the real local composer (dev server, fa-IR):

| state | before | after |
| --- | --- | --- |
| empty | `dir=auto`, computed `ltr` | `dir=rtl`, computed `rtl` |
| `H` (first letter) | `ltr` | `ltr` (visible flip from right) |
| `Hi سلام` | `ltr` | `ltr` |

- [x] Tested locally (real app, keystroke-by-keystroke probe + screenshot)
- [x] Added/updated tests (`bun run check` lint-clean, 12 passed; no type errors in changed files)

#### 🔗 Related Issue

Fixes #357