### PR TITLE
🔧 fix(ci): stop freezing an install against a lockfile this repo does not keep

### DIFF
--- a/.github/workflows/claude-auto-e2e-testing.yml
+++ b/.github/workflows/claude-auto-e2e-testing.yml
@@ -54,7 +54,8 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Lockfile-free repo — see type-check.yml for why this cannot be frozen.
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install Playwright browsers (with system deps)
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/claude-auto-testing.yml
+++ b/.github/workflows/claude-auto-testing.yml
@@ -32,7 +32,8 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Lockfile-free repo — see type-check.yml for why this cannot be frozen.
+        run: pnpm install --no-frozen-lockfile
 
       - name: Configure Git
         run: |

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -33,7 +33,12 @@ jobs:
         uses: ./.github/actions/setup-env
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # This repo is deliberately lockfile-free: `pnpm-lock.yaml` is gitignored
+        # and `pnpm-workspace.yaml` sets `lockfile: false`. There is nothing to
+        # freeze against, so `--frozen-lockfile` only ever compares the config
+        # against a stale lockfile restored from the runner cache and fails with
+        # ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+        run: pnpm install --no-frozen-lockfile
         env:
           NODE_OPTIONS: --max-old-space-size=8192
 


### PR DESCRIPTION
Closes #370

## Summary

`pnpm install --frozen-lockfile` was failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The flag's contract is *"install exactly what the committed lockfile says"* — but this repo has no committed lockfile. `pnpm-lock.yaml` is gitignored and `pnpm-workspace.yaml` sets `lockfile: false`, both inherited from upstream LobeHub.

So the flag never compared against anything in the repository. It compared the current `overrides` config against whatever **stale lockfile the runner restored from cache**, and failed as soon as they drifted.

## Changes

`--frozen-lockfile` → `--no-frozen-lockfile` in the three workflows still using it, with the rationale recorded in `type-check.yml` so the flag doesn't get re-added later.

`pr-build-desktop.yml` already used `--no-frozen-lockfile` for exactly this reason — this brings the rest in line.

## Notes for review

**`type-check.yml` is the live breakage** and is fork-owned — the flag came in on 2026-09-08 with "gate type-check in CI". The other two are upstream files set to manual-only dispatch, so they weren't failing, but they carry the same latent bug.

**I deliberately did not touch the conflicting `overrides` blocks.** `package.json` pins react/react-dom to `19.2.7` while `pnpm-workspace.yaml` pins `19.2.4`. Both blocks are upstream-owned (last touched by Innei / Arvin Xu), it currently resolves to the correct version — installed `react` is `19.2.7`, matching the direct dependency — and editing upstream config would create merge friction on every `aico-upstream-sync` for no live benefit. Recorded in #370 to report upstream or handle during a sync instead.

## Test plan

- [x] All three workflows parse as valid YAML, and the install step resolves to `pnpm install --no-frozen-lockfile` in each
- [x] `bun run check --lint` clean on all three
- [x] No `--frozen-lockfile` remains anywhere under `.github/workflows/`
- [ ] Confirmed by this PR's own `type-check` run — it exercises the changed step directly

## Worth a separate decision

`lockfile: false` plus no committed lockfile means every CI run and every developer install can resolve different transitive dependency versions. For a product handling real money that's a reproducibility and supply-chain gap. Fixing it would mean deliberately diverging from upstream, so it should be a considered decision rather than a side effect of unblocking CI — captured in #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)