### PR TITLE
🔧 fix(ci): make the type-check reproducible and fix the errors it surfaced

### DIFF
--- a/package.json
+++ b/package.json
@@ -581,11 +581,13 @@
       "ffmpeg-static"
     ],
     "overrides": {
+      "@lobehub/ui": "5.24.0",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",
       "antd": "6.3.5",
       "baseline-browser-mapping": "2.10.31",
+      "chat": "4.35.0",
       "drizzle-orm": "^0.45.2",
       "fast-xml-parser": "5.4.2",
       "lexical": "0.42.0",

--- a/packages/chat-adapter-qq/src/adapter.test.ts
+++ b/packages/chat-adapter-qq/src/adapter.test.ts
@@ -423,7 +423,9 @@ describe('QQAdapter', () => {
       const data = await message.attachments[0].fetchData!();
 
       expect(data).toBeInstanceOf(Buffer);
-      expect(data.length).toBe(4);
+      // `byteLength` reads the same on Buffer and ArrayBuffer; `length` does
+      // not exist on the latter, which `chat` may now return.
+      expect(data.byteLength).toBe(4);
 
       vi.unstubAllGlobals();
     });

--- a/packages/chat-adapter-wechat/src/adapter.ts
+++ b/packages/chat-adapter-wechat/src/adapter.ts
@@ -332,7 +332,9 @@ async function loadAttachmentBuffer(
   }
   if (typeof attachment.fetchData === 'function') {
     try {
-      return await attachment.fetchData();
+      // `chat` widened this to `ArrayBuffer | Buffer` in a 4.x minor, and the
+      // repo installs the newest match for `^4.31.0`, so both shapes are live.
+      return blobOrBufferToBuffer(await attachment.fetchData());
     } catch (error) {
       logger?.warn?.('Attachment fetchData failed: %s', error);
     }

--- a/src/features/Conversation/Messages/components/resolveMessageModelName.ts
+++ b/src/features/Conversation/Messages/components/resolveMessageModelName.ts
@@ -12,9 +12,12 @@ import { formatBrandedModelId } from '@/components/Branding/brandedModelId';
  */
 export const resolveCostModelId = (
   model: string | null | undefined,
-  metadata: Record<string, unknown> | null | undefined,
+  // Callers hold `MessageMetadata`, an interface, and interfaces have no
+  // implicit index signature — so `Record<string, unknown>` rejects them.
+  // Accept the wider type and narrow to the one field actually read.
+  metadata: object | null | undefined,
 ): string | null | undefined => {
-  const resolved = metadata?.resolvedModel;
+  const resolved = (metadata as { resolvedModel?: unknown } | null | undefined)?.resolvedModel;
   return typeof resolved === 'string' && resolved ? resolved : model;
 };
 


### PR DESCRIPTION
Closes #372
Follows #371 — that PR unblocked the install, which is what let `type-check` run and surface these.

## Summary

Four type errors. **Three could not be reproduced locally** — they exist only in CI, because `.npmrc` sets `resolution-mode=highest` with `lockfile=false`, so CI installs the newest version of every dependency on every run:

| package | range | local | CI | drift |
|---|---|---|---|---|
| `chat` | `^4.31.0` | 4.35.0 | **4.40.0** | 5 minors |
| `@lobehub/ui` | `^5.24.0` | 5.24.0 | **5.43.1** | **19 minors** |

## Changes

**Pinned `chat` and `@lobehub/ui` in `pnpm.overrides`** — the mechanism this repo already uses to stabilise 16 other packages (react, typescript, antd, vitest…) in the absence of a lockfile. Every workspace range (`^5`, `^4.31.0`) is satisfied by the pinned versions, so nothing is downgraded below what it declared. This resolves errors 1–3, including `mdx/Image.tsx`, whose `placeholder` prop the newer `@lobehub/ui` removed when it rewrote that component off antd.

**Two code fixes kept regardless**, because they're correct under either version:
- `wechat/adapter.ts` routes `fetchData()` through `blobOrBufferToBuffer`, which already normalises `ArrayBuffer | Buffer`
- the QQ test reads `byteLength`, which exists on both `Buffer` and `ArrayBuffer`

**`resolveCostModelId` — the one genuine bug**, reproducing everywhere. `MessageCostBadgeProps.metadata` was deliberately widened to `object` so interface-typed `MessageMetadata` would be accepted (the comment above it explains why `Record<string, unknown>` rejects interfaces), and then passed straight into a `Record<string, unknown>` parameter — the exact assignment that comment rules out. It now takes the wider type and narrows to the single field it reads.

## Notes for review

**Why pin rather than chase the errors.** Fixing drift errors one at a time is whack-a-mole — the next `@lobehub/ui` release breaks something else and the gate is never reliably green. Pinning makes the input deterministic; upgrades become a deliberate edit.

**I did not touch `mdx/Image.tsx`.** Adapting the blur-up placeholder to the rewritten component would be a real UI change I can't verify without installing the newer library, and it would only hold until the next breaking release. Pinning is the correct answer for now.

**This does not close the underlying gap.** ~100 other dependencies still float freely, and `pnpm.overrides` will keep growing as each one bites. A committed lockfile is the durable fix, but it diverges from upstream — captured in #372 as a separate decision.

## Test plan

- [x] `bun run check --type` → **`✓ types clean`**, the first clean run this session; the `MessageCostBadge` error that had been present throughout is gone
- [x] `bun run check --lint --test` on all changed files — **100 tests pass, lint clean**
- [x] Verified every workspace declaration of `@lobehub/ui` (`^5`, `^5.24.0`) and `chat` (`^4.31.0`) is satisfied by the pins, so nothing resolves below its declared range
- [ ] Errors 1–3 can only be confirmed by CI, since they don't reproduce on a local install — this PR's own `type-check` run is the verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)