### PR TITLE
🐛 fix(chat): name the model Auto picked in the cost card

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmAttempt.ts
@@ -93,6 +93,7 @@ export class ServerCallLlmAttempt {
   private readonly provider: string;
   private reasoning?: ModelReasoning;
   private readonly reasoningPartEvents: ContentPartData[] = [];
+  private resolvedModel?: string;
   private readonly resolved: ServerCallLlmTooling['resolved'];
   private speed?: ModelPerformance;
   private readonly streamSink: ServerCallLlmStreamSink;
@@ -170,6 +171,7 @@ export class ServerCallLlmAttempt {
           if (data.speed) this.speed = data.speed;
           if (data.finishReason) this.finishReason = data.finishReason;
           if (data.reasoning) this.reasoning = data.reasoning;
+          if (data.resolvedModel) this.resolvedModel = data.resolvedModel;
         },
         onContentPart: async (part) => {
           this.onFirstChunk();
@@ -287,6 +289,7 @@ export class ServerCallLlmAttempt {
       imageList: [...this.imageList],
       reasoning: this.reasoning,
       reasoningParts: [...this.streamSink.reasoningParts],
+      resolvedModel: this.resolvedModel,
       speed: this.speed,
       thinkingContent: this.streamSink.thinkingContent,
       toolCalls: [...this.toolCalls],

--- a/packages/agent-runtime/src/executors/callLlmFinalizer.ts
+++ b/packages/agent-runtime/src/executors/callLlmFinalizer.ts
@@ -63,6 +63,7 @@ const buildMessageMetadata = ({
   finishType,
   hasContentImages,
   interruptedMidStream,
+  resolvedModel,
 }: {
   answerSalvagedFromReasoning?: boolean;
   currentStepSpeed?: ModelPerformance;
@@ -70,10 +71,12 @@ const buildMessageMetadata = ({
   finishType?: string;
   hasContentImages?: boolean;
   interruptedMidStream?: boolean;
+  resolvedModel?: string;
 }): CallLlmMessageMetadata | undefined => {
   const metadata: CallLlmMessageMetadata = {
     ...(currentStepUsage && { ...currentStepUsage, usage: currentStepUsage }),
     ...(currentStepSpeed && { ...currentStepSpeed, performance: currentStepSpeed }),
+    ...(resolvedModel && { resolvedModel }),
     ...(finishType && { finishType }),
     ...(hasContentImages && { isMultimodal: true }),
     ...(answerSalvagedFromReasoning && { answerSalvagedFromReasoning: true }),
@@ -179,6 +182,7 @@ const persistFinalMessage = async ({
     currentStepUsage: output.usage,
     finishType: output.finishReason,
     hasContentImages: output.hasContentImages,
+    resolvedModel: output.resolvedModel,
   });
   const workAnchor = buildWorkAnchor({
     operationId: host.operation.operationId,
@@ -392,6 +396,7 @@ export const persistInterruptedCallLlmResult = async ({
         currentStepSpeed: output.speed,
         currentStepUsage: output.usage,
         interruptedMidStream: true,
+        resolvedModel: output.resolvedModel,
       }),
       reasoning: output.thinkingContent ? { content: output.thinkingContent } : undefined,
       tools: sanitizePersistedTools(output.toolsCalling),

--- a/packages/agent-runtime/src/transport/llm.ts
+++ b/packages/agent-runtime/src/transport/llm.ts
@@ -56,6 +56,11 @@ export interface LLMAttemptOutput {
   /** Adapter-produced structured reasoning metadata such as duration and signature. */
   reasoning?: ModelReasoning;
   reasoningParts: LLMAttemptContentPart[];
+  /**
+   * The model a router alias actually dispatched to (`openrouter/auto` →
+   * `openai/gpt-4o`). Undefined for direct model requests.
+   */
+  resolvedModel?: string;
   speed?: ModelPerformance;
   /** Raw streamed thinking text; finalization converts it to the message reasoning object. */
   thinkingContent: string;

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -27,6 +27,8 @@ export type OnFinishHandler = (
     images?: ChatImageChunk[];
     observationId?: string | null;
     reasoning?: ModelReasoning;
+    /** Model a router alias (e.g. `openrouter/auto`) actually dispatched to. */
+    resolvedModel?: string;
     speed?: ModelPerformance;
     toolCalls?: MessageToolCall[];
     traceId?: string | null;
@@ -317,6 +319,7 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
   let usage: ModelUsage | undefined = undefined;
   const images: ChatImageChunk[] = [];
   let speed: ModelPerformance | undefined = undefined;
+  let resolvedModel: string | undefined = undefined;
 
   await fetchEventSource(url, {
     body: options.body,
@@ -433,6 +436,11 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         case 'speed': {
           speed = data;
           options.onMessageHandle?.({ speed: data, type: 'speed' });
+          break;
+        }
+
+        case 'resolved_model': {
+          if (typeof data === 'string' && data) resolvedModel = data;
           break;
         }
 
@@ -588,6 +596,7 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
               }
             : undefined;
         })(),
+        resolvedModel,
         speed,
         toolCalls,
         traceId,

--- a/packages/model-runtime/src/core/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.test.ts
@@ -737,6 +737,66 @@ describe('OpenAIStream', () => {
     });
   });
 
+  describe('router alias resolution', () => {
+    const buildStream = (model: string) =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            choices: [{ delta: { content: 'Hi' }, index: 0 }],
+            id: 'chat-1',
+            model,
+          });
+          controller.enqueue({
+            choices: [{ delta: { content: '!' }, index: 0 }],
+            id: 'chat-1',
+            model,
+          });
+          controller.close();
+        },
+      });
+
+    const collect = async (protocolStream: ReadableStream) => {
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      // @ts-ignore async iteration over the protocol stream
+      for await (const chunk of protocolStream) {
+        chunks.push(decoder.decode(chunk, { stream: true }));
+      }
+      return chunks;
+    };
+
+    it('reports the model an auto router picked, once per stream', async () => {
+      const onFinal = vi.fn();
+
+      const chunks = await collect(
+        OpenAIStream(buildStream('openai/gpt-5'), {
+          callbacks: { onFinal },
+          payload: { model: 'openrouter/auto', provider: 'openrouter' },
+        }),
+      );
+
+      expect(chunks.filter((chunk) => chunk.includes('event: resolved_model'))).toHaveLength(1);
+      expect(chunks.join('')).toContain('data: "openai/gpt-5"');
+      expect(onFinal).toHaveBeenCalledWith(
+        expect.objectContaining({ resolvedModel: 'openai/gpt-5' }),
+      );
+    });
+
+    it('stays quiet for a direct model request, even when the provider answers with a dated snapshot id', async () => {
+      const onFinal = vi.fn();
+
+      const chunks = await collect(
+        OpenAIStream(buildStream('gpt-4o-2024-08-06'), {
+          callbacks: { onFinal },
+          payload: { model: 'gpt-4o', provider: 'openai' },
+        }),
+      );
+
+      expect(chunks.join('')).not.toContain('resolved_model');
+      expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ resolvedModel: undefined }));
+    });
+  });
+
   describe('Tools Calling', () => {
     it('should handle OpenAI official tool calls', async () => {
       const mockOpenAIStream = new ReadableStream({

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -679,6 +679,35 @@ const transformOpenAIStream = (
   }
 };
 
+/**
+ * Router aliases (`openrouter/auto`, and any `<vendor>/auto`) do not name a real
+ * model — the router picks one per request and reports it back on every chunk.
+ * Direct model requests are excluded on purpose: providers often answer with a
+ * dated snapshot id (`gpt-4o-2024-08-06`), which is the same model and would
+ * only make the UI less readable.
+ */
+const isRouterAliasModel = (model: string | undefined): boolean =>
+  !!model && /\/auto$/i.test(model.trim());
+
+/**
+ * Emits the router-picked model once per stream, so the persisted message can
+ * name what actually ran instead of the alias the user selected.
+ */
+const readResolvedRouterModel = (
+  chunk: OpenAI.ChatCompletionChunk,
+  streamContext: StreamContext,
+  payload: ChatPayloadForTransformStream | undefined,
+): string | undefined => {
+  if (streamContext.resolvedModel) return undefined;
+  if (!isRouterAliasModel(payload?.model)) return undefined;
+
+  const { model } = chunk;
+  if (typeof model !== 'string' || !model || model === payload?.model) return undefined;
+
+  streamContext.resolvedModel = model;
+  return model;
+};
+
 export interface OpenAIStreamOptions {
   bizErrorTypeTransformer?: (error: {
     message: string;
@@ -704,8 +733,19 @@ export const OpenAIStream = (
     id: '',
   };
 
-  const transformWithProvider = (chunk: OpenAI.ChatCompletionChunk, streamContext: StreamContext) =>
-    transformOpenAIStream(chunk, streamContext, payload);
+  const transformWithProvider = (
+    chunk: OpenAI.ChatCompletionChunk,
+    streamContext: StreamContext,
+  ): StreamProtocolChunk | StreamProtocolChunk[] => {
+    const result = transformOpenAIStream(chunk, streamContext, payload);
+    const resolvedModel = readResolvedRouterModel(chunk, streamContext, payload);
+    if (!resolvedModel) return result;
+
+    return [
+      { data: resolvedModel, id: chunk.id, type: 'resolved_model' },
+      ...(Array.isArray(result) ? result : [result]),
+    ];
+  };
 
   const readableStream =
     stream instanceof ReadableStream

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -32,6 +32,12 @@ export interface StreamContext {
   chunkIndex?: number;
   id: string;
   /**
+   * Model id the provider reported for this response. Only set when the request
+   * targeted a router alias (e.g. `openrouter/auto`), so it names the model the
+   * router actually picked. Tracked here to emit the chunk only once per stream.
+   */
+  resolvedModel?: string;
+  /**
    * As pplx citations is in every chunk, but we only need to return it once
    * this flag is used to check if the pplx citation is returned,and then not return it again.
    * Same as Hunyuan and Wenxin
@@ -134,6 +140,8 @@ export interface StreamProtocolChunk {
     | 'error'
     // token usage
     | 'usage'
+    // model a router alias (e.g. `openrouter/auto`) actually dispatched to
+    | 'resolved_model'
     // performance monitor
     | 'speed'
     // unknown data result
@@ -453,6 +461,7 @@ export function createCallbacksTransformer(
   const reasoningResponseItems: ModelReasoningResponseItem[] = [];
   let usage: ModelUsage | undefined;
   let speed: ModelPerformance | undefined;
+  let resolvedModel: string | undefined;
   let grounding: any;
   let toolsCalling: any;
   let streamError: any;
@@ -481,6 +490,7 @@ export function createCallbacksTransformer(
         error: streamError,
         finishReason,
         grounding,
+        resolvedModel,
         speed,
         text: aggregatedText,
         thinking: reasoningContent,
@@ -613,6 +623,11 @@ export function createCallbacksTransformer(
 
           case 'speed': {
             speed = data;
+            break;
+          }
+
+          case 'resolved_model': {
+            if (typeof data === 'string' && data) resolvedModel = data;
             break;
           }
 

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -257,6 +257,12 @@ export interface OnFinishData {
   finishReason?: string;
   grounding?: any;
   reasoning?: ModelReasoning;
+  /**
+   * The model a router alias actually dispatched to, when the request targeted
+   * one (e.g. `openrouter/auto` → `openai/gpt-4o`). Undefined for direct model
+   * requests, where the requested id already names what ran.
+   */
+  resolvedModel?: string;
   speed?: ModelPerformance;
   text: string;
   thinking?: string;

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -212,6 +212,7 @@ export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSche
   // (e.g. messageService.updateMessage, used by the heterogeneous-agent executor).
   performance: ModelPerformanceSchema.optional(),
   reactions: z.array(EmojiReactionSchema).optional(),
+  resolvedModel: z.string().optional(),
   scope: z.string().optional(),
   // External-signal lineage for Monitor-style callback turns ().
   signal: MessageSignalSchema.optional(),
@@ -407,6 +408,12 @@ export interface MessageMetadata {
   reactions?: EmojiReaction[];
   /** @deprecated use the top-level message `usage` field instead */
   rejectedPredictionTokens?: number;
+  /**
+   * The model a router alias actually dispatched to, reported by the provider
+   * (`openrouter/auto` → `openai/gpt-4o`). The message `model` keeps the alias
+   * the user selected; this names what ran, for cost attribution.
+   */
+  resolvedModel?: string;
   /**
    * Message scope - indicates the context in which this message was created
    * Used by conversation-flow to determine how to handle message grouping and display

--- a/src/features/Conversation/Messages/components/MessageCostBadge.tsx
+++ b/src/features/Conversation/Messages/components/MessageCostBadge.tsx
@@ -13,7 +13,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { formatNumber } from '@/utils/format';
 
 import { formatMessageCostUsd, resolveMessageCost } from './resolveMessageCost';
-import { resolveMessageModelName } from './resolveMessageModelName';
+import { resolveCostModelId, resolveMessageModelName } from './resolveMessageModelName';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -143,7 +143,10 @@ const MessageCostBadge = memo<MessageCostBadgeProps>(
   ({ usage, metadata, performance, model, provider }) => {
     const { t } = useTranslation('chat');
     const isShowCredit = useGlobalStore(systemStatusSelectors.isShowCredit);
-    const modelCard = useAiInfraStore(aiModelSelectors.getModelCard(model ?? '', provider ?? ''));
+    const costModel = resolveCostModelId(model, metadata);
+    const modelCard = useAiInfraStore(
+      aiModelSelectors.getModelCard(costModel ?? '', provider ?? ''),
+    );
 
     const cost = useMemo(() => resolveMessageCost(usage, metadata), [usage, metadata]);
     const detailRows = useMemo(
@@ -159,7 +162,7 @@ const MessageCostBadge = memo<MessageCostBadgeProps>(
 
     const { name: modelName, showIcon } = resolveMessageModelName({
       displayName: modelCard?.displayName,
-      model,
+      model: costModel,
       provider,
     });
 
@@ -174,7 +177,7 @@ const MessageCostBadge = memo<MessageCostBadgeProps>(
                 they belong to. */}
             {modelName && (
               <div className={styles.modelRow}>
-                {showIcon && <BrandedModelIcon model={model!} size={16} type={'mono'} />}
+                {showIcon && <BrandedModelIcon model={costModel!} size={16} type={'mono'} />}
                 <span className={styles.modelName}>{modelName}</span>
               </div>
             )}

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.test.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveMessageModelName } from './resolveMessageModelName';
+import { resolveCostModelId, resolveMessageModelName } from './resolveMessageModelName';
+
+describe('resolveCostModelId', () => {
+  it('names the model the Auto router picked, not the alias', () => {
+    expect(
+      resolveCostModelId('openrouter/auto', { cost: 0.002, resolvedModel: 'openai/gpt-5' }),
+    ).toBe('openai/gpt-5');
+  });
+
+  it('keeps the requested model when the provider reported no router pick', () => {
+    expect(resolveCostModelId('openai/gpt-5', { cost: 0.002 })).toBe('openai/gpt-5');
+  });
+
+  it('ignores a non-string resolvedModel', () => {
+    expect(resolveCostModelId('openrouter/auto', { resolvedModel: 42 })).toBe('openrouter/auto');
+  });
+
+  it('tolerates missing metadata', () => {
+    expect(resolveCostModelId('openrouter/auto', null)).toBe('openrouter/auto');
+  });
+});
 
 describe('resolveMessageModelName', () => {
   it('prefers the model card display name', () => {

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.ts
@@ -5,6 +5,19 @@ import {
 
 import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
 
+/**
+ * Which model id the cost card should name. A router alias (`panachat/auto`)
+ * names the picker, not what ran — when the provider reported the model the
+ * router chose, the cost belongs to that one.
+ */
+export const resolveCostModelId = (
+  model: string | null | undefined,
+  metadata: Record<string, unknown> | null | undefined,
+): string | null | undefined => {
+  const resolved = metadata?.resolvedModel;
+  return typeof resolved === 'string' && resolved ? resolved : model;
+};
+
 interface MessageModelNameInput {
   /** `displayName` of the resolved model card, when the model is known locally. */
   displayName?: string;

--- a/src/store/chat/agents/transports/ClientLLMTransport.ts
+++ b/src/store/chat/agents/transports/ClientLLMTransport.ts
@@ -264,12 +264,23 @@ export class ClientLLMTransport implements LLMTransport {
           },
           onFinish: async (
             _content,
-            { traceId, observationId, toolCalls, reasoning, grounding, usage, speed, type },
+            {
+              traceId,
+              observationId,
+              toolCalls,
+              reasoning,
+              grounding,
+              usage,
+              speed,
+              type,
+              resolvedModel,
+            },
           ) => {
             finishData = {
               grounding,
               observationId,
               reasoning,
+              resolvedModel,
               speed,
               toolCalls,
               traceId,
@@ -415,6 +426,7 @@ export class ClientLLMTransport implements LLMTransport {
       observationId: finishData.observationId ?? undefined,
       reasoning,
       reasoningParts: handler.getReasoningParts(),
+      resolvedModel: finishData.resolvedModel,
       speed: result.metadata.performance,
       thinkingContent,
       toolCalls: result.toolCalls ?? [],

--- a/src/store/chat/agents/types/streaming.ts
+++ b/src/store/chat/agents/types/streaming.ts
@@ -66,6 +66,8 @@ export interface FinishData {
   grounding?: GroundingData;
   observationId?: string | null;
   reasoning?: ModelReasoning;
+  /** Model a router alias (e.g. `openrouter/auto`) actually dispatched to. */
+  resolvedModel?: string;
   speed?: ModelPerformance;
   toolCalls?: MessageToolCall[];
   traceId?: string | null;


### PR DESCRIPTION
The cost card on an assistant message echoed the **requested** model id. A turn run through the `openrouter/auto` router therefore reported `panachat/auto` — the picker, not the model that actually answered and produced the charge.

Nothing in the chat pipeline captured the provider-reported model, so this carries it end to end:

1. **Capture** — `packages/model-runtime/src/core/streams/openai/openai.ts` emits a new `resolved_model` protocol event once per stream, carrying `chunk.model`, but only when the request targeted a router alias (`*/auto`). Direct model requests stay silent on purpose: providers often answer with a dated snapshot id (`gpt-4o-2024-08-06`) that names the same model and would only make the card harder to read.
2. **Carry** — through `StreamProtocolChunk` / `OnFinishData`, the client SSE parser (`packages/fetch-sse`), and both the client and server LLM transports.
3. **Persist** — `callLlmFinalizer` writes it to the assistant message as `metadata.resolvedModel`. The message's own `model` still holds the alias the user selected, so model-of-record and billing attribution are untouched.
4. **Display** — `MessageCostBadge` resolves the model card and icon from that id, showing e.g. *GPT-5* instead of *panachat/auto*.

Both halves degrade safely on their own: an unknown SSE event is ignored, and a message without `resolvedModel` falls back to `model`.

| Before | After |
| ------ | ----- |
| Cost card reads `panachat/auto` | Cost card reads the model Auto dispatched to |

#### Test

- Stream-level tests in `openai.test.ts`: a router alias emits `resolved_model` exactly once and surfaces it on `onFinal`; a direct request answering with a dated snapshot id emits nothing.
- Unit tests for `resolveCostModelId` covering the alias, the no-router case, a non-string value, and missing metadata.
- `bun run check` clean (182 tests).

Not verified against a live Auto request — that needs a real OpenRouter call. Worth a manual check that the model shown matches what OpenRouter reports for the turn.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 🔗 Related Issue

No existing issue found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)