### PR TITLE
🐛 fix(branding): convert the last readBrandingEnv call site

### DIFF
--- a/packages/business/const/src/branding.ts
+++ b/packages/business/const/src/branding.ts
@@ -126,7 +126,10 @@ export const BRANDING_EMAIL: {
   replyTo: OptionalUrl;
   support: string;
 } = {
-  business: readBrandingEnv('BRANDING_BUSINESS_EMAIL', ''),
+  business: brandingValue(
+    process.env.BRANDING_BUSINESS_EMAIL ?? process.env.NEXT_PUBLIC_BRANDING_BUSINESS_EMAIL,
+    '',
+  ),
   replyTo: undefined,
   support: brandingValue(
     process.env.BRANDING_SUPPORT_EMAIL ?? process.env.NEXT_PUBLIC_BRANDING_SUPPORT_EMAIL,


### PR DESCRIPTION
## Summary

`readBrandingEnv` was removed in #342 in favour of literal `process.env.X` reads (esbuild can only statically substitute literal keys), but `BRANDING_EMAIL.business` in `packages/business/const/src/branding.ts` was missed.

The result is a module-scope `ReferenceError: readBrandingEnv is not defined` on any import of `@lobechat/business-const` — which is currently breaking canary for every consumer, including the entire server test suite.

## Fix

Converted the one remaining call site to the same shape as its `support` sibling two lines below:

```ts
business: brandingValue(
  process.env.BRANDING_BUSINESS_EMAIL ?? process.env.NEXT_PUBLIC_BRANDING_BUSINESS_EMAIL,
  '',
),
```

## Verification

`apps/server/src/services/aico/renewalScheduler.test.ts` fails to collect on canary with the ReferenceError and passes 5/5 with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)