### PR TITLE
🐛 fix(billing): stop manual credits from being applied twice

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aico.rbacIdor.test.ts
@@ -85,6 +85,7 @@ const cleanup = async () => {
     platformAdmins,
     platformAdminSessions,
     platformAdminUsers,
+    aicoKeyOutbox,
     platformTrialConfig,
     trialAbuseBlocklist,
     usageLogs,
@@ -93,6 +94,7 @@ const cleanup = async () => {
     walletTransactions,
   } = await import('@/database/schemas/aicoOrganization');
   const { users } = await import('@/database/schemas');
+  await testDB.delete(aicoKeyOutbox);
   await testDB.delete(usageLogs);
   await testDB.delete(trialAbuseBlocklist);
   await testDB.delete(userTrials);
@@ -238,6 +240,7 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     await platformCaller.addManualCredit({
       amountToman: 25_000,
       description: 'analytics seed',
+      idempotencyKey: 'rbac-analytics-seed',
       orgId: created.id,
     });
 
@@ -284,6 +287,7 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     await platformCaller.addManualCredit({
       amountToman: 1_000_000,
       description: 'tenant isolation seed',
+      idempotencyKey: 'rbac-tenant-isolation-seed',
       orgId: orgB.id,
     });
 
@@ -339,13 +343,88 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     await expect(caller.suspendOrganization({ orgId: 'any' })).rejects.toMatchObject({
       code: 'UNAUTHORIZED',
     });
-    await expect(caller.addManualCredit({ amountToman: 1000, orgId: 'any' })).rejects.toMatchObject(
-      { code: 'UNAUTHORIZED' },
-    );
     await expect(
-      caller.addManualUserCredit({ amountToman: 1000, email: 'stranger@rbac.test' }),
+      caller.addManualCredit({
+        amountToman: 1000,
+        idempotencyKey: 'rbac-unauthorized-org',
+        orgId: 'any',
+      }),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await expect(
+      caller.addManualUserCredit({
+        amountToman: 1000,
+        email: 'stranger@rbac.test',
+        idempotencyKey: 'rbac-unauthorized-user',
+      }),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
     await expect(caller.listUserWallets()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  describe('FIN-013 a committed credit is never reported as a failure', () => {
+    it('reports success and queues a key retry when the OpenRouter push fails', async () => {
+      ensureUserKeyMock.mockRejectedValueOnce(new Error('OpenRouter Management API 503'));
+      const platformCaller = platformAdminRouter.createCaller(createAdminContext(operatorId));
+
+      // Before the fix this threw BAD_REQUEST over a wallet that had already
+      // been credited, which is what made an admin retry into a double credit.
+      const result = await platformCaller.addManualUserCredit({
+        amountToman: 30_000,
+        description: 'key push fails',
+        idempotencyKey: 'fin013-key-push-fails',
+        userId: strangerId,
+      });
+
+      expect(result.userId).toBe(strangerId);
+      expect(Number(result.wallet.balanceToman)).toBe(30_000);
+
+      const { aicoKeyOutbox } = await import('@/database/schemas/aicoOrganization');
+      const queued = await testDB.select().from(aicoKeyOutbox);
+      expect(queued).toHaveLength(1);
+      expect(queued[0]).toMatchObject({
+        action: 'sync_user_key',
+        status: 'pending',
+        userId: strangerId,
+      });
+    });
+
+    it('credits once when the admin retries with the same key', async () => {
+      const platformCaller = platformAdminRouter.createCaller(createAdminContext(operatorId));
+      const args = {
+        amountToman: 30_000,
+        description: 'retried credit',
+        idempotencyKey: 'fin013-router-retry',
+        userId: strangerId,
+      };
+
+      const first = await platformCaller.addManualUserCredit(args);
+      const second = await platformCaller.addManualUserCredit(args);
+
+      expect(second.transaction.id).toBe(first.transaction.id);
+      expect(Number(second.wallet.balanceToman)).toBe(30_000);
+
+      const wallets = await platformCaller.listUserWallets();
+      expect(Number(wallets.find((w) => w.userId === strangerId)?.balanceToman)).toBe(30_000);
+    });
+
+    it('credits an org wallet once when the admin retries with the same key', async () => {
+      const ownerCaller = organizationRouter.createCaller(createTestContext(ownerId));
+      const org = await ownerCaller.create({ name: 'FIN-013 Org' });
+      const platformCaller = platformAdminRouter.createCaller(createAdminContext(operatorId));
+      const args = {
+        amountToman: 40_000,
+        description: 'retried org credit',
+        idempotencyKey: 'fin013-org-retry',
+        orgId: org.id,
+      };
+
+      const first = await platformCaller.addManualCredit(args);
+      const second = await platformCaller.addManualCredit(args);
+
+      expect(second.transaction.id).toBe(first.transaction.id);
+      expect(Number(second.organization.walletBalanceMicroUsd)).toBe(
+        Number(first.organization.walletBalanceMicroUsd),
+      );
+    });
   });
 
   it('platform admin can manually credit a B2C user wallet by email', async () => {
@@ -354,6 +433,7 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
       amountToman: 50_000,
       description: 'Support credit',
       email: 'stranger@rbac.test',
+      idempotencyKey: 'rbac-support-credit',
     });
     expect(result.userId).toBe(strangerId);
     expect(result.transaction.type).toBe('manual_credit');
@@ -400,6 +480,7 @@ describe('Aico RBAC / IDOR matrix (Phase 2)', () => {
     await platformCaller.addManualUserCredit({
       amountToman: 50_000,
       description: 'seed for publicCode',
+      idempotencyKey: 'rbac-publiccode-seed',
       userId: strangerId,
     });
     const strangerCaller = aicoBillingRouter.createCaller(createTestContext(strangerId));

--- a/apps/server/src/routers/lambda/platformAdmin.ts
+++ b/apps/server/src/routers/lambda/platformAdmin.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { AicoBillingModel } from '@/database/models/aicoBilling';
 import { OrganizationModel } from '@/database/models/organization';
 import { PlatformAdminUserModel } from '@/database/models/platformAdminUser';
-import { session, users, userWallets } from '@/database/schemas';
+import { aicoKeyOutbox, session, users, userWallets } from '@/database/schemas';
 import {
   DEFAULT_USAGE_MULTIPLIER_BP,
   MAX_USAGE_MULTIPLIER_BP,
@@ -306,61 +306,71 @@ export const platformAdminRouter = router({
     .input(
       topupAmountInputSchema.extend({
         description: z.string().max(500).optional(),
-        idempotencyKey: z.string().min(8).max(128).optional(),
+        // FIN-013: required, not optional. A null gateway_ref_id skips the
+        // partial unique index entirely, which left every manual credit
+        // replayable by a simple retry.
+        idempotencyKey: z.string().min(8).max(128),
         orgId: z.string().min(1),
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      let amountMicroUsd: number;
+      let amountToman: number;
+      let result: Awaited<ReturnType<typeof ctx.organizationModel.addManualCredit>>;
+
       try {
         const fxConfig = await ctx.billingModel.getFxConfig();
-        const { amountMicroUsd, amountToman, fxRateTomanPerUsd } = await resolveTopupAmount(input, {
-          adminRate: fxConfig.tomanPerUsd,
-        });
-        const result = await ctx.organizationModel.addManualCredit({
+        const amounts = await resolveTopupAmount(input, { adminRate: fxConfig.tomanPerUsd });
+        amountMicroUsd = amounts.amountMicroUsd;
+        amountToman = amounts.amountToman;
+        result = await ctx.organizationModel.addManualCredit({
           amountMicroUsd,
           amountToman,
           createdByAdminId: ctx.adminId,
           description: input.description,
-          fxRateTomanPerUsd,
+          fxRateTomanPerUsd: amounts.fxRateTomanPerUsd,
           idempotencyKey: input.idempotencyKey,
           orgId: input.orgId,
           type: 'manual_credit',
         });
-        await recordAicoSecurityEvent(ctx.serverDB, {
-          action: 'platform.credit.org_add',
-          actorAdminId: ctx.adminId,
-          ipAddress: ctx.clientIp,
-          metadata: {
-            amountMicroUsd,
-            amountToman,
-            idempotencyKey: input.idempotencyKey ?? null,
-            transactionId: result.transaction.id,
-          },
-          organizationId: input.orgId,
-          targetId: result.transaction.id,
-          targetType: 'wallet_transaction',
-          userAgent: ctx.userAgent,
-        });
-        return {
-          organization: {
-            ...result.organization,
-            walletBalanceMicroUsd: String(result.organization.walletBalanceMicroUsd ?? 0),
-            walletBalanceUsd: microUsdToDecimalString(
-              result.organization.walletBalanceMicroUsd ?? 0,
-            ),
-          },
-          transaction: {
-            ...result.transaction,
-            amountMicroUsd: String(result.transaction.amountMicroUsd ?? 0),
-            amountUsd: microUsdToDecimalString(result.transaction.amountMicroUsd ?? 0),
-          },
-        };
       } catch (error) {
+        // Nothing committed on this path — a retry is safe.
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: error instanceof Error ? error.message : 'Failed to add credit',
         });
       }
+
+      // FIN-013: the money has moved; a failure below must not be reported as a
+      // failed credit, or the admin's retry credits the org a second time.
+      await recordAicoSecurityEvent(ctx.serverDB, {
+        action: 'platform.credit.org_add',
+        actorAdminId: ctx.adminId,
+        ipAddress: ctx.clientIp,
+        metadata: {
+          amountMicroUsd,
+          amountToman,
+          idempotencyKey: input.idempotencyKey,
+          transactionId: result.transaction.id,
+        },
+        organizationId: input.orgId,
+        targetId: result.transaction.id,
+        targetType: 'wallet_transaction',
+        userAgent: ctx.userAgent,
+      }).catch((error) => console.error('[aico] failed to record credit audit event', error));
+
+      return {
+        organization: {
+          ...result.organization,
+          walletBalanceMicroUsd: String(result.organization.walletBalanceMicroUsd ?? 0),
+          walletBalanceUsd: microUsdToDecimalString(result.organization.walletBalanceMicroUsd ?? 0),
+        },
+        transaction: {
+          ...result.transaction,
+          amountMicroUsd: String(result.transaction.amountMicroUsd ?? 0),
+          amountUsd: microUsdToDecimalString(result.transaction.amountMicroUsd ?? 0),
+        },
+      };
     }),
 
   /**
@@ -436,7 +446,8 @@ export const platformAdminRouter = router({
       topupAmountInputSchema.extend({
         description: z.string().max(500).optional(),
         email: z.string().email().optional(),
-        idempotencyKey: z.string().min(8).max(128).optional(),
+        // FIN-013: required — see addManualCredit above.
+        idempotencyKey: z.string().min(8).max(128),
         publicCode: z.string().min(1).max(32).optional(),
         userId: z.string().min(1).optional(),
       }),
@@ -456,61 +467,81 @@ export const platformAdminRouter = router({
         });
       }
 
+      let amountMicroUsd: number;
+      let amountToman: number;
+      let result: Awaited<ReturnType<typeof ctx.billingModel.manualCreditUser>>;
+
       try {
         const fxConfig = await ctx.billingModel.getFxConfig();
-        const { amountMicroUsd, amountToman, fxRateTomanPerUsd } = await resolveTopupAmount(input, {
-          adminRate: fxConfig.tomanPerUsd,
-        });
-        const result = await ctx.billingModel.manualCreditUser({
+        const amounts = await resolveTopupAmount(input, { adminRate: fxConfig.tomanPerUsd });
+        amountMicroUsd = amounts.amountMicroUsd;
+        amountToman = amounts.amountToman;
+        result = await ctx.billingModel.manualCreditUser({
           amountMicroUsd,
           amountToman,
           createdByAdminId: ctx.adminId,
           description: input.description,
-          fxRateTomanPerUsd,
+          fxRateTomanPerUsd: amounts.fxRateTomanPerUsd,
           idempotencyKey: input.idempotencyKey,
           userId,
         });
-
-        // Ensure the user can spend the new balance via a managed key.
-        const keyService = new AicoOpenRouterKeyService(ctx.serverDB);
-        await keyService.ensureUserKey(userId);
-
-        await recordAicoSecurityEvent(ctx.serverDB, {
-          action: 'platform.credit.user_add',
-          actorAdminId: ctx.adminId,
-          ipAddress: ctx.clientIp,
-          metadata: {
-            amountMicroUsd,
-            amountToman,
-            idempotencyKey: input.idempotencyKey ?? null,
-            targetUserId: userId,
-            transactionId: result.transaction.id,
-          },
-          targetId: userId,
-          targetType: 'user',
-          userAgent: ctx.userAgent,
-        });
-
-        return {
-          transaction: {
-            ...result.transaction,
-            amountMicroUsd: String(result.transaction.amountMicroUsd ?? 0),
-            amountToman: tomanString(result.transaction.amountToman ?? 0),
-            amountUsd: microUsdToDecimalString(result.transaction.amountMicroUsd ?? 0),
-          },
-          userId,
-          wallet: {
-            balanceMicroUsd: String(result.wallet.balanceMicroUsd ?? 0),
-            balanceToman: tomanString(result.wallet.balanceToman ?? 0),
-            balanceUsd: microUsdToDecimalString(result.wallet.balanceMicroUsd ?? 0),
-          },
-        };
       } catch (error) {
+        // Nothing has been committed on this path, so reporting a failure here
+        // is honest and a retry is safe.
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: error instanceof Error ? error.message : 'Failed to add user credit',
         });
       }
+
+      // FIN-013: the money has moved. Nothing below may turn this into a reported
+      // failure — an admin who sees "credit failed" over a committed credit
+      // retries, and the retry credits the wallet a second time.
+      try {
+        // Push the new balance to the managed key so the user can spend it.
+        await new AicoOpenRouterKeyService(ctx.serverDB).ensureUserKey(userId);
+      } catch (error) {
+        console.error('[aico] user credit committed but OpenRouter key push failed', error);
+        // Without a retry the wallet stays funded behind a stale key limit until
+        // an operator re-runs the credit by hand.
+        await ctx.serverDB
+          .insert(aicoKeyOutbox)
+          .values({ action: 'sync_user_key', nextAttemptAt: new Date(), status: 'pending', userId })
+          .catch((enqueueError) =>
+            console.error('[aico] failed to enqueue sync_user_key retry', enqueueError),
+          );
+      }
+
+      await recordAicoSecurityEvent(ctx.serverDB, {
+        action: 'platform.credit.user_add',
+        actorAdminId: ctx.adminId,
+        ipAddress: ctx.clientIp,
+        metadata: {
+          amountMicroUsd,
+          amountToman,
+          idempotencyKey: input.idempotencyKey,
+          targetUserId: userId,
+          transactionId: result.transaction.id,
+        },
+        targetId: userId,
+        targetType: 'user',
+        userAgent: ctx.userAgent,
+      }).catch((error) => console.error('[aico] failed to record credit audit event', error));
+
+      return {
+        transaction: {
+          ...result.transaction,
+          amountMicroUsd: String(result.transaction.amountMicroUsd ?? 0),
+          amountToman: tomanString(result.transaction.amountToman ?? 0),
+          amountUsd: microUsdToDecimalString(result.transaction.amountMicroUsd ?? 0),
+        },
+        userId,
+        wallet: {
+          balanceMicroUsd: String(result.wallet.balanceMicroUsd ?? 0),
+          balanceToman: tomanString(result.wallet.balanceToman ?? 0),
+          balanceUsd: microUsdToDecimalString(result.wallet.balanceMicroUsd ?? 0),
+        },
+      };
     }),
 
   addPlatformAdmin: platformProcedure

--- a/apps/server/src/services/aico/renewalScheduler.ts
+++ b/apps/server/src/services/aico/renewalScheduler.ts
@@ -546,6 +546,15 @@ const runOutboxAction = async (params: {
       return;
     }
 
+    // FIN-013: a credit commits before its key limit is pushed. When that push
+    // fails the wallet is funded behind a stale limit, so the retry lands here
+    // rather than being reported to the admin as a failed credit.
+    case 'sync_user_key': {
+      if (!row.userId) throw new Error('USER_ID_REQUIRED');
+      await keyService.ensureUserKey(row.userId);
+      return;
+    }
+
     case 'reclaim_member': {
       if (!row.orgMemberId || !row.orgId) throw new Error('ORG_MEMBER_ID_REQUIRED');
       const reclaimed = await keyService.reclaimMemberKey({

--- a/packages/database/src/models/__tests__/aicoBilling.manualCreditUser.test.ts
+++ b/packages/database/src/models/__tests__/aicoBilling.manualCreditUser.test.ts
@@ -1,3 +1,4 @@
+import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -93,5 +94,86 @@ describe('AicoBillingModel.manualCreditUser', () => {
     expect(rows[0]?.actorAdminEmail).toBe('operator@manual-credit.test');
     expect(rows[0]?.userEmail).toBe('user@manual-credit.test');
     expect(rows[0]?.description).toBe('Ops credit');
+  });
+
+  describe('FIN-013 idempotency', () => {
+    const credit = (idempotencyKey: string) =>
+      billingModel.manualCreditUser({
+        amountMicroUsd: 2_000_000,
+        amountToman: 10_000,
+        createdByAdminId: operatorId,
+        fxRateTomanPerUsd: 5000,
+        idempotencyKey,
+        userId,
+      });
+
+    it('credits balance and capacity exactly once when the same key is retried', async () => {
+      const first = await credit('fin013-sequential-retry');
+      const second = await credit('fin013-sequential-retry');
+
+      expect(second.transaction.id).toBe(first.transaction.id);
+
+      const [wallet] = await serverDB
+        .select()
+        .from(userWallets)
+        .where(eq(userWallets.userId, userId));
+      expect(Number(wallet.balanceMicroUsd)).toBe(2_000_000);
+      expect(Number(wallet.balanceToman)).toBe(10_000);
+      // The OpenRouter key limit is pushed from capacity, so a double-credit
+      // here would hand out spend the user never paid for.
+      expect(Number(wallet.rawCapacityMicroUsd)).toBeGreaterThan(0);
+      const capacityAfterRetry = Number(wallet.rawCapacityMicroUsd);
+
+      const rows = await serverDB
+        .select()
+        .from(walletTransactions)
+        .where(eq(walletTransactions.gatewayRefId, 'fin013-sequential-retry'));
+      expect(rows).toHaveLength(1);
+
+      const third = await credit('fin013-sequential-retry');
+      expect(third.transaction.id).toBe(first.transaction.id);
+      const [afterThird] = await serverDB
+        .select()
+        .from(userWallets)
+        .where(eq(userWallets.userId, userId));
+      expect(Number(afterThird.rawCapacityMicroUsd)).toBe(capacityAfterRetry);
+    });
+
+    it('resolves concurrent submits of one key to a single credit', async () => {
+      // Both callers clear the pre-check before either commits, so the unique
+      // index is what separates them. The loser must return the winner's
+      // transaction rather than an error the admin would retry.
+      const [a, b] = await Promise.all([credit('fin013-concurrent'), credit('fin013-concurrent')]);
+
+      expect(a.transaction.id).toBe(b.transaction.id);
+
+      const [wallet] = await serverDB
+        .select()
+        .from(userWallets)
+        .where(eq(userWallets.userId, userId));
+      expect(Number(wallet.balanceMicroUsd)).toBe(2_000_000);
+
+      const rows = await serverDB
+        .select()
+        .from(walletTransactions)
+        .where(eq(walletTransactions.gatewayRefId, 'fin013-concurrent'));
+      expect(rows).toHaveLength(1);
+    });
+
+    it('rejects a key already used for a different user', async () => {
+      await credit('fin013-cross-user');
+      await serverDB.insert(users).values({ email: 'other@manual-credit.test', id: 'other-user' });
+
+      await expect(
+        billingModel.manualCreditUser({
+          amountMicroUsd: 2_000_000,
+          amountToman: 10_000,
+          createdByAdminId: operatorId,
+          fxRateTomanPerUsd: 5000,
+          idempotencyKey: 'fin013-cross-user',
+          userId: 'other-user',
+        }),
+      ).rejects.toThrow('IDEMPOTENCY_KEY_CONFLICT');
+    });
   });
 });

--- a/packages/database/src/models/aicoBilling.ts
+++ b/packages/database/src/models/aicoBilling.ts
@@ -76,9 +76,19 @@ export const normalizeIranianPhoneForFingerprint = (raw: string): string => {
   throw new Error('INVALID_PHONE');
 };
 
-/** Postgres unique_violation. */
-const isUniqueConstraintViolation = (error: unknown): boolean =>
-  Boolean(error && typeof error === 'object' && (error as { code?: string }).code === '23505');
+/**
+ * Postgres unique_violation. Drizzle wraps driver errors in a `Failed query:`
+ * Error and hangs the original off `cause`, so the code is not always on the
+ * error we are handed.
+ */
+const isUniqueConstraintViolation = (error: unknown): boolean => {
+  let current = error;
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth += 1) {
+    if ((current as { code?: string }).code === '23505') return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+};
 
 export const fingerprintPhone = (phone: string): string =>
   createHash('sha256')
@@ -159,12 +169,12 @@ export class AicoBillingModel {
       }
     }
 
-    return this.db.transaction(async (tx) => {
-      await tx.insert(userWallets).values({ userId: params.userId }).onConflictDoNothing({
-        target: userWallets.userId,
-      });
+    const applyCredit = () =>
+      this.db.transaction(async (tx) => {
+        await tx.insert(userWallets).values({ userId: params.userId }).onConflictDoNothing({
+          target: userWallets.userId,
+        });
 
-      try {
         const before = await tx.query.userWallets.findFirst({
           where: eq(userWallets.userId, params.userId),
         });
@@ -211,14 +221,26 @@ export class AicoBillingModel {
           .returning();
 
         return { transaction: txRow, wallet };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (params.idempotencyKey && /gateway_ref|unique|duplicate/i.test(message)) {
-          throw new Error('IDEMPOTENCY_KEY_CONFLICT', { cause: error });
-        }
-        throw error;
+      });
+
+    if (!params.idempotencyKey) return applyCredit();
+
+    try {
+      return await applyCredit();
+    } catch (error) {
+      // FIN-013: a concurrent submit carrying the same key won the race. The
+      // credit it committed is the one this caller asked for, so return it —
+      // surfacing an error here is what makes an admin retry into a double credit.
+      if (!isUniqueConstraintViolation(error)) throw error;
+      const existingTx = await this.db.query.walletTransactions.findFirst({
+        where: eq(walletTransactions.gatewayRefId, params.idempotencyKey),
+      });
+      if (!existingTx) throw error;
+      if (existingTx.userId !== params.userId || existingTx.type !== 'manual_credit') {
+        throw new Error('IDEMPOTENCY_KEY_CONFLICT', { cause: error });
       }
-    });
+      return { transaction: existingTx, wallet: await this.getOrCreateUserWallet(params.userId) };
+    }
   };
 
   /**

--- a/packages/database/src/models/organization.ts
+++ b/packages/database/src/models/organization.ts
@@ -88,9 +88,19 @@ export const seedDefaultTeamModels = async (
     .returning();
 };
 
-/** Postgres unique_violation. */
-const isUniqueConstraintViolation = (error: unknown): boolean =>
-  Boolean(error && typeof error === 'object' && (error as { code?: string }).code === '23505');
+/**
+ * Postgres unique_violation. Drizzle wraps driver errors in a `Failed query:`
+ * Error and hangs the original off `cause`, so the code is not always on the
+ * error we are handed.
+ */
+const isUniqueConstraintViolation = (error: unknown): boolean => {
+  let current = error;
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth += 1) {
+    if ((current as { code?: string }).code === '23505') return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+};
 
 /**
  * UTC period-window computation — intentionally duplicated (not imported)
@@ -578,8 +588,8 @@ export class OrganizationModel {
       }
     }
 
-    return this.db.transaction(async (tx) => {
-      try {
+    const applyCredit = () =>
+      this.db.transaction(async (tx) => {
         const before = await tx.query.organizations.findFirst({
           where: eq(organizations.id, params.orgId),
         });
@@ -617,14 +627,28 @@ export class OrganizationModel {
           .returning();
 
         return { organization: org, transaction: txRow };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (params.idempotencyKey && /gateway_ref|unique|duplicate/i.test(message)) {
-          throw new Error('IDEMPOTENCY_KEY_CONFLICT', { cause: error });
-        }
-        throw error;
+      });
+
+    if (!params.idempotencyKey) return applyCredit();
+
+    try {
+      return await applyCredit();
+    } catch (error) {
+      // FIN-013: a concurrent submit carrying the same key won the race. Return
+      // the credit it committed rather than an error the admin would retry into
+      // a second credit.
+      if (!isUniqueConstraintViolation(error)) throw error;
+      const existingTx = await this.db.query.walletTransactions.findFirst({
+        where: eq(walletTransactions.gatewayRefId, params.idempotencyKey),
+      });
+      if (!existingTx) throw error;
+      if (existingTx.orgId !== params.orgId || existingTx.type !== type) {
+        throw new Error('IDEMPOTENCY_KEY_CONFLICT', { cause: error });
       }
-    });
+      const organization = await this.getById(params.orgId);
+      if (!organization) throw new Error('ORG_NOT_FOUND', { cause: error });
+      return { organization, transaction: existingTx };
+    }
   };
 
   // ─── Members ───────────────────────────────────────────────────────

--- a/packages/database/src/schemas/aicoOrganization.ts
+++ b/packages/database/src/schemas/aicoOrganization.ts
@@ -505,7 +505,7 @@ export const aicoKeyOutbox = pgTable(
       .$defaultFn(() => idGenerator('keyOutbox'))
       .notNull()
       .primaryKey(),
-    /** disable_member_key | reclaim_member | disable_user_key | disable_trial_keys */
+    /** disable_member_key | reclaim_member | disable_user_key | disable_trial_keys | sync_user_key */
     action: text('action').notNull(),
     orgId: text('org_id').references(() => organizations.id, { onDelete: 'set null' }),
     orgMemberId: text('org_member_id').references(() => organizationMembers.id, {

--- a/src/features/PlatformAdmin/PlatformAdminPanel.tsx
+++ b/src/features/PlatformAdmin/PlatformAdminPanel.tsx
@@ -5,11 +5,12 @@
  * Talks to `@aico/control-plane` via `controlPlaneClient` (not the product lambda).
  */
 
+import { uuid } from '@lobechat/utils';
 import { Block, Flexbox, Tag, Text } from '@lobehub/ui';
 import { Button, Select, Switch, Tabs, toast } from '@lobehub/ui/base-ui';
 import { Form, Input, InputNumber, Table } from 'antd';
 import { Building2Icon, RefreshCwIcon, ShieldIcon, WalletIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { toastAicoError } from '@/business/client/resolveAicoErrorMessage';
@@ -50,10 +51,17 @@ export const PlatformAdminPanel = () => {
   // guard in onFinish.
   const [creditForm] = Form.useForm<FxTopupFormValues & { description?: string; orgId?: string }>();
   const [creditChargeField, setCreditChargeField] = useState<FxTopupChargeField>('toman');
+  /**
+   * FIN-013: one key per in-flight credit attempt, held until the credit is
+   * known to have landed. A retry after a failure reuses it, so the second
+   * attempt resolves to the same transaction instead of crediting again.
+   */
+  const creditIdempotencyKeyRef = useRef<string | null>(null);
   const [userCreditForm] = Form.useForm<
     FxTopupFormValues & { description?: string; email?: string; userId?: string }
   >();
   const [userCreditChargeField, setUserCreditChargeField] = useState<FxTopupChargeField>('toman');
+  const userCreditIdempotencyKeyRef = useRef<string | null>(null);
   const [assignForm] = Form.useForm<{
     managerEmail: string;
     orgId: string;
@@ -951,14 +959,17 @@ export const PlatformAdminPanel = () => {
                 onFinish={async (values) => {
                   const payload = resolveFxTopupPayload(values, creditChargeField);
                   if (!payload || !values.orgId) return;
+                  creditIdempotencyKeyRef.current ??= uuid();
                   setBusy(true);
                   try {
                     await controlPlaneClient.platformAdmin.addManualCredit.mutate({
                       ...payload,
                       description: values.description,
+                      idempotencyKey: creditIdempotencyKeyRef.current,
                       orgId: values.orgId,
                     });
                     toast.success(t('platform.credited'));
+                    creditIdempotencyKeyRef.current = null;
                     creditForm.resetFields(['amountToman', 'amountUsd', 'description']);
                     await Promise.all([mutate(), mutateFinancials()]);
                   } catch (err) {
@@ -966,6 +977,11 @@ export const PlatformAdminPanel = () => {
                   } finally {
                     setBusy(false);
                   }
+                }}
+                // Editing the form starts a new logical credit, so the held key
+                // cannot make the next submit resolve to the previous amount.
+                onValuesChange={() => {
+                  creditIdempotencyKeyRef.current = null;
                 }}
               >
                 <Form.Item label={t('platform.orgId')} name="orgId" rules={[{ required: true }]}>
@@ -1011,15 +1027,18 @@ export const PlatformAdminPanel = () => {
                   }
                   const payload = resolveFxTopupPayload(values, userCreditChargeField);
                   if (!payload) return;
+                  userCreditIdempotencyKeyRef.current ??= uuid();
                   setBusy(true);
                   try {
                     await controlPlaneClient.platformAdmin.addManualUserCredit.mutate({
                       ...payload,
                       description: values.description,
                       email: values.email || undefined,
+                      idempotencyKey: userCreditIdempotencyKeyRef.current,
                       userId: values.userId || undefined,
                     });
                     toast.success(t('platform.userCredited'));
+                    userCreditIdempotencyKeyRef.current = null;
                     userCreditForm.resetFields(['amountToman', 'amountUsd', 'description']);
                     await Promise.all([mutateUserWallets(), mutateFinancials()]);
                   } catch (err) {
@@ -1027,6 +1046,9 @@ export const PlatformAdminPanel = () => {
                   } finally {
                     setBusy(false);
                   }
+                }}
+                onValuesChange={() => {
+                  userCreditIdempotencyKeyRef.current = null;
                 }}
               >
                 <div className={aicoPanelStyles.formRow}>


### PR DESCRIPTION
Closes #364

## Summary

Manual credits could be applied twice, handing out OpenRouter capacity nobody paid for. Two faults compounded: the idempotency key was optional and no UI sent one, so `gateway_ref_id` was always `NULL` and the partial unique index never fired; and a post-commit `ensureUserKey` failure was reported to the admin as *"credit failed"* over a wallet that had already been funded, making the natural retry credit it again — balance **and** `raw_capacity_micro_usd`, which is pushed to OpenRouter as the key's lifetime spend limit.

## Changes

- **`idempotencyKey` is now required** on `addManualCredit` and `addManualUserCredit`, and both admin forms send one. The control plane composes the same `platformAdminRouter` and the SPA client is typed from it, so this is enforced end to end.
- **The mutations split at the commit boundary.** Failures before the credit commits still report honestly and are safe to retry; the key push and audit event afterwards are best-effort and can no longer turn a committed credit into a reported failure.
- **A failed key push retries** through a new `sync_user_key` outbox action rather than leaving the wallet funded behind a stale limit. No migration — `aico_key_outbox.action` is free text.
- **Concurrent submits of one key resolve to a single credit.** The loser now returns the winner's transaction instead of throwing.
- **`isUniqueConstraintViolation` now walks the `cause` chain** in both models. Drizzle wraps driver errors, so the SQLSTATE `23505` check never matched — this also silently broke the existing correct use of the helper in `activateTrial`.

## Notes for review

**The form resets its key on edit.** `onValuesChange` clears the held key. Without this, an admin who edits the amount after a failure would reuse the key, and the server would resolve the submit to the *previous* transaction — reporting success while crediting the old amount.

**Audit events are now best-effort.** A deliberate trade: a committed credit must never be reported as failed. Failures are logged, and the `wallet_transactions` row remains the durable record.

**Existing test call sites were updated** to pass a key, since the field is now required. Model-level `addManualCredit` keeps `idempotencyKey` optional — only the router requires it.

## Test plan

- [x] `bun run check --lint --test` over all 8 changed files — **62 tests pass, lint clean**
- [x] New regression tests in `aicoBilling.manualCreditUser.test.ts` (`FIN-013 idempotency`): same key retried credits balance and capacity exactly once; concurrent submits resolve to one credit; a key reused for a different user is rejected
- [x] New regression tests in `aico.rbacIdor.test.ts` (`FIN-013 a committed credit is never reported as a failure`): a failing key push still returns success and queues `sync_user_key`; admin retry credits once; org retry credits once
- [x] **Verified the tests actually catch the bug** — temporarily restoring the old behaviour made the key-push test fail with `TRPCError: OpenRouter Management API 503` over a committed credit, the exact reported symptom
- [x] Full type check clean. The one `MessageCostBadge.tsx` error is pre-existing on `canary` — confirmed by running the baseline with these changes stashed

## Out of scope

FIN-014 and FIN-015 (the other two P0s from the audit) are untouched and still open. FIN-014 in particular can push a member's OpenRouter key limit far above their funded cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)