### PR TITLE
🐛 fix(billing): stop a wallet freeze from stranding funds and leaking capacity

### DIFF
--- a/apps/server/src/routers/lambda/platformAdmin.ts
+++ b/apps/server/src/routers/lambda/platformAdmin.ts
@@ -793,15 +793,23 @@ export const platformAdminRouter = router({
         })
         .where(eq(users.id, input.userId));
 
-      await ctx.serverDB
-        .update(userWallets)
-        .set({ isActive: true })
-        .where(eq(userWallets.userId, input.userId));
+      // FIN-015: flipping `isActive` alone left the balance parked in
+      // `frozenMicroUsd` with no way back, so a "reactivated" user had no
+      // spendable funds and a key that stayed disabled. Restore the money and
+      // the capacity it bought, on the ledger, then push the limit.
+      const restored = await ctx.billingModel.unfreezePersonalWallet({
+        createdByAdminId: ctx.adminId,
+        description: 'Restored on account reactivation',
+        userId: input.userId,
+      });
 
       const keyService = new AicoOpenRouterKeyService(ctx.serverDB);
       await keyService.ensureUserKey(input.userId);
 
-      return { ok: true as const };
+      return {
+        ok: true as const,
+        restoredMicroUsd: String(restored?.transaction?.amountMicroUsd ?? 0),
+      };
     }),
 
   getOpenRouterModelSyncStatus: platformProcedure.query(async ({ ctx }) => {

--- a/apps/server/src/services/aico/softDelete.ts
+++ b/apps/server/src/services/aico/softDelete.ts
@@ -11,13 +11,7 @@ import {
   normalizeIranianPhoneForFingerprint,
 } from '@/database/models/aicoBilling';
 import { OrganizationModel } from '@/database/models/organization';
-import {
-  aicoAccountTombs,
-  aicoKeyOutbox,
-  organizationMembers,
-  userWallets,
-  users,
-} from '@/database/schemas';
+import { aicoAccountTombs, aicoKeyOutbox, organizationMembers, users } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 
 export class AicoSoftDeleteService {
@@ -36,10 +30,7 @@ export class AicoSoftDeleteService {
    * 3. Anonymize email/phone; retain irreversible fingerprints in tomb
    * 4. Caller must also invalidate Better Auth sessions
    */
-  softDeleteUser = async (params: {
-    deletedByUserId?: string | null;
-    userId: string;
-  }) => {
+  softDeleteUser = async (params: { deletedByUserId?: string | null; userId: string }) => {
     const user = await this.db.query.users.findFirst({ where: eq(users.id, params.userId) });
     if (!user) throw new Error('USER_NOT_FOUND');
 
@@ -71,14 +62,13 @@ export class AicoSoftDeleteService {
     const wallet = await this.billingModel.getUserWallet(params.userId);
     const personalMicro = Number(wallet?.balanceMicroUsd ?? 0);
     if (wallet) {
-      await this.db
-        .update(userWallets)
-        .set({
-          balanceMicroUsd: personalMicro > 0 ? 0 : Number(wallet.balanceMicroUsd ?? 0),
-          frozenMicroUsd: personalMicro > 0 ? personalMicro : Number(wallet.frozenMicroUsd ?? 0),
-          isActive: false,
-        })
-        .where(eq(userWallets.userId, params.userId));
+      // Parks the balance *and* the capacity it bought, and writes the
+      // `personal_freeze` ledger row this move never used to leave behind.
+      await this.billingModel.freezePersonalWallet({
+        createdByUserId: params.deletedByUserId ?? null,
+        description: 'Frozen on account deletion',
+        userId: params.userId,
+      });
     }
 
     await this.db.insert(aicoKeyOutbox).values({

--- a/docs/development/database-schema.dbml
+++ b/docs/development/database-schema.dbml
@@ -738,6 +738,9 @@ table member_budgets {
   renewal_status text [not null, default: 'active']
   reserved_micro_usd bigint [not null, default: 0]
   settled_usage_micro_usd bigint [not null, default: 0]
+  usage_baseline_micro_usd bigint [not null, default: 0]
+  billed_usage_before_baseline_micro_usd bigint [not null, default: 0]
+  checkpoint_multiplier_bp bigint [not null, default: 12000]
   refunded_micro_usd bigint [not null, default: 0]
   pending_period text
   pending_period_amount_micro_usd bigint
@@ -971,6 +974,14 @@ table platform_trial_config {
   updated_at "timestamp with time zone" [not null, default: `now()`]
 }
 
+table platform_usage_multiplier_config {
+  id text [pk, not null, default: 'default']
+  multiplier_bp bigint [not null, default: 12000]
+  updated_by_user_id text
+  created_at "timestamp with time zone" [not null, default: `now()`]
+  updated_at "timestamp with time zone" [not null, default: `now()`]
+}
+
 table trial_abuse_blocklist {
   id text [pk, not null]
   fingerprint_type text [not null]
@@ -994,6 +1005,7 @@ table usage_logs {
   completion_tokens integer [not null, default: 0]
   total_tokens integer [not null, default: 0]
   cost_micro_usd bigint [not null, default: 0]
+  multiplier_bp bigint [not null, default: 12000]
   settlement_status text [not null, default: 'pending']
   created_at "timestamp with time zone" [not null, default: `now()`]
 
@@ -1034,6 +1046,8 @@ table user_wallets {
   openrouter_key_ciphertext text
   is_active boolean [not null, default: true]
   frozen_micro_usd bigint [not null, default: 0]
+  raw_capacity_micro_usd bigint [not null, default: 0]
+  frozen_raw_capacity_micro_usd bigint [not null, default: 0]
   last_synced_at "timestamp with time zone"
   created_at "timestamp with time zone" [not null, default: `now()`]
   updated_at "timestamp with time zone" [not null, default: `now()`]

--- a/packages/database/migrations/0149_aico_wallet_frozen_capacity.sql
+++ b/packages/database/migrations/0149_aico_wallet_frozen_capacity.sql
@@ -1,0 +1,14 @@
+-- FIN-015: a freeze zeroed `balance_micro_usd` but left `raw_capacity_micro_usd`
+-- in place. That column is pushed to OpenRouter as the key limit, so the next
+-- credit re-enabled the wallet carrying the pre-freeze capacity on top of the
+-- newly purchased one — spend the user never paid for. Capacity now moves out
+-- alongside the balance and is restored by an explicit unfreeze.
+ALTER TABLE "user_wallets" ADD COLUMN IF NOT EXISTS "frozen_raw_capacity_micro_usd" bigint DEFAULT 0 NOT NULL;--> statement-breakpoint
+
+-- Repair wallets already frozen under the old behaviour: park their capacity
+-- with the balance it belongs to, so it is restored on unfreeze rather than
+-- handed out by the next credit.
+UPDATE "user_wallets"
+SET "frozen_raw_capacity_micro_usd" = "raw_capacity_micro_usd",
+    "raw_capacity_micro_usd" = 0
+WHERE "frozen_micro_usd" > 0 AND "balance_micro_usd" = 0;

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -1043,6 +1043,13 @@
       "when": 1788000000000,
       "tag": "0148_aico_wallet_raw_capacity",
       "breakpoints": true
+    },
+    {
+      "idx": 149,
+      "version": "7",
+      "when": 1788100000000,
+      "tag": "0149_aico_wallet_frozen_capacity",
+      "breakpoints": true
     }
   ],
   "version": "6"

--- a/packages/database/src/models/__tests__/aicoBilling.freezeWallet.test.ts
+++ b/packages/database/src/models/__tests__/aicoBilling.freezeWallet.test.ts
@@ -1,0 +1,138 @@
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getTestDB } from '../../core/getTestDB';
+import { userWallets, walletTransactions } from '../../schemas/aicoOrganization';
+import { users } from '../../schemas/user';
+import type { LobeChatDatabase } from '../../type';
+import { AicoBillingModel } from '../aicoBilling';
+
+const serverDB: LobeChatDatabase = await getTestDB();
+const billingModel = new AicoBillingModel(serverDB);
+
+const userId = 'aico-freeze-user';
+
+const readWallet = async () => {
+  const [row] = await serverDB.select().from(userWallets).where(eq(userWallets.userId, userId));
+  return row;
+};
+
+const credit = (amountMicroUsd: number, idempotencyKey: string) =>
+  billingModel.manualCreditUser({
+    amountMicroUsd,
+    amountToman: amountMicroUsd / 100,
+    createdByUserId: userId,
+    fxRateTomanPerUsd: 5000,
+    idempotencyKey,
+    userId,
+  });
+
+beforeEach(async () => {
+  await serverDB.delete(walletTransactions);
+  await serverDB.delete(userWallets);
+  await serverDB.delete(users);
+  await serverDB.insert(users).values({ email: 'freeze@wallet.test', id: userId });
+});
+
+afterEach(async () => {
+  await serverDB.delete(walletTransactions);
+  await serverDB.delete(userWallets);
+  await serverDB.delete(users);
+});
+
+describe('FIN-015 personal wallet freeze / unfreeze', () => {
+  it('parks balance and the capacity it bought, and records the move on the ledger', async () => {
+    await credit(6_000_000, 'freeze-seed');
+    const funded = await readWallet();
+    expect(Number(funded.balanceMicroUsd)).toBe(6_000_000);
+    const purchasedCapacity = Number(funded.rawCapacityMicroUsd);
+    expect(purchasedCapacity).toBeGreaterThan(0);
+
+    await billingModel.freezePersonalWallet({ userId });
+
+    const frozen = await readWallet();
+    expect(Number(frozen.balanceMicroUsd)).toBe(0);
+    expect(Number(frozen.frozenMicroUsd)).toBe(6_000_000);
+    expect(frozen.isActive).toBe(false);
+    // Capacity is the OpenRouter key limit. Leaving it behind is what let the
+    // next credit hand back spend the user never paid for.
+    expect(Number(frozen.rawCapacityMicroUsd)).toBe(0);
+    expect(Number(frozen.frozenRawCapacityMicroUsd)).toBe(purchasedCapacity);
+
+    const [row] = await serverDB
+      .select()
+      .from(walletTransactions)
+      .where(eq(walletTransactions.type, 'personal_freeze'));
+    expect(row).toBeTruthy();
+    expect(Number(row.amountMicroUsd)).toBe(-6_000_000);
+    expect(Number(row.balanceBeforeMicroUsd)).toBe(6_000_000);
+    expect(Number(row.balanceAfterMicroUsd)).toBe(0);
+    // INV-6: a wallet must be reconstructable from its ledger.
+    expect(Number(row.balanceAfterMicroUsd) - Number(row.balanceBeforeMicroUsd)).toBe(
+      Number(row.amountMicroUsd),
+    );
+  });
+
+  it('restores balance, capacity and spendability on unfreeze', async () => {
+    await credit(6_000_000, 'unfreeze-seed');
+    const purchasedCapacity = Number((await readWallet()).rawCapacityMicroUsd);
+
+    await billingModel.freezePersonalWallet({ userId });
+    await billingModel.unfreezePersonalWallet({ userId });
+
+    const restored = await readWallet();
+    expect(Number(restored.balanceMicroUsd)).toBe(6_000_000);
+    expect(Number(restored.frozenMicroUsd)).toBe(0);
+    expect(Number(restored.rawCapacityMicroUsd)).toBe(purchasedCapacity);
+    expect(Number(restored.frozenRawCapacityMicroUsd)).toBe(0);
+    expect(restored.isActive).toBe(true);
+
+    const [row] = await serverDB
+      .select()
+      .from(walletTransactions)
+      .where(eq(walletTransactions.type, 'personal_unfreeze'));
+    expect(Number(row.amountMicroUsd)).toBe(6_000_000);
+    expect(Number(row.balanceAfterMicroUsd) - Number(row.balanceBeforeMicroUsd)).toBe(
+      Number(row.amountMicroUsd),
+    );
+  });
+
+  it('refuses to credit a frozen wallet instead of silently resurrecting it', async () => {
+    await credit(6_000_000, 'refuse-seed');
+    await billingModel.freezePersonalWallet({ userId });
+
+    await expect(credit(1_000_000, 'refuse-second')).rejects.toThrow('WALLET_INACTIVE');
+
+    const wallet = await readWallet();
+    expect(wallet.isActive).toBe(false);
+    expect(Number(wallet.balanceMicroUsd)).toBe(0);
+    expect(Number(wallet.rawCapacityMicroUsd)).toBe(0);
+  });
+
+  it('grants only newly purchased capacity after a freeze and unfreeze cycle', async () => {
+    // The P0: capacity surviving a freeze meant the key limit became
+    // pre-freeze + newly purchased, i.e. free upstream spend.
+    await credit(6_000_000, 'capacity-first');
+    const firstCapacity = Number((await readWallet()).rawCapacityMicroUsd);
+
+    await billingModel.freezePersonalWallet({ userId });
+    await billingModel.unfreezePersonalWallet({ userId });
+    await credit(6_000_000, 'capacity-second');
+
+    const wallet = await readWallet();
+    expect(Number(wallet.balanceMicroUsd)).toBe(12_000_000);
+    // Exactly two purchases' worth — never three.
+    expect(Number(wallet.rawCapacityMicroUsd)).toBe(firstCapacity * 2);
+  });
+
+  it('freezing a wallet with no balance moves nothing and writes no ledger row', async () => {
+    await billingModel.getOrCreateUserWallet(userId);
+
+    const result = await billingModel.freezePersonalWallet({ userId });
+
+    expect(result?.transaction).toBeNull();
+    const rows = await serverDB.select().from(walletTransactions);
+    expect(rows).toHaveLength(0);
+    expect((await readWallet()).isActive).toBe(false);
+  });
+});

--- a/packages/database/src/models/aicoBilling.ts
+++ b/packages/database/src/models/aicoBilling.ts
@@ -178,6 +178,11 @@ export class AicoBillingModel {
         const before = await tx.query.userWallets.findFirst({
           where: eq(userWallets.userId, params.userId),
         });
+        // FIN-015: crediting used to flip `isActive` back on, silently
+        // resurrecting a soft-deleted or deactivated wallet — and, before the
+        // capacity fix, handing back its pre-freeze spend limit for free.
+        // Restoring an account is now an explicit, ledgered step.
+        if (before && !before.isActive) throw new Error('WALLET_INACTIVE');
         const balanceBeforeMicroUsd = Number(before?.balanceMicroUsd ?? 0);
         const balanceBeforeToman = Number(before?.balanceToman ?? 0);
 
@@ -192,7 +197,6 @@ export class AicoBillingModel {
           .set({
             balanceMicroUsd: sql`${userWallets.balanceMicroUsd} + ${params.amountMicroUsd}`,
             balanceToman: sql`${userWallets.balanceToman} + ${params.amountToman}`,
-            isActive: true,
             rawCapacityMicroUsd: sql`${userWallets.rawCapacityMicroUsd} + ${rawCapacityAdded}`,
           })
           .where(eq(userWallets.userId, params.userId))
@@ -241,6 +245,118 @@ export class AicoBillingModel {
       }
       return { transaction: existingTx, wallet: await this.getOrCreateUserWallet(params.userId) };
     }
+  };
+
+  /**
+   * Park a personal balance and the capacity it bought while the account is
+   * disabled, and record the move on the ledger.
+   *
+   * Balance and capacity must travel together: `rawCapacityMicroUsd` is pushed
+   * to OpenRouter as the key limit, so capacity left behind on a zeroed wallet
+   * is handed back free by the next credit (FIN-015). `balanceToman` is a
+   * paid-in mirror and deliberately untouched, as it was before.
+   */
+  freezePersonalWallet = async (params: {
+    createdByAdminId?: string | null;
+    createdByUserId?: string | null;
+    description?: string;
+    userId: string;
+  }) => {
+    return this.db.transaction(async (tx) => {
+      const before = await tx.query.userWallets.findFirst({
+        where: eq(userWallets.userId, params.userId),
+      });
+      if (!before) return null;
+
+      const balanceMicroUsd = Number(before.balanceMicroUsd ?? 0);
+      const rawCapacityMicroUsd = Number(before.rawCapacityMicroUsd ?? 0);
+
+      const [wallet] = await tx
+        .update(userWallets)
+        .set({
+          balanceMicroUsd: 0,
+          frozenMicroUsd: sql`${userWallets.frozenMicroUsd} + ${balanceMicroUsd}`,
+          frozenRawCapacityMicroUsd: sql`${userWallets.frozenRawCapacityMicroUsd} + ${rawCapacityMicroUsd}`,
+          isActive: false,
+          rawCapacityMicroUsd: 0,
+        })
+        .where(eq(userWallets.userId, params.userId))
+        .returning();
+
+      if (balanceMicroUsd === 0) return { transaction: null, wallet };
+
+      const [transaction] = await tx
+        .insert(walletTransactions)
+        .values({
+          // Negative, so `balance_after - balance_before == amount` still holds
+          // for anyone reconstructing a wallet from its ledger.
+          amountMicroUsd: -balanceMicroUsd,
+          // `balanceToman` is a paid-in mirror and does not move on a freeze.
+          amountToman: 0,
+          balanceAfterMicroUsd: 0,
+          balanceBeforeMicroUsd: balanceMicroUsd,
+          createdByAdminId: params.createdByAdminId ?? null,
+          createdByUserId: params.createdByUserId ?? null,
+          description: params.description ?? 'Personal balance frozen',
+          metadata: { frozenRawCapacityMicroUsd: rawCapacityMicroUsd },
+          type: 'personal_freeze',
+          userId: params.userId,
+        })
+        .returning();
+
+      return { transaction, wallet };
+    });
+  };
+
+  /** Reverse of {@link freezePersonalWallet}: return parked funds and capacity. */
+  unfreezePersonalWallet = async (params: {
+    createdByAdminId?: string | null;
+    createdByUserId?: string | null;
+    description?: string;
+    userId: string;
+  }) => {
+    return this.db.transaction(async (tx) => {
+      const before = await tx.query.userWallets.findFirst({
+        where: eq(userWallets.userId, params.userId),
+      });
+      if (!before) return null;
+
+      const frozenMicroUsd = Number(before.frozenMicroUsd ?? 0);
+      const frozenRawCapacityMicroUsd = Number(before.frozenRawCapacityMicroUsd ?? 0);
+      const balanceBeforeMicroUsd = Number(before.balanceMicroUsd ?? 0);
+
+      const [wallet] = await tx
+        .update(userWallets)
+        .set({
+          balanceMicroUsd: sql`${userWallets.balanceMicroUsd} + ${frozenMicroUsd}`,
+          frozenMicroUsd: 0,
+          frozenRawCapacityMicroUsd: 0,
+          isActive: true,
+          rawCapacityMicroUsd: sql`${userWallets.rawCapacityMicroUsd} + ${frozenRawCapacityMicroUsd}`,
+        })
+        .where(eq(userWallets.userId, params.userId))
+        .returning();
+
+      if (frozenMicroUsd === 0) return { transaction: null, wallet };
+
+      const [transaction] = await tx
+        .insert(walletTransactions)
+        .values({
+          amountMicroUsd: frozenMicroUsd,
+          amountToman: 0,
+          balanceAfterMicroUsd: Number(wallet?.balanceMicroUsd ?? 0),
+          balanceBeforeMicroUsd,
+          createdByAdminId: params.createdByAdminId ?? null,
+          createdByUserId: params.createdByUserId ?? null,
+          description: params.description ?? 'Personal balance restored',
+          metadata: { restoredRawCapacityMicroUsd: frozenRawCapacityMicroUsd },
+          type: 'personal_unfreeze',
+          userId: params.userId,
+        })
+        .returning();
+
+      return { transaction, wallet };
+    });
   };
 
   /**

--- a/packages/database/src/schemas/aicoOrganization.ts
+++ b/packages/database/src/schemas/aicoOrganization.ts
@@ -358,7 +358,11 @@ export const userWallets = pgTable(
     openrouterKeyId: text('openrouter_key_id'),
     openrouterKeyCiphertext: text('openrouter_key_ciphertext'),
     isActive: boolean('is_active').notNull().default(true),
-    /** Soft-delete freeze of non-zero personal balance pending refund/recovery. */
+    /**
+     * Soft-delete freeze of non-zero personal balance pending refund/recovery.
+     * Restored to `balanceMicroUsd` by an explicit unfreeze — money parked here
+     * is not spendable and not lost.
+     */
     frozenMicroUsd: bigint('frozen_micro_usd', { mode: 'number' }).notNull().default(0),
     /**
      * AICO-184. Raw upstream spend this wallet has bought, accumulated as
@@ -367,6 +371,15 @@ export const userWallets = pgTable(
      * revalue money already paid. Doubles as the OpenRouter key limit.
      */
     rawCapacityMicroUsd: bigint('raw_capacity_micro_usd', { mode: 'number' }).notNull().default(0),
+    /**
+     * Capacity counterpart of `frozenMicroUsd`. A freeze must move capacity out
+     * alongside the balance: `rawCapacityMicroUsd` is pushed to OpenRouter as
+     * the key limit, so capacity left behind on a zeroed wallet is re-granted
+     * free by the next credit.
+     */
+    frozenRawCapacityMicroUsd: bigint('frozen_raw_capacity_micro_usd', { mode: 'number' })
+      .notNull()
+      .default(0),
     lastSyncedAt: timestamptz('last_synced_at'),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
@@ -420,7 +433,7 @@ export const walletTransactions = pgTable(
     /**
      * topup | manual_credit | refund | allocate | period_reservation |
      * period_settlement | period_refund | period_renewal | renewal_failure |
-     * adjustment | reclaim | personal_freeze
+     * adjustment | reclaim | personal_freeze | personal_unfreeze
      */
     type: text('type').notNull(),
     amountToman: bigint('amount_toman', { mode: 'number' }).notNull().default(0),


### PR DESCRIPTION
Closes #368

## Summary

Freezing a personal wallet zeroed `balance_micro_usd` but left `raw_capacity_micro_usd` in place, wrote no ledger row, and had no reverse.

Capacity is what gets pushed to OpenRouter as the key's lifetime limit. Leaving it on a zeroed wallet meant the next credit — which also silently flipped `is_active` back on — re-enabled the account carrying the **pre-freeze capacity on top of the newly purchased one**, handing out upstream spend nobody paid for. In the other direction the money was simply stranded: `frozen_micro_usd` had one writer and **no reader anywhere**, so `reactivateUser` un-banned a user into an empty wallet and a key that stayed disabled.

## Changes

- **Freeze and unfreeze are now a ledgered pair** on `AicoBillingModel`. `freezePersonalWallet` parks the balance *and* the capacity it bought; `unfreezePersonalWallet` restores both.
- **New `user_wallets.frozen_raw_capacity_micro_usd`** (migration `0149`), which also **backfills wallets already frozen under the old behaviour** so their capacity is parked rather than waiting to be handed out.
- **`personal_freeze` is finally written.** It was declared in the transaction type enum and never written by anything. `personal_unfreeze` is added alongside it. Both rows satisfy INV-6 (`balance_after − balance_before == amount`), negative on the freeze.
- **`reactivateUser` restores the money**, then pushes the key limit — so a reactivated user actually has spendable funds.
- **`manualCreditUser` no longer flips `is_active`.** Crediting a disabled wallet is refused with `WALLET_INACTIVE`, making account restoration an explicit, auditable step instead of a side effect of a top-up.

## Notes for review

**`balanceToman` is deliberately untouched**, matching the previous behaviour. It is a paid-in mirror, and the freeze/unfreeze pair is symmetric about it. Making the Toman figure spend-aware is FIN-016 and out of scope here.

**`deactivateUser` still does not freeze**, which is correct — a ban is not a deletion and the funds should stay in `balance_micro_usd`. The reactivate path works for both: unfreezing a wallet with nothing parked just re-enables it.

**The migration is hand-written.** `bun run db:generate` is currently unusable on this repo: the newest Drizzle snapshot is `0146` and predates `balance_micro_usd` entirely, so five of the last six migrations have no snapshot. Generating would try to re-diff all of that drift and prompts for destructive column-rename resolutions. I followed the precedent set by `0147`/`0148` and applied the `db-migrations` hardening rules by hand (`IF NOT EXISTS`, meaningful filename, matching journal tag). **The snapshot drift is worth its own issue** — it is a latent hazard for anyone who runs the generator next.

**`database-schema.dbml` carries extra churn.** `db:generate` regenerates it from the schema, and it was stale — the diff therefore also backfills `member_budgets` checkpoint columns and `platform_usage_multiplier_config` from `0147`, which were never documented.

## Test plan

- [x] `bun run check` over all changed files — **lint clean**
- [x] **68 tests pass** across the new suite, `aicoBilling`, `manualCreditUser`, financial concurrency, RBAC/IDOR and account deletion
- [x] New `aicoBilling.freezeWallet.test.ts`: freeze parks balance and capacity and writes a correct `personal_freeze` row; unfreeze restores both and writes `personal_unfreeze`; crediting a frozen wallet is refused; a freeze/unfreeze/credit cycle grants exactly two purchases' worth of capacity, never three; freezing an empty wallet writes no row
- [x] **Verified the tests catch the bug** — restoring the old behaviour produced `expected 5000000 to be +0` (capacity left behind by the freeze) and `promise resolved instead of rejecting` (a frozen wallet being silently credited and resurrected)
- [x] Full type check clean. The one `MessageCostBadge.tsx` error is pre-existing on `canary` — confirmed by running the baseline with these changes stashed

## Unrelated pre-existing failures

`aico.trialAbuse.test.ts` (2 tests) and `aico.multiOrgMigration.test.ts` (2 tests) fail on `canary` today and are **not** caused by this PR — verified by running them with these changes stashed. Together with the `aico.phase3.e2eJourneys.test.ts` failure noted in #367, that is five financial tests currently red on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)