### PR TITLE
🐛 fix(billing): never bill a period budget from OpenRouter's lifetime counter

### DIFF
--- a/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
+++ b/apps/server/src/services/openrouter/aico.keyFailureInjection.test.ts
@@ -465,6 +465,141 @@ describe('Aico OpenRouter failure injection (Phase 2)', () => {
     expect(budget!.settledUsageMicroUsd).toBe(2_400_000);
   });
 
+  describe('FIN-014 a missing period counter must never fall back to lifetime usage', () => {
+    const seedDailyBudget = async (
+      keyId: string,
+      keyInfo: Record<string, unknown>,
+      budgetOverrides: Record<string, unknown> = {},
+    ) => {
+      const { OrganizationModel } = await import('@/database/models/organization');
+      const orgModel = new OrganizationModel(db);
+      const org = await orgModel.createOrganization({
+        name: `FIN014 ${keyId}`,
+        ownerUserId: userId,
+      });
+      const members = await orgModel.listMembers(org.id);
+      const ownerMember = members[0];
+
+      const client = new ControllableOpenRouterClient();
+      const keys = new AicoOpenRouterKeyService(db, client);
+
+      await db.insert(memberBudgets).values({
+        isActive: true,
+        openrouterKeyCiphertext: 'enc',
+        openrouterKeyId: keyId,
+        orgId: org.id,
+        orgMemberId: ownerMember.id,
+        period: 'daily',
+        periodAmountMicroUsd: 10_000_000,
+        reservedMicroUsd: 10_000_000,
+        settledUsageMicroUsd: 0,
+        ...budgetOverrides,
+      });
+
+      client.keys.set(keyId, {
+        disabled: false,
+        hash: keyId,
+        key: `${FAKE_SECRET}-${keyId}`,
+        limit: 10,
+        name: 'test',
+        ...keyInfo,
+      });
+
+      return { client, keys, orgModel, ownerMember };
+    };
+
+    it('does not stamp the checkpoint baseline with lifetime usage, so the key limit stays at the funded cap', async () => {
+      // A stale checkpoint rate forces the rebase path, and OpenRouter reports
+      // no daily counter. Before the fix the $500 lifetime figure became the
+      // baseline, and the key was then pushed a $500 limit against a $10/day cap.
+      const { client, keys, orgModel, ownerMember } = await seedDailyBudget(
+        'ctrl_fin014_rebase',
+        { limitRemaining: 8, usage: 500, usageDaily: null, usageMonthly: null, usageWeekly: null },
+        { checkpointMultiplierBp: 11_000 },
+      );
+
+      await keys.syncMemberCycleUsage(ownerMember.id);
+
+      const budget = await orgModel.getMemberBudget(ownerMember.id);
+      expect(Number(budget!.usageBaselineMicroUsd ?? 0)).toBe(0);
+      expect(Number(budget!.checkpointMultiplierBp)).toBe(11_000);
+
+      await keys.ensureMemberKey(ownerMember.id);
+      const key = client.keys.get('ctrl_fin014_rebase');
+      // $10 cycle cap ÷ the 1.2x platform multiplier — never the lifetime figure.
+      expect(key.limit).toBeCloseTo(8.333_333, 6);
+      expect(key.limit).toBeLessThan(10);
+    });
+
+    it('holds settled usage at the last known value instead of saturating the cap', async () => {
+      // Neither `limit_remaining` nor a period counter is available. Converting
+      // lifetime usage here would bill $50 against a $10 cap, clamp to the cap
+      // and strand the member for the rest of the day.
+      const { keys, orgModel, ownerMember } = await seedDailyBudget(
+        'ctrl_fin014_settle',
+        {
+          limitRemaining: null,
+          usage: 50,
+          usageDaily: null,
+          usageMonthly: null,
+          usageWeekly: null,
+        },
+        { settledUsageMicroUsd: 1_000_000 },
+      );
+
+      await keys.syncMemberCycleUsage(ownerMember.id);
+
+      const budget = await orgModel.getMemberBudget(ownerMember.id);
+      expect(Number(budget!.settledUsageMicroUsd)).toBe(1_000_000);
+    });
+
+    it('records the degraded sync so the gap is visible to operators', async () => {
+      const { keys, orgModel, ownerMember } = await seedDailyBudget(
+        'ctrl_fin014_status',
+        { limitRemaining: 8, usage: 500, usageDaily: null, usageMonthly: null, usageWeekly: null },
+        { checkpointMultiplierBp: 11_000 },
+      );
+
+      await keys.syncMemberCycleUsage(ownerMember.id);
+
+      const budget = await orgModel.getMemberBudget(ownerMember.id);
+      expect(budget!.lastSyncStatus).toBe('degraded');
+      expect(budget!.lastSyncError).toMatch(/period usage counter/i);
+    });
+
+    it('still reads the lifetime counter for a legacy total budget', async () => {
+      // `total` budgets are created without `limit_reset`, so OpenRouter meters
+      // them on the lifetime counter and it remains the correct source.
+      const { keys, orgModel, ownerMember } = await seedDailyBudget(
+        'ctrl_fin014_total',
+        { limitRemaining: null, usage: 2, usageDaily: null, usageMonthly: null, usageWeekly: null },
+        { period: 'total', settledUsageMicroUsd: 0 },
+      );
+
+      await keys.syncMemberCycleUsage(ownerMember.id);
+
+      const budget = await orgModel.getMemberBudget(ownerMember.id);
+      expect(Number(budget!.settledUsageMicroUsd)).toBe(2_400_000);
+      expect(budget!.lastSyncStatus).toBe('synced');
+    });
+
+    it('still uses the period counter when OpenRouter reports one', async () => {
+      const { keys, orgModel, ownerMember } = await seedDailyBudget('ctrl_fin014_happy', {
+        limitRemaining: 8,
+        usage: 50,
+        usageDaily: 2,
+        usageMonthly: 50,
+        usageWeekly: 50,
+      });
+
+      await keys.syncMemberCycleUsage(ownerMember.id);
+
+      const budget = await orgModel.getMemberBudget(ownerMember.id);
+      expect(Number(budget!.settledUsageMicroUsd)).toBe(2_400_000);
+      expect(budget!.lastSyncStatus).toBe('synced');
+    });
+  });
+
   it('FIN-004: recreate after 404 disables/deletes the stale key hash', async () => {
     const billing = new AicoBillingModel(db);
     const client = new ControllableOpenRouterClient();

--- a/apps/server/src/services/openrouter/keyService.ts
+++ b/apps/server/src/services/openrouter/keyService.ts
@@ -8,6 +8,7 @@ import {
   type BudgetPeriod,
   currentCycleLimitMicroUsd,
   DEFAULT_USAGE_MULTIPLIER_BP,
+  isPeriodScopedBudget,
   isStaleManagedKeyId,
   keyLimitFromBilled,
   microUsdToDecimalString,
@@ -23,6 +24,9 @@ import {
   type OpenRouterKeyLimitReset,
   type OpenRouterManagementClient,
 } from './management';
+
+const MISSING_PERIOD_COUNTER =
+  'OpenRouter reported no period usage counter for this budget; usage held at the last settled value';
 
 const locks = new Map<string, Promise<unknown>>();
 const runExclusive = <T>(key: string, fn: () => Promise<T>): Promise<T> => {
@@ -104,6 +108,12 @@ export class AicoOpenRouterKeyService {
    * multiplier checkpoint baseline must be period-scoped too — using lifetime
    * `info.usage` here would leave the baseline and the metered value in
    * different units and corrupt every subsequent conversion.
+   *
+   * Returns `null` when a period-scoped budget has no period counter to read.
+   * OpenRouter genuinely omits `usage_daily`/`usage_weekly`/`usage_monthly` for
+   * some key shapes, and substituting lifetime usage there is what corrupted
+   * the checkpoint and pushed key limits far above the funded cap. Callers must
+   * degrade rather than guess.
    */
   private rawMeteredUsageMicro = (
     budget: { period?: string | null },
@@ -113,17 +123,22 @@ export class AicoOpenRouterKeyService {
       usageMonthly?: number | null;
       usageWeekly?: number | null;
     },
-  ): number => {
+  ): number | null => {
+    // A `total` budget has no `limit_reset`, so OpenRouter meters it on the
+    // lifetime counter and that counter is the correct source.
+    if (!isPeriodScopedBudget(budget.period)) {
+      return Number(openRouterUsdToMicroFloor(info.usage ?? 0));
+    }
+
     const periodUsageUsd =
       budget.period === 'daily'
         ? info.usageDaily
         : budget.period === 'weekly'
           ? info.usageWeekly
-          : budget.period === 'monthly'
-            ? info.usageMonthly
-            : null;
-    const source = periodUsageUsd ?? info.usage ?? 0;
-    return Number(openRouterUsdToMicroFloor(source));
+          : info.usageMonthly;
+
+    if (periodUsageUsd == null) return null;
+    return Number(openRouterUsdToMicroFloor(periodUsageUsd));
   };
 
   /**
@@ -134,11 +149,23 @@ export class AicoOpenRouterKeyService {
   private syncMemberCheckpoint = async (params: {
     checkpoint: UsageMultiplierCheckpoint;
     orgMemberId: string;
-    rawUsage: number;
-  }): Promise<{ bp: number; checkpoint: UsageMultiplierCheckpoint }> => {
+    rawUsage: number | null;
+  }): Promise<{ bp: number; checkpoint: UsageMultiplierCheckpoint; degraded: boolean }> => {
     const bp = await this.billingModel.getUsageMultiplierBp();
     const currentBp = Number(params.checkpoint.checkpointMultiplierBp ?? bp);
-    if (currentBp === bp) return { bp, checkpoint: params.checkpoint };
+    if (currentBp === bp) {
+      return { bp, checkpoint: params.checkpoint, degraded: params.rawUsage === null };
+    }
+
+    // The rebase stamps the baseline with the raw counter, and the key limit is
+    // derived from that baseline. Rebasing against an unknown counter is what
+    // let a lifetime figure become the baseline of a daily budget and push a
+    // limit orders of magnitude above the funded cap — hold the old checkpoint
+    // (and its rate, since usage is still expressed in it) until a real counter
+    // arrives.
+    if (params.rawUsage === null) {
+      return { bp: currentBp, checkpoint: params.checkpoint, degraded: true };
+    }
 
     const rebased = rebaseCheckpoint({
       checkpoint: params.checkpoint,
@@ -152,7 +179,7 @@ export class AicoOpenRouterKeyService {
       usageBaselineMicroUsd: rebased.usageBaselineMicroUsd,
     });
 
-    return { bp, checkpoint: { ...rebased, checkpointMultiplierBp: bp } };
+    return { bp, checkpoint: { ...rebased, checkpointMultiplierBp: bp }, degraded: false };
   };
 
   ensureUserKey = async (userId: string) => {
@@ -372,12 +399,18 @@ export class AicoOpenRouterKeyService {
     // same counter the key limit is enforced against, since the checkpoint
     // baseline is expressed in those units.
     const bp = await this.billingModel.getUsageMultiplierBp();
-    const usageMicro = billedUsageFromRaw({
-      baselineRaw: Number(budget.usageBaselineMicroUsd ?? 0),
-      billedBefore: Number(budget.billedUsageBeforeBaselineMicroUsd ?? 0),
-      bp: Number(budget.checkpointMultiplierBp ?? bp),
-      rawUsage: this.rawMeteredUsageMicro(budget, info),
-    });
+    const rawUsage = this.rawMeteredUsageMicro(budget, info);
+    // With no period counter the last settled figure is the most we can honestly
+    // claim was spent; lifetime usage would over-state it and under-refund the org.
+    const usageMicro =
+      rawUsage === null
+        ? Math.max(0, Number(budget.settledUsageMicroUsd ?? 0))
+        : billedUsageFromRaw({
+            baselineRaw: Number(budget.usageBaselineMicroUsd ?? 0),
+            billedBefore: Number(budget.billedUsageBeforeBaselineMicroUsd ?? 0),
+            bp: Number(budget.checkpointMultiplierBp ?? bp),
+            rawUsage,
+          });
     const currentCycle = currentCycleLimitMicroUsd(budget);
     const pendingHeld = Math.max(0, Number(budget.pendingPeriodAmountMicroUsd ?? 0));
     const remainingFromOr =
@@ -496,7 +529,16 @@ export class AicoOpenRouterKeyService {
     } else if (periodUsageMicro != null) {
       usageMicro = Math.min(currentCycle, Math.max(0, periodUsageMicro));
       remainingMicro = Math.max(0, currentCycle - usageMicro);
+    } else if (isPeriodScopedBudget(budget.period)) {
+      // Neither `limit_remaining` nor the period counter is available. Lifetime
+      // `info.usage` spans earlier cycles, so converting it here saturates
+      // usage at the cap and strands the member for the rest of the period —
+      // which is also what the docstring above promises never to do. Hold the
+      // last settled figure until a real counter arrives.
+      usageMicro = Math.min(currentCycle, priorSettled);
+      remainingMicro = Math.max(0, currentCycle - usageMicro);
     } else {
+      // A `total` budget is metered on the lifetime counter, so it is correct here.
       usageMicro = toBilledUsage(Number(openRouterUsdToMicroFloor(info.usage ?? 0)));
       usageMicro = Math.min(currentCycle, Math.max(0, usageMicro));
       remainingMicro = Math.max(0, currentCycle - usageMicro);
@@ -523,7 +565,7 @@ export class AicoOpenRouterKeyService {
     if (!budget?.openrouterKeyId) return null;
 
     const info = await this.client.getKey(budget.openrouterKeyId);
-    const { bp, checkpoint } = await this.syncMemberCheckpoint({
+    const { bp, checkpoint, degraded } = await this.syncMemberCheckpoint({
       checkpoint: budget,
       orgMemberId,
       rawUsage: this.rawMeteredUsageMicro(budget, info),
@@ -537,6 +579,8 @@ export class AicoOpenRouterKeyService {
     await this.orgModel.syncMemberBudgetUsage({
       orgMemberId,
       settledUsageMicroUsd: usageMicroUsd,
+      syncError: degraded ? MISSING_PERIOD_COUNTER : null,
+      syncStatus: degraded ? 'degraded' : 'synced',
     });
 
     return { remainingMicroUsd, usageMicroUsd };
@@ -597,7 +641,7 @@ export class AicoOpenRouterKeyService {
     if (!budget?.openrouterKeyId || isStaleManagedKeyId(budget.openrouterKeyId)) return null;
 
     const info = await this.client.getKey(budget.openrouterKeyId);
-    const { bp, checkpoint } = await this.syncMemberCheckpoint({
+    const { bp, checkpoint, degraded } = await this.syncMemberCheckpoint({
       checkpoint: budget,
       orgMemberId,
       rawUsage: this.rawMeteredUsageMicro(budget, info),
@@ -610,6 +654,8 @@ export class AicoOpenRouterKeyService {
     return this.orgModel.syncMemberBudgetUsage({
       orgMemberId,
       settledUsageMicroUsd: usageMicroUsd,
+      syncError: degraded ? MISSING_PERIOD_COUNTER : null,
+      syncStatus: degraded ? 'degraded' : 'synced',
     });
   };
 

--- a/packages/database/src/models/organization.ts
+++ b/packages/database/src/models/organization.ts
@@ -1617,10 +1617,21 @@ export class OrganizationModel {
     return row;
   };
 
-  syncMemberBudgetUsage = async (params: { orgMemberId: string; settledUsageMicroUsd: number }) => {
+  syncMemberBudgetUsage = async (params: {
+    orgMemberId: string;
+    settledUsageMicroUsd: number;
+    /** Why the figure is not fully trusted, when `syncStatus` is `degraded`. */
+    syncError?: string | null;
+    syncStatus?: 'synced' | 'degraded';
+  }) => {
     const [row] = await this.db
       .update(memberBudgets)
-      .set({ lastSyncedAt: new Date(), settledUsageMicroUsd: params.settledUsageMicroUsd })
+      .set({
+        lastSyncError: params.syncError ?? null,
+        lastSyncStatus: params.syncStatus ?? 'synced',
+        lastSyncedAt: new Date(),
+        settledUsageMicroUsd: params.settledUsageMicroUsd,
+      })
       .where(eq(memberBudgets.orgMemberId, params.orgMemberId))
       .returning();
     return row;

--- a/packages/database/src/utils/aicoMoney.ts
+++ b/packages/database/src/utils/aicoMoney.ts
@@ -31,6 +31,16 @@ export const isBudgetPeriod = (value: string): value is BudgetPeriod =>
 export const isProductBudgetPeriod = (value: string): value is ProductBudgetPeriod =>
   (PRODUCT_BUDGET_PERIODS as readonly string[]).includes(value);
 
+/**
+ * Whether OpenRouter meters this budget on a period counter rather than the
+ * lifetime one. A `total` budget — and a legacy row with no period at all — is
+ * created without `limit_reset`, so lifetime `usage` is its correct counter;
+ * for every other period the lifetime counter is in different units than the
+ * cycle and must never be substituted for a missing period counter.
+ */
+export const isPeriodScopedBudget = (period: string | null | undefined): boolean =>
+  !!period && isProductBudgetPeriod(period);
+
 /** OpenRouter Management API `limit_reset` mapping (midnight UTC; weeks Mon–Sun). */
 export const periodToOpenRouterLimitReset = (
   period: BudgetPeriod,


### PR DESCRIPTION
Closes #366

## Summary

A period-scoped member budget whose OpenRouter key reported no period counter fell back to the **lifetime** `usage` figure. That value became the multiplier checkpoint baseline, and the key limit is derived from it — so a daily budget capped at $10, on a key with $500 of lifetime spend, had a **$500 limit pushed to OpenRouter**. Enforcement was gone until the next renewal, while the member was simultaneously shown as fully spent and blocked.

The comment directly above the offending line already warned that this substitution "would corrupt every subsequent conversion."

## Changes

- **`rawMeteredUsageMicro` returns `null`** when a period-scoped budget has no matching period counter, instead of substituting lifetime usage. New `isPeriodScopedBudget` helper in `aicoMoney.ts` makes the `total`-vs-period distinction explicit and reuses the existing `isProductBudgetPeriod`.
- **The checkpoint rebase is skipped** when the counter is unknown, holding the old baseline *and* its rate (usage is still expressed in that rate) rather than stamping an unknown value. This is the step that produced the inflated limit.
- **`computeCycleUsageFromKeyInfo` no longer converts lifetime usage** for a period-scoped budget — it holds the last settled figure instead of saturating the cycle cap and stranding the member. Closes FIN-020, same root cause.
- **`peekMemberRemaining`** falls back to the last settled figure rather than over-stating usage and under-refunding the org on reclaim/sweep.
- **The degraded state is now visible** in `member_budgets.last_sync_status` / `last_sync_error` — columns that existed but nothing ever wrote. No migration needed.

## Notes for review

**`total` budgets still read the lifetime counter, deliberately.** They are created without `limit_reset`, so OpenRouter genuinely meters them on `usage`. `period` defaults to `'total'` in the schema and `ensureMemberKey` does `budget.period || 'total'`, so this path is live, not dead code — there is a test pinning it.

**The degraded path returns the checkpoint's own bp, not the platform bp.** Since the baseline was not rebased, usage is still expressed at the old rate and must be converted with it.

**This does not close FIN-019.** `ensureMemberKey` is still called outside the allocation transaction with no outbox retry.

## Test plan

- [x] `bun run check` over all changed files — **lint clean**
- [x] **89 tests pass** across keyService, organization, aicoMoney, renewalScheduler, orgBudgetSweep, managedPolicy and the financial-concurrency suite
- [x] New `FIN-014` suite in `aico.keyFailureInjection.test.ts`: baseline is not stamped with lifetime usage and the pushed key limit stays at the funded cap; settled usage holds at the last known value instead of saturating; degraded sync is recorded; `total` budgets still read lifetime; the happy path still reads the period counter
- [x] **Verified the tests catch the bug** — restoring the old behaviour produced exactly the predicted failures: `expected 500000000 to be +0` (the $500 lifetime figure becoming a daily budget's baseline) and `expected 10000000 to be 1000000` (settled usage saturating the full cap)
- [x] Full type check clean. The one `MessageCostBadge.tsx` error is pre-existing on `canary` — confirmed by running the baseline with these changes stashed

## Unrelated pre-existing failure

`aico.phase3.e2eJourneys.test.ts` ("over-allocation deny") fails on `canary` today and is **not** caused by this PR — I confirmed it already fails at `85a8545f92`, before any of my recent work. An over-allocation guard expecting `/INSUFFICIENT/` now resolves instead. Worth its own issue; it is a financial guard that has silently stopped working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)