### PR TITLE
🐛 fix(agent): stop flashing "Lobe AI" before the inbox title loads

### DIFF
--- a/src/features/AgentHome/AgentInfo.tsx
+++ b/src/features/AgentHome/AgentInfo.tsx
@@ -5,7 +5,7 @@ import isEqual from 'fast-deep-equal';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { contextSelectors, useConversationStore } from '@/features/Conversation/store';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -17,7 +17,7 @@ const AgentInfo = memo(() => {
   // Scope the welcome to the conversation's agent, not the global
   // `activeAgentId`. In the multi-tab desktop app `activeAgentId` is shared and
   // can momentarily point at another tab's agent (or the inbox), which used to
-  // flash this card back to the inbox "Lobe AI" identity.
+  // flash this card back to the inbox's default identity.
   const agentId = useConversationStore(contextSelectors.agentId) || '';
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
   const isInbox = !!inboxAgentId && agentId === inboxAgentId;
@@ -29,7 +29,7 @@ const AgentInfo = memo(() => {
   const fontSize = useUserStore(userGeneralSettingsSelectors.fontSize);
 
   const displayTitle = isInbox
-    ? meta.title || 'Lobe AI'
+    ? meta.title || DEFAULT_INBOX_TITLE
     : meta.title || t('defaultSession', { ns: 'common' });
 
   const message = useMemo(() => {

--- a/src/features/AgentSidebar/Header/Agent/index.tsx
+++ b/src/features/AgentSidebar/Header/Agent/index.tsx
@@ -7,7 +7,7 @@ import React, { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { SkeletonItem } from '@/features/NavPanel/components/SkeletonList';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -26,7 +26,7 @@ const Agent = memo<PropsWithChildren>(() => {
   ]);
 
   const displayTitle = isInbox
-    ? title || 'Lobe AI'
+    ? title || DEFAULT_INBOX_TITLE
     : title || t('defaultSession', { ns: 'common' });
 
   if (isLoading) return <SkeletonItem height={32} padding={0} />;

--- a/src/features/Conversation/hooks/useAgentMeta.test.ts
+++ b/src/features/Conversation/hooks/useAgentMeta.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { useAgentStore } from '@/store/agent';
 
 import type * as ConversationStoreModule from '../store';
@@ -87,7 +88,7 @@ describe('useAgentMeta', () => {
     expect(result.current.description).toBe('Inbox description');
   });
 
-  it('should fallback to Lobe AI title for builtin agent without custom title', () => {
+  it('should fallback to the default inbox title for builtin agent without custom title', () => {
     const mockInboxAgentId = 'inbox-agent-id';
     const mockMeta = {
       avatar: '/icons/icon-lobe.png',
@@ -113,7 +114,7 @@ describe('useAgentMeta', () => {
     const { result } = renderHook(() => useAgentMeta());
 
     expect(result.current.avatar).toBe('/icons/icon-lobe.png');
-    expect(result.current.title).toBe('Lobe AI');
+    expect(result.current.title).toBe(DEFAULT_INBOX_TITLE);
   });
 
   it('should preserve custom title for page agent (builtin)', () => {

--- a/src/features/Conversation/hooks/useAgentMeta.ts
+++ b/src/features/Conversation/hooks/useAgentMeta.ts
@@ -1,17 +1,16 @@
 import { type MetaData } from '@lobechat/types';
 import { useMemo } from 'react';
 
+import { DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
 import { contextSelectors, useConversationStore } from '../store';
 
-const LOBE_AI_TITLE = 'Lobe AI';
-
 /**
  * Hook to get agent meta data for a specific agent or the current conversation.
  * Handles special cases for builtin agents (inbox, page agent, agent builder)
- * by showing Lobe AI title instead of the agent's own meta.
+ * by showing the default inbox title instead of the agent's own meta.
  * Avatar is now returned from the backend (merged from builtin-agents package).
  *
  * @param messageAgentId - Optional agent ID from the message. If provided, uses this agent's meta.
@@ -30,8 +29,8 @@ export const useAgentMeta = (messageAgentId?: string | null): MetaData => {
     const isBuiltinAgent = builtinAgentIds.includes(agentId);
 
     if (isBuiltinAgent) {
-      // Use DB-stored title if customized (e.g. via onboarding), otherwise fallback to Lobe AI
-      return { ...agentMeta, title: agentMeta.title || LOBE_AI_TITLE };
+      // Use DB-stored title if customized (e.g. via onboarding), otherwise fallback to the default
+      return { ...agentMeta, title: agentMeta.title || DEFAULT_INBOX_TITLE };
     }
 
     return agentMeta;

--- a/src/features/Home/AgentSelect/index.tsx
+++ b/src/features/Home/AgentSelect/index.tsx
@@ -7,7 +7,7 @@ import { ChevronsUpDownIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';
 import { agentService } from '@/services/agent';
 import { useAgentStore } from '@/store/agent';
@@ -68,7 +68,8 @@ const AgentSelect = memo(() => {
   const showInboxFallback = isInbox || !resolvedAgentId;
   const displayMeta = showInboxFallback ? inboxMeta : (sidebarItem ?? agentMapMeta);
   const displayTitle =
-    displayMeta?.title || (showInboxFallback ? 'Lobe AI' : t('defaultSession', { ns: 'common' }));
+    displayMeta?.title ||
+    (showInboxFallback ? DEFAULT_INBOX_TITLE : t('defaultSession', { ns: 'common' }));
   const displayAvatar =
     (typeof displayMeta?.avatar === 'string' ? displayMeta.avatar : undefined) ||
     (showInboxFallback ? DEFAULT_INBOX_AVATAR : DEFAULT_AVATAR);

--- a/src/features/Home/AgentSelect/useHomeAgentRows.ts
+++ b/src/features/Home/AgentSelect/useHomeAgentRows.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import { useKeepSidebarListed } from '@/routes/(main)/home/_layout/Body/Agent/List/useAgentList';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
@@ -100,7 +100,7 @@ export const useHomeAgentRows = (): HomeAgentRows => {
           DEFAULT_INBOX_AVATAR,
         backgroundColor: inboxMeta?.backgroundColor || undefined,
         id: inboxAgentId,
-        title: inboxMeta?.title || 'Lobe AI',
+        title: inboxMeta?.title || DEFAULT_INBOX_TITLE,
       });
     }
     workspaceRows.push(

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -6,7 +6,7 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
-import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
+import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@/const/meta';
 import {
   AgentSettings as Settings,
   SettingsModalLayout,
@@ -81,7 +81,9 @@ const Content = memo(() => {
     [availableTabs, t],
   );
 
-  const displayTitle = isInbox ? 'Lobe AI' : meta.title || t('defaultSession', { ns: 'common' });
+  const displayTitle = isInbox
+    ? DEFAULT_INBOX_TITLE
+    : meta.title || t('defaultSession', { ns: 'common' });
 
   return (
     <SettingsModalLayout


### PR DESCRIPTION
While the app is loading, the inbox agent's title briefly shows the hardcoded upstream string "Lobe AI" before flipping to the branded default, "AI Assistant" (`DEFAULT_INBOX_TITLE`) — the value the backend already persists for a blank inbox title. Six UI call sites hardcoded "Lobe AI" as their loading-state fallback instead of reusing that constant, causing the visible flash on every fresh page load.

| Before | After |
| ------ | ----- |
| Briefly shows "Lobe AI" while the inbox title loads, then flips to "AI Assistant" | Shows "AI Assistant" immediately — fallback matches the settled value, no flash |

#### Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Fixed `useAgentMeta.test.ts`'s assertion, which had encoded the old (buggy) "Lobe AI" fallback as the expected value — it now asserts `DEFAULT_INBOX_TITLE`. `bun run check` on all seven changed files: lint clean, 24 tests passed.

#### 🔗 Related Issue

None — reported directly in conversation, no tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)